### PR TITLE
Add discovery-only external API listings

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1636,6 +1636,246 @@ describe("marketplace api", () => {
     expect(updatedService.body.error).toContain("serviceType can only change before");
   });
 
+  it("returns 409 when republishing a submitted snapshot whose apiNamespace is now claimed by another service", async () => {
+    const providerWallet = await createTestWallet(PROVIDER_PRIVATE_KEY);
+    const { app } = await createTestApp();
+    const providerToken = await createSiteSession(app, providerWallet);
+
+    const profile = await request(app)
+      .post("/provider/me")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        displayName: "Signal Labs",
+        websiteUrl: "https://provider.example.com"
+      });
+
+    expect(profile.status).toBe(201);
+
+    const firstService = await request(app)
+      .post("/provider/services")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        serviceType: "marketplace_proxy",
+        slug: "signal-labs-republish-a",
+        apiNamespace: "signals-republish",
+        name: "Signal Labs Republish A",
+        tagline: "Short-form market signals",
+        about: "Provider-authored signal endpoints.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs Republish A" service on Fast Marketplace.',
+        setupInstructions: ["Use a funded Fast wallet."],
+        websiteUrl: "https://provider.example.com",
+        payoutWallet: providerWallet.address
+      });
+
+    expect(firstService.status).toBe(201);
+    const firstServiceId = firstService.body.service.id as string;
+
+    const firstEndpoint = await request(app)
+      .post(`/provider/services/${firstServiceId}/endpoints`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        endpointType: "marketplace_proxy",
+        operation: "quote",
+        title: "Quote",
+        description: "Return a single quote snapshot.",
+        billingType: "fixed_x402",
+        price: "$0.25",
+        mode: "sync",
+        requestSchemaJson: {
+          type: "object",
+          properties: {
+            symbol: { type: "string" }
+          },
+          required: ["symbol"],
+          additionalProperties: false
+        },
+        responseSchemaJson: {
+          type: "object",
+          properties: {
+            symbol: { type: "string" },
+            price: { type: "number" }
+          },
+          required: ["symbol", "price"],
+          additionalProperties: false
+        },
+        requestExample: { symbol: "FAST" },
+        responseExample: { symbol: "FAST", price: 42.5 },
+        upstreamBaseUrl: "https://provider.example.com",
+        upstreamPath: "/api/quote",
+        upstreamAuthMode: "none"
+      });
+
+    expect(firstEndpoint.status).toBe(201);
+
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const firstChallenge = await request(app)
+      .post(`/provider/services/${firstServiceId}/verification-challenge`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(firstChallenge.status).toBe(200);
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === firstChallenge.body.expectedUrl) {
+        return new Response(firstChallenge.body.token, { status: 200 });
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    const firstVerified = await request(app)
+      .post(`/provider/services/${firstServiceId}/verify`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(firstVerified.status).toBe(200);
+
+    const firstSubmitted = await request(app)
+      .post(`/provider/services/${firstServiceId}/submit`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(firstSubmitted.status).toBe(202);
+
+    const firstPublished = await request(app)
+      .post(`/internal/provider-services/${firstServiceId}/publish`)
+      .set("Authorization", "Bearer test-admin-token")
+      .send({
+        reviewerIdentity: "ops@test",
+        settlementMode: "verified_escrow"
+      });
+
+    expect(firstPublished.status).toBe(200);
+
+    const firstReviewChanges = await request(app)
+      .post(`/internal/provider-services/${firstServiceId}/request-changes`)
+      .set("Authorization", "Bearer test-admin-token")
+      .send({
+        reviewerIdentity: "ops@test",
+        reviewNotes: "Move the provider namespace before republishing."
+      });
+
+    expect(firstReviewChanges.status).toBe(200);
+
+    const firstEndpointDeleted = await request(app)
+      .delete(`/provider/services/${firstServiceId}/endpoints/${firstEndpoint.body.id}`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(firstEndpointDeleted.status).toBe(204);
+
+    const firstUpdatedDraft = await request(app)
+      .patch(`/provider/services/${firstServiceId}`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        apiNamespace: "signals-republish-next"
+      });
+
+    expect(firstUpdatedDraft.status).toBe(200);
+
+    const secondService = await request(app)
+      .post("/provider/services")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        serviceType: "marketplace_proxy",
+        slug: "signal-labs-republish-b",
+        apiNamespace: "signals-republish",
+        name: "Signal Labs Republish B",
+        tagline: "Short-form market signals",
+        about: "Provider-authored signal endpoints.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs Republish B" service on Fast Marketplace.',
+        setupInstructions: ["Use a funded Fast wallet."],
+        websiteUrl: "https://provider.example.com",
+        payoutWallet: providerWallet.address
+      });
+
+    expect(secondService.status).toBe(201);
+    const secondServiceId = secondService.body.service.id as string;
+
+    const secondEndpoint = await request(app)
+      .post(`/provider/services/${secondServiceId}/endpoints`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        endpointType: "marketplace_proxy",
+        operation: "quote",
+        title: "Quote",
+        description: "Return a single quote snapshot.",
+        billingType: "fixed_x402",
+        price: "$0.25",
+        mode: "sync",
+        requestSchemaJson: {
+          type: "object",
+          properties: {
+            symbol: { type: "string" }
+          },
+          required: ["symbol"],
+          additionalProperties: false
+        },
+        responseSchemaJson: {
+          type: "object",
+          properties: {
+            symbol: { type: "string" },
+            price: { type: "number" }
+          },
+          required: ["symbol", "price"],
+          additionalProperties: false
+        },
+        requestExample: { symbol: "FAST" },
+        responseExample: { symbol: "FAST", price: 42.5 },
+        upstreamBaseUrl: "https://provider.example.com",
+        upstreamPath: "/api/quote",
+        upstreamAuthMode: "none"
+      });
+
+    expect(secondEndpoint.status).toBe(201);
+
+    const secondChallenge = await request(app)
+      .post(`/provider/services/${secondServiceId}/verification-challenge`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(secondChallenge.status).toBe(200);
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === secondChallenge.body.expectedUrl) {
+        return new Response(secondChallenge.body.token, { status: 200 });
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    const secondVerified = await request(app)
+      .post(`/provider/services/${secondServiceId}/verify`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(secondVerified.status).toBe(200);
+
+    const secondSubmitted = await request(app)
+      .post(`/provider/services/${secondServiceId}/submit`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(secondSubmitted.status).toBe(202);
+
+    const secondPublished = await request(app)
+      .post(`/internal/provider-services/${secondServiceId}/publish`)
+      .set("Authorization", "Bearer test-admin-token")
+      .send({
+        reviewerIdentity: "ops@test",
+        settlementMode: "verified_escrow"
+      });
+
+    expect(secondPublished.status).toBe(200);
+
+    const republishedFirst = await request(app)
+      .post(`/internal/provider-services/${firstServiceId}/publish`)
+      .set("Authorization", "Bearer test-admin-token")
+      .send({
+        reviewerIdentity: "ops@test",
+        settlementMode: "verified_escrow"
+      });
+
+    expect(republishedFirst.status).toBe(409);
+    expect(republishedFirst.body.error).toContain("API namespace already exists: signals-republish");
+  });
+
   it("still returns the free upstream result when completion persistence fails", async () => {
     class FailingCompletionAttemptStore extends InMemoryMarketplaceStore {
       private attemptWrites = 0;

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1350,6 +1350,74 @@ describe("marketplace api", () => {
     expect(routeResponse.status).toBe(404);
   });
 
+  it("returns 409 when an external service tries to add a duplicate external endpoint", async () => {
+    const providerWallet = await createTestWallet(PROVIDER_PRIVATE_KEY);
+    const { app } = await createTestApp();
+    const providerToken = await createSiteSession(app, providerWallet);
+
+    const profile = await request(app)
+      .post("/provider/me")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        displayName: "Signal Labs",
+        websiteUrl: "https://provider.example.com"
+      });
+
+    expect(profile.status).toBe(201);
+
+    const createdService = await request(app)
+      .post("/provider/services")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        serviceType: "external_registry",
+        slug: "signal-labs-direct-duplicate",
+        name: "Signal Labs Direct Duplicate",
+        tagline: "Direct provider APIs",
+        about: "Discovery-only direct APIs that the marketplace lists but does not execute.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs Direct Duplicate" service.',
+        setupInstructions: ["Read the provider docs first."],
+        websiteUrl: "https://provider.example.com"
+      });
+
+    expect(createdService.status).toBe(201);
+
+    const firstEndpoint = await request(app)
+      .post(`/provider/services/${createdService.body.service.id}/endpoints`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        endpointType: "external_registry",
+        title: "Status",
+        description: "Returns service status directly from the provider.",
+        method: "GET",
+        publicUrl: "https://provider.example.com/api/status",
+        docsUrl: "https://provider.example.com/docs/status",
+        authNotes: "Bearer token required.",
+        requestExample: {},
+        responseExample: { status: "ok" }
+      });
+
+    expect(firstEndpoint.status).toBe(201);
+
+    const duplicateEndpoint = await request(app)
+      .post(`/provider/services/${createdService.body.service.id}/endpoints`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        endpointType: "external_registry",
+        title: "Status duplicate",
+        description: "Duplicate provider status route.",
+        method: "GET",
+        publicUrl: "https://provider.example.com/api/status",
+        docsUrl: "https://provider.example.com/docs/status-v2",
+        authNotes: "Bearer token required.",
+        requestExample: {},
+        responseExample: { status: "ok" }
+      });
+
+    expect(duplicateEndpoint.status).toBe(409);
+    expect(duplicateEndpoint.body.error).toContain("External endpoint already exists");
+  });
+
   it("keeps the published catalog bound to the published slug while the next draft slug changes", async () => {
     const providerWallet = await createTestWallet(PROVIDER_PRIVATE_KEY);
     const { app } = await createTestApp();
@@ -1483,6 +1551,89 @@ describe("marketplace api", () => {
 
     const draftSlugDetail = await request(app).get("/catalog/services/signal-labs-next");
     expect(draftSlugDetail.status).toBe(404);
+  });
+
+  it("returns 409 when serviceType changes after endpoints already exist", async () => {
+    const providerWallet = await createTestWallet(PROVIDER_PRIVATE_KEY);
+    const { app } = await createTestApp();
+    const providerToken = await createSiteSession(app, providerWallet);
+
+    const profile = await request(app)
+      .post("/provider/me")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        displayName: "Signal Labs",
+        websiteUrl: "https://provider.example.com"
+      });
+
+    expect(profile.status).toBe(201);
+
+    const createdService = await request(app)
+      .post("/provider/services")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        serviceType: "marketplace_proxy",
+        slug: "signal-labs-service-type-lock",
+        apiNamespace: "signals-service-type-lock",
+        name: "Signal Labs Service Type Lock",
+        tagline: "Short-form market signals",
+        about: "Provider-authored signal endpoints.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs Service Type Lock" service on Fast Marketplace.',
+        setupInstructions: ["Use a funded Fast wallet."],
+        websiteUrl: "https://provider.example.com",
+        payoutWallet: providerWallet.address
+      });
+
+    expect(createdService.status).toBe(201);
+    const serviceId = createdService.body.service.id as string;
+
+    const createdEndpoint = await request(app)
+      .post(`/provider/services/${serviceId}/endpoints`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        endpointType: "marketplace_proxy",
+        operation: "quote",
+        title: "Quote",
+        description: "Return a single quote snapshot.",
+        billingType: "fixed_x402",
+        price: "$0.25",
+        mode: "sync",
+        requestSchemaJson: {
+          type: "object",
+          properties: {
+            symbol: { type: "string" }
+          },
+          required: ["symbol"],
+          additionalProperties: false
+        },
+        responseSchemaJson: {
+          type: "object",
+          properties: {
+            symbol: { type: "string" },
+            price: { type: "number" }
+          },
+          required: ["symbol", "price"],
+          additionalProperties: false
+        },
+        requestExample: { symbol: "FAST" },
+        responseExample: { symbol: "FAST", price: 42.5 },
+        upstreamBaseUrl: "https://provider.example.com",
+        upstreamPath: "/api/quote",
+        upstreamAuthMode: "none"
+      });
+
+    expect(createdEndpoint.status).toBe(201);
+
+    const updatedService = await request(app)
+      .patch(`/provider/services/${serviceId}`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        serviceType: "external_registry"
+      });
+
+    expect(updatedService.status).toBe(409);
+    expect(updatedService.body.error).toContain("serviceType can only change before");
   });
 
   it("still returns the free upstream result when completion persistence fails", async () => {

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1350,6 +1350,141 @@ describe("marketplace api", () => {
     expect(routeResponse.status).toBe(404);
   });
 
+  it("keeps the published catalog bound to the published slug while the next draft slug changes", async () => {
+    const providerWallet = await createTestWallet(PROVIDER_PRIVATE_KEY);
+    const { app } = await createTestApp();
+    const providerToken = await createSiteSession(app, providerWallet);
+
+    const profile = await request(app)
+      .post("/provider/me")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        displayName: "Signal Labs",
+        websiteUrl: "https://provider.example.com"
+      });
+
+    expect(profile.status).toBe(201);
+
+    const createdService = await request(app)
+      .post("/provider/services")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        serviceType: "marketplace_proxy",
+        slug: "signal-labs",
+        apiNamespace: "signals",
+        name: "Signal Labs",
+        tagline: "Short-form market signals",
+        about: "Provider-authored signal endpoints.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs" service on Fast Marketplace.',
+        setupInstructions: ["Use a funded Fast wallet."],
+        websiteUrl: "https://provider.example.com",
+        payoutWallet: providerWallet.address
+      });
+
+    expect(createdService.status).toBe(201);
+    const serviceId = createdService.body.service.id as string;
+
+    const createdEndpoint = await request(app)
+      .post(`/provider/services/${serviceId}/endpoints`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        endpointType: "marketplace_proxy",
+        operation: "quote",
+        title: "Quote",
+        description: "Return a single quote snapshot.",
+        billingType: "fixed_x402",
+        price: "$0.25",
+        mode: "sync",
+        requestSchemaJson: {
+          type: "object",
+          properties: {
+            symbol: { type: "string" }
+          },
+          required: ["symbol"],
+          additionalProperties: false
+        },
+        responseSchemaJson: {
+          type: "object",
+          properties: {
+            symbol: { type: "string" },
+            price: { type: "number" }
+          },
+          required: ["symbol", "price"],
+          additionalProperties: false
+        },
+        requestExample: { symbol: "FAST" },
+        responseExample: { symbol: "FAST", price: 42.5 },
+        upstreamBaseUrl: "https://provider.example.com",
+        upstreamPath: "/api/quote",
+        upstreamAuthMode: "none"
+      });
+
+    expect(createdEndpoint.status).toBe(201);
+
+    const verificationChallenge = await request(app)
+      .post(`/provider/services/${serviceId}/verification-challenge`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(verificationChallenge.status).toBe(200);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === verificationChallenge.body.expectedUrl) {
+        return new Response(verificationChallenge.body.token, { status: 200 });
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    const verified = await request(app)
+      .post(`/provider/services/${serviceId}/verify`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(verified.status).toBe(200);
+
+    const submitted = await request(app)
+      .post(`/provider/services/${serviceId}/submit`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(submitted.status).toBe(202);
+
+    const published = await request(app)
+      .post(`/internal/provider-services/${serviceId}/publish`)
+      .set("Authorization", "Bearer test-admin-token")
+      .send({
+        reviewerIdentity: "ops@test",
+        settlementMode: "verified_escrow"
+      });
+
+    expect(published.status).toBe(200);
+
+    const originalDetail = await request(app).get("/catalog/services/signal-labs");
+    expect(originalDetail.status).toBe(200);
+
+    const updatedDraft = await request(app)
+      .patch(`/provider/services/${serviceId}`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        slug: "signal-labs-next"
+      });
+
+    expect(updatedDraft.status).toBe(200);
+    expect(updatedDraft.body.slug).toBe("signal-labs-next");
+
+    const publicList = await request(app).get("/catalog/services");
+    expect(publicList.status).toBe(200);
+    expect(publicList.body.services.some((service: { slug: string }) => service.slug === "signal-labs")).toBe(true);
+    expect(publicList.body.services.some((service: { slug: string }) => service.slug === "signal-labs-next")).toBe(false);
+
+    const publishedDetail = await request(app).get("/catalog/services/signal-labs");
+    expect(publishedDetail.status).toBe(200);
+    expect(publishedDetail.body.summary.slug).toBe("signal-labs");
+
+    const draftSlugDetail = await request(app).get("/catalog/services/signal-labs-next");
+    expect(draftSlugDetail.status).toBe(404);
+  });
+
   it("still returns the free upstream result when completion persistence fails", async () => {
     class FailingCompletionAttemptStore extends InMemoryMarketplaceStore {
       private attemptWrites = 0;

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -102,6 +102,20 @@ async function createTestApp(
   };
 }
 
+function marketplaceServiceDraft<T extends Record<string, unknown>>(input: T) {
+  return {
+    serviceType: "marketplace_proxy" as const,
+    ...input
+  };
+}
+
+function marketplaceEndpointDraft<T extends Record<string, unknown>>(input: T) {
+  return {
+    endpointType: "marketplace_proxy" as const,
+    ...input
+  };
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -859,6 +873,7 @@ describe("marketplace api", () => {
       .post("/provider/services")
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        serviceType: "marketplace_proxy",
         slug: "signal-labs",
         apiNamespace: "signals",
         name: "Signal Labs",
@@ -886,6 +901,7 @@ describe("marketplace api", () => {
       .post(`/provider/services/${serviceId}/endpoints`)
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        endpointType: "marketplace_proxy",
         operation: "quote",
         title: "Quote",
         description: "Return a single quote snapshot.",
@@ -1056,6 +1072,7 @@ describe("marketplace api", () => {
       .post("/provider/services")
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        serviceType: "marketplace_proxy",
         slug: "signal-labs-free",
         apiNamespace: "signals-free",
         name: "Signal Labs Free",
@@ -1083,6 +1100,7 @@ describe("marketplace api", () => {
       .post(`/provider/services/${serviceId}/endpoints`)
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        endpointType: "marketplace_proxy",
         operation: "search",
         title: "Search",
         description: "Return a free signal snapshot.",
@@ -1223,6 +1241,115 @@ describe("marketplace api", () => {
     expect(analytics.successRate30d).toBe(50);
   });
 
+  it("publishes discovery-only external registry services without executable marketplace routes", async () => {
+    const providerWallet = await createTestWallet(PROVIDER_PRIVATE_KEY);
+    const { app } = await createTestApp();
+    const providerToken = await createSiteSession(app, providerWallet);
+
+    const profile = await request(app)
+      .post("/provider/me")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        displayName: "Signal Labs",
+        websiteUrl: "https://provider.example.com"
+      });
+
+    expect(profile.status).toBe(201);
+
+    const createdService = await request(app)
+      .post("/provider/services")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        serviceType: "external_registry",
+        slug: "signal-labs-direct",
+        name: "Signal Labs Direct",
+        tagline: "Direct provider APIs",
+        about: "Discovery-only direct APIs that the marketplace lists but does not execute.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs Direct" service.',
+        setupInstructions: ["Read the provider docs first."],
+        websiteUrl: "https://provider.example.com"
+      });
+
+    expect(createdService.status).toBe(201);
+    const serviceId = createdService.body.service.id as string;
+
+    const createdEndpoint = await request(app)
+      .post(`/provider/services/${serviceId}/endpoints`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        endpointType: "external_registry",
+        title: "Status",
+        description: "Returns service status directly from the provider.",
+        method: "GET",
+        publicUrl: "https://provider.example.com/api/status",
+        docsUrl: "https://provider.example.com/docs/status",
+        authNotes: "Bearer token required.",
+        requestExample: {},
+        responseExample: { status: "ok" }
+      });
+
+    expect(createdEndpoint.status).toBe(201);
+
+    const verificationChallenge = await request(app)
+      .post(`/provider/services/${serviceId}/verification-challenge`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(verificationChallenge.status).toBe(200);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === verificationChallenge.body.expectedUrl) {
+        return new Response(verificationChallenge.body.token, { status: 200 });
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    const verified = await request(app)
+      .post(`/provider/services/${serviceId}/verify`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(verified.status).toBe(200);
+
+    const submitted = await request(app)
+      .post(`/provider/services/${serviceId}/submit`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(submitted.status).toBe(202);
+
+    const published = await request(app)
+      .post(`/internal/provider-services/${serviceId}/publish`)
+      .set("Authorization", "Bearer test-admin-token")
+      .send({
+        reviewerIdentity: "ops@test"
+      });
+
+    expect(published.status).toBe(200);
+
+    const publicDetail = await request(app).get("/catalog/services/signal-labs-direct");
+    expect(publicDetail.status).toBe(200);
+    expect(publicDetail.body.serviceType).toBe("external_registry");
+    expect(publicDetail.body.skillUrl).toBeNull();
+    expect(publicDetail.body.endpoints[0]).toMatchObject({
+      endpointType: "external_registry",
+      method: "GET",
+      publicUrl: "https://provider.example.com/api/status",
+      docsUrl: "https://provider.example.com/docs/status"
+    });
+
+    const llms = await request(app).get("/llms.txt");
+    expect(llms.status).toBe(200);
+    expect(llms.text).toContain("## Discovery-Only External APIs");
+    expect(llms.text).toContain("https://provider.example.com/api/status");
+
+    const routeResponse = await request(app)
+      .post("/api/signal-labs-direct/status")
+      .send({});
+
+    expect(routeResponse.status).toBe(404);
+  });
+
   it("still returns the free upstream result when completion persistence fails", async () => {
     class FailingCompletionAttemptStore extends InMemoryMarketplaceStore {
       private attemptWrites = 0;
@@ -1260,6 +1387,7 @@ describe("marketplace api", () => {
       .post("/provider/services")
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        serviceType: "marketplace_proxy",
         slug: "signal-labs-free-persist",
         apiNamespace: "signals-free-persist",
         name: "Signal Labs Free Persist",
@@ -1279,6 +1407,7 @@ describe("marketplace api", () => {
       .post(`/provider/services/${serviceId}/endpoints`)
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        endpointType: "marketplace_proxy",
         operation: "search",
         title: "Search",
         description: "Return a free signal snapshot.",
@@ -1393,6 +1522,7 @@ describe("marketplace api", () => {
       .post("/provider/services")
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        serviceType: "marketplace_proxy",
         slug: "signal-labs-snapshot",
         apiNamespace: "signals-snapshot",
         name: "Signal Snapshot",
@@ -1417,6 +1547,7 @@ describe("marketplace api", () => {
       .post(`/provider/services/${serviceId}/endpoints`)
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        endpointType: "marketplace_proxy",
         operation: "quote",
         title: "Get Quote",
         description: "Returns the latest signal quote.",
@@ -1475,6 +1606,7 @@ describe("marketplace api", () => {
       .post(`/provider/services/${serviceId}/endpoints`)
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        endpointType: "marketplace_proxy",
         operation: "topup",
         title: "Top Up",
         description: "Funds marketplace-managed balance for later spending.",
@@ -1553,6 +1685,7 @@ describe("marketplace api", () => {
       .post("/provider/services")
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        serviceType: "marketplace_proxy",
         slug: "signal-labs-recovery",
         apiNamespace: "signals-recovery",
         name: "Signal Labs Recovery",
@@ -1572,6 +1705,7 @@ describe("marketplace api", () => {
       .post(`/provider/services/${serviceId}/endpoints`)
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        endpointType: "marketplace_proxy",
         operation: "quote",
         title: "Quote",
         description: "Return a single quote snapshot.",
@@ -1727,6 +1861,7 @@ describe("marketplace api", () => {
       .post("/provider/services")
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        serviceType: "marketplace_proxy",
         slug: "orders-inc",
         apiNamespace: "orders",
         name: "Orders Inc",
@@ -1754,6 +1889,7 @@ describe("marketplace api", () => {
       .post(`/provider/services/${serviceId}/endpoints`)
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        endpointType: "marketplace_proxy",
         operation: "topup",
         title: "Top Up",
         description: "Add prepaid marketplace credit.",
@@ -1791,6 +1927,7 @@ describe("marketplace api", () => {
       .post(`/provider/services/${serviceId}/endpoints`)
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        endpointType: "marketplace_proxy",
         operation: "place-order",
         title: "Place Order",
         description: "Place an order against prepaid credit.",
@@ -2002,6 +2139,7 @@ describe("marketplace api", () => {
       .post("/provider/services")
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        serviceType: "marketplace_proxy",
         slug: "signal-labs-reverify",
         apiNamespace: "signals-reverify",
         name: "Signal Labs Reverify",
@@ -2020,6 +2158,7 @@ describe("marketplace api", () => {
       .post(`/provider/services/${serviceId}/endpoints`)
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        endpointType: "marketplace_proxy",
         operation: "quote",
         title: "Quote",
         description: "Return a single quote snapshot.",
@@ -2101,6 +2240,7 @@ describe("marketplace api", () => {
       .post("/provider/services")
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        serviceType: "marketplace_proxy",
         slug: "signal-labs-failure",
         apiNamespace: "signals-failure",
         name: "Signal Labs Failure",
@@ -2119,6 +2259,7 @@ describe("marketplace api", () => {
       .post(`/provider/services/${serviceId}/endpoints`)
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        endpointType: "marketplace_proxy",
         operation: "quote",
         title: "Quote",
         description: "Return a single quote snapshot.",
@@ -2230,6 +2371,7 @@ describe("marketplace api", () => {
       .post("/provider/services")
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        serviceType: "marketplace_proxy",
         slug: "private-signal-labs",
         apiNamespace: "private-signals",
         name: "Private Signal Labs",
@@ -2259,6 +2401,7 @@ describe("marketplace api", () => {
       .post("/provider/services")
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        serviceType: "marketplace_proxy",
         slug: "signal-labs",
         apiNamespace: "signals",
         name: "Signal Labs",
@@ -2285,6 +2428,7 @@ describe("marketplace api", () => {
       .post("/provider/services")
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        serviceType: "marketplace_proxy",
         slug: "signal-labs-2",
         apiNamespace: "signals-2",
         name: "Signal Labs 2",
@@ -2303,6 +2447,7 @@ describe("marketplace api", () => {
       .post(`/provider/services/${createdService.body.service.id}/endpoints`)
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        endpointType: "marketplace_proxy",
         operation: "quote",
         title: "Quote",
         description: "Return a single quote snapshot.",
@@ -2338,6 +2483,7 @@ describe("marketplace api", () => {
       .post(`/provider/services/${createdService.body.service.id}/endpoints`)
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        endpointType: "marketplace_proxy",
         operation: "quote",
         title: "Quote duplicate",
         description: "Duplicate operation.",
@@ -2382,6 +2528,7 @@ describe("marketplace api", () => {
       .post("/provider/services")
       .set("Authorization", `Bearer ${providerToken}`)
       .send({
+        serviceType: "marketplace_proxy",
         slug: "signal-import",
         apiNamespace: "signal-import",
         name: "Signal Import",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -863,23 +863,27 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
       payoutWallet = null;
     }
 
-    const updated = await options.store.updateProviderServiceForOwner(req.params.id, session.wallet, {
-      ...parsed.data,
-      apiNamespace: nextServiceType === "external_registry" ? null : parsed.data.apiNamespace,
-      payoutWallet
-    });
-    if (!updated) {
-      return res.status(404).json({ error: "Provider service not found." });
-    }
-
-    if (websiteHostChanged(existing.service.websiteUrl, updated.websiteUrl)) {
-      await options.store.markProviderVerificationResult(req.params.id, "failed", {
-        verifiedHost: null,
-        failureReason: "Website URL changed. Re-verify ownership before submit."
+    try {
+      const updated = await options.store.updateProviderServiceForOwner(req.params.id, session.wallet, {
+        ...parsed.data,
+        apiNamespace: nextServiceType === "external_registry" ? null : parsed.data.apiNamespace,
+        payoutWallet
       });
-    }
+      if (!updated) {
+        return res.status(404).json({ error: "Provider service not found." });
+      }
 
-    return res.json(updated);
+      if (websiteHostChanged(existing.service.websiteUrl, updated.websiteUrl)) {
+        await options.store.markProviderVerificationResult(req.params.id, "failed", {
+          verifiedHost: null,
+          failureReason: "Website URL changed. Re-verify ownership before submit."
+        });
+      }
+
+      return res.json(updated);
+    } catch (error) {
+      return handleProviderMutationError(res, error);
+    }
   });
 
   app.post("/provider/services/:id/endpoints", async (req, res) => {
@@ -2956,6 +2960,7 @@ function handleProviderMutationError(res: ExpressResponse, error: unknown) {
   if (
     message.includes("already exists") ||
     message.includes("cannot change after endpoints exist") ||
+    message.includes("can only change before") ||
     message.includes("already claimed") ||
     message.includes("not claimable")
   ) {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1461,16 +1461,20 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
       }
     }
 
-    const updated = await options.store.publishProviderService(req.params.id, {
-      reviewerIdentity: parsed.data.reviewerIdentity,
-      settlementMode,
-      submittedVersionId: validationDetail.latestReview?.submittedVersionId ?? null
-    });
-    if (!updated) {
-      return res.status(404).json({ error: "Provider service not found." });
-    }
+    try {
+      const updated = await options.store.publishProviderService(req.params.id, {
+        reviewerIdentity: parsed.data.reviewerIdentity,
+        settlementMode,
+        submittedVersionId: validationDetail.latestReview?.submittedVersionId ?? null
+      });
+      if (!updated) {
+        return res.status(404).json({ error: "Provider service not found." });
+      }
 
-    return res.json(updated);
+      return res.json(updated);
+    } catch (error) {
+      return handleProviderMutationError(res, error);
+    }
   });
 
   app.patch("/internal/provider-services/:id/settlement-mode", async (req, res) => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -54,18 +54,23 @@ import {
   PAYMENT_RESPONSE_HEADER,
   PAYMENT_SIGNATURE_HEADER,
   type CreateProviderEndpointDraftInput,
+  type ExternalProviderEndpointDraftRecord,
   type FacilitatorClient,
   type IdempotencyRecord,
   type JobRecord,
   type MarketplaceRoute,
   type MarketplaceStore,
   type OpenApiImportPreview,
+  type ProviderEndpointDraftRecord,
   type ProviderExecuteContext,
   type ProviderRequestRecord,
   type ProviderRuntimeKeyRecord,
   type ProviderServiceDetailRecord,
+  type ProviderServiceRecord,
+  type ProviderServiceType,
   type ProviderRegistry,
   type PublishedEndpointVersionRecord,
+  type PublishedServiceEndpointVersionRecord,
   type PublishedServiceVersionRecord,
   type RefundService,
   type RouteBillingType,
@@ -88,6 +93,11 @@ export interface MarketplaceApiOptions {
   secretsKey: string;
   tavilyApiKey?: string;
 }
+
+type PublishedCatalogService = {
+  service: PublishedServiceVersionRecord;
+  endpoints: PublishedServiceEndpointVersionRecord[];
+};
 
 const suggestionCreateSchema = z
   .object({
@@ -123,9 +133,12 @@ const providerAccountSchema = z.object({
   contactEmail: z.string().email().optional().nullable()
 });
 
+const providerServiceTypeSchema = z.enum(["marketplace_proxy", "external_registry"]);
+
 const providerServiceCreateSchema = z.object({
+  serviceType: providerServiceTypeSchema,
   slug: z.string().regex(/^[a-z0-9-]{3,64}$/),
-  apiNamespace: z.string().regex(/^[a-z0-9-]{3,64}$/),
+  apiNamespace: z.string().regex(/^[a-z0-9-]{3,64}$/).optional().nullable(),
   name: z.string().min(2).max(120),
   tagline: z.string().min(5).max(240),
   about: z.string().min(20).max(4_000),
@@ -133,16 +146,46 @@ const providerServiceCreateSchema = z.object({
   promptIntro: z.string().min(10).max(500),
   setupInstructions: z.array(z.string().min(3).max(240)).min(1).max(10),
   websiteUrl: z.string().url().optional().nullable(),
-  payoutWallet: z.string().min(1),
+  payoutWallet: z.string().min(1).optional().nullable(),
   featured: z.boolean().optional()
+}).superRefine((value, ctx) => {
+  if (value.serviceType === "marketplace_proxy" && !value.apiNamespace) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "apiNamespace is required when serviceType=marketplace_proxy.",
+      path: ["apiNamespace"]
+    });
+  }
+
+  if (value.serviceType === "marketplace_proxy" && !value.payoutWallet) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "payoutWallet is required when serviceType=marketplace_proxy.",
+      path: ["payoutWallet"]
+    });
+  }
 });
 
-const providerServiceUpdateSchema = providerServiceCreateSchema.partial();
+const providerServiceUpdateSchema = z.object({
+  serviceType: providerServiceTypeSchema.optional(),
+  slug: z.string().regex(/^[a-z0-9-]{3,64}$/).optional(),
+  apiNamespace: z.string().regex(/^[a-z0-9-]{3,64}$/).optional().nullable(),
+  name: z.string().min(2).max(120).optional(),
+  tagline: z.string().min(5).max(240).optional(),
+  about: z.string().min(20).max(4_000).optional(),
+  categories: z.array(z.string().min(2).max(40)).min(1).max(8).optional(),
+  promptIntro: z.string().min(10).max(500).optional(),
+  setupInstructions: z.array(z.string().min(3).max(240)).min(1).max(10).optional(),
+  websiteUrl: z.string().url().optional().nullable(),
+  payoutWallet: z.string().min(1).optional().nullable(),
+  featured: z.boolean().optional()
+});
 
 const routeBillingTypeSchema = z.enum(["fixed_x402", "topup_x402_variable", "prepaid_credit", "free"]);
 const decimalAmountSchema = z.string().regex(/^\d+(?:\.\d{1,6})?$/);
 
-const endpointSchemaInput = z.object({
+const marketplaceEndpointSchemaInput = z.object({
+  endpointType: z.literal("marketplace_proxy"),
   operation: z.string().regex(/^[a-z0-9-]{2,64}$/),
   title: z.string().min(2).max(120),
   description: z.string().min(10).max(500),
@@ -163,16 +206,44 @@ const endpointSchemaInput = z.object({
   upstreamSecret: z.string().min(1).max(4_000).optional().nullable()
 });
 
-const endpointCreateSchema = endpointSchemaInput;
+const externalEndpointSchemaInput = z.object({
+  endpointType: z.literal("external_registry"),
+  title: z.string().min(2).max(120),
+  description: z.string().min(10).max(500),
+  method: z.enum(["GET", "POST"]),
+  publicUrl: z.string().url(),
+  docsUrl: z.string().url(),
+  authNotes: z.string().max(1_000).optional().nullable(),
+  requestExample: z.unknown(),
+  responseExample: z.unknown(),
+  usageNotes: z.string().max(1_000).optional().nullable()
+});
 
-const endpointUpdateSchema = endpointSchemaInput
+const endpointCreateSchema = z.discriminatedUnion("endpointType", [
+  marketplaceEndpointSchemaInput,
+  externalEndpointSchemaInput
+]);
+
+const marketplaceEndpointUpdateSchema = marketplaceEndpointSchemaInput
   .omit({
     mode: true
   })
   .partial()
   .extend({
+    endpointType: z.literal("marketplace_proxy"),
     clearUpstreamSecret: z.boolean().optional()
   });
+
+const externalEndpointUpdateSchema = externalEndpointSchemaInput
+  .partial()
+  .extend({
+    endpointType: z.literal("external_registry")
+  });
+
+const endpointUpdateSchema = z.discriminatedUnion("endpointType", [
+  marketplaceEndpointUpdateSchema,
+  externalEndpointUpdateSchema
+]);
 
 const openApiImportSchema = z.object({
   documentUrl: z.string().url()
@@ -266,7 +337,7 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
     res.json(
       buildOpenApiDocument({
         baseUrl,
-        services: catalog.services,
+        services: catalog.services.map((entry) => entry.service),
         routes: catalog.routes
       })
     );
@@ -298,11 +369,11 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
     const catalog = filterVisibleCatalog(await loadPublishedCatalog(options.store), tavilyEnabled);
 
     const services = await Promise.all(
-      catalog.services.map(async (service) =>
+      catalog.services.map(async (serviceDetail) =>
         buildServiceSummary({
-          service,
-          endpoints: catalog.routes.filter((route) => route.serviceVersionId === service.versionId),
-          analytics: await options.store.getServiceAnalytics(service.routeIds)
+          service: serviceDetail.service,
+          endpoints: serviceDetail.endpoints,
+          analytics: await options.store.getServiceAnalytics(serviceDetail.service.routeIds)
         })
       )
     );
@@ -654,11 +725,13 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
       return res.status(400).json({ error: "Provider service validation failed.", issues: parsed.error.issues });
     }
 
-    let payoutWallet: string;
-    try {
-      payoutWallet = normalizeFastWalletAddress(parsed.data.payoutWallet);
-    } catch (error) {
-      return res.status(400).json({ error: error instanceof Error ? error.message : "Invalid payout wallet." });
+    let payoutWallet: string | null = null;
+    if (parsed.data.serviceType === "marketplace_proxy" && parsed.data.payoutWallet) {
+      try {
+        payoutWallet = normalizeFastWalletAddress(parsed.data.payoutWallet);
+      } catch (error) {
+        return res.status(400).json({ error: error instanceof Error ? error.message : "Invalid payout wallet." });
+      }
     }
 
     try {
@@ -692,6 +765,15 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
       return;
     }
 
+    const detail = await options.store.getProviderServiceForOwner(req.params.id, session.wallet);
+    if (!detail) {
+      return res.status(404).json({ error: "Provider service not found." });
+    }
+
+    if (detail.service.serviceType === "external_registry") {
+      return res.json({ runtimeKey: null });
+    }
+
     const runtimeKey = await options.store.getProviderRuntimeKeyForOwner(req.params.id, session.wallet);
     return res.json({
       runtimeKey: runtimeKey
@@ -709,6 +791,15 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
     const session = requireSiteSession(req, res, options.sessionSecret, webBaseUrl);
     if (!session) {
       return;
+    }
+
+    const detail = await options.store.getProviderServiceForOwner(req.params.id, session.wallet);
+    if (!detail) {
+      return res.status(404).json({ error: "Provider service not found." });
+    }
+
+    if (detail.service.serviceType === "external_registry") {
+      return res.status(400).json({ error: "External registry services do not use runtime keys." });
     }
 
     try {
@@ -751,7 +842,9 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
       return res.status(400).json({ error: "Provider service validation failed.", issues: parsed.error.issues });
     }
 
+    const nextServiceType = parsed.data.serviceType ?? existing.service.serviceType;
     if (
+      nextServiceType === "marketplace_proxy" &&
       parsed.data.apiNamespace &&
       parsed.data.apiNamespace !== existing.service.apiNamespace &&
       existing.endpoints.length > 0
@@ -760,16 +853,19 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
     }
 
     let payoutWallet = parsed.data.payoutWallet;
-    if (payoutWallet) {
+    if (nextServiceType === "marketplace_proxy" && payoutWallet) {
       try {
         payoutWallet = normalizeFastWalletAddress(payoutWallet);
       } catch (error) {
         return res.status(400).json({ error: error instanceof Error ? error.message : "Invalid payout wallet." });
       }
+    } else if (nextServiceType === "external_registry") {
+      payoutWallet = null;
     }
 
     const updated = await options.store.updateProviderServiceForOwner(req.params.id, session.wallet, {
       ...parsed.data,
+      apiNamespace: nextServiceType === "external_registry" ? null : parsed.data.apiNamespace,
       payoutWallet
     });
     if (!updated) {
@@ -797,7 +893,34 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
       return res.status(404).json({ error: "Provider service not found." });
     }
 
-    const parsed = endpointCreateSchema.safeParse(req.body ?? {});
+    if (service.service.serviceType === "external_registry") {
+      const parsed = externalEndpointSchemaInput.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        return res.status(400).json({ error: "Endpoint validation failed.", issues: parsed.error.issues });
+      }
+
+      const validation = validateExternalEndpointInput({
+        service: service.service,
+        input: parsed.data
+      });
+      if (!validation.ok) {
+        return res.status(validation.statusCode).json({ error: validation.error });
+      }
+
+      try {
+        const endpoint = await options.store.createProviderEndpointDraft(
+          req.params.id,
+          session.wallet,
+          parsed.data as CreateProviderEndpointDraftInput
+        );
+
+        return res.status(201).json(endpoint);
+      } catch (error) {
+        return handleProviderMutationError(res, error);
+      }
+    }
+
+    const parsed = marketplaceEndpointSchemaInput.safeParse(req.body ?? {});
     if (!parsed.success) {
       return res.status(400).json({ error: "Endpoint validation failed.", issues: parsed.error.issues });
     }
@@ -847,9 +970,50 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
       return res.status(404).json({ error: "Endpoint draft not found." });
     }
 
-    const parsed = endpointUpdateSchema.safeParse(req.body ?? {});
+    if (service.service.serviceType === "external_registry") {
+      const parsed = externalEndpointUpdateSchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        return res.status(400).json({ error: "Endpoint validation failed.", issues: parsed.error.issues });
+      }
+
+      if (existingEndpoint.endpointType !== "external_registry") {
+        return res.status(409).json({ error: "Endpoint type does not match the parent service." });
+      }
+
+      const validation = validateExternalEndpointInput({
+        service: service.service,
+        existingEndpoint,
+        input: parsed.data
+      });
+      if (!validation.ok) {
+        return res.status(validation.statusCode).json({ error: validation.error });
+      }
+
+      try {
+        const endpoint = await options.store.updateProviderEndpointDraft(
+          req.params.id,
+          req.params.endpointId,
+          session.wallet,
+          parsed.data as UpdateProviderEndpointDraftInput
+        );
+
+        if (!endpoint) {
+          return res.status(404).json({ error: "Endpoint draft not found." });
+        }
+
+        return res.json(endpoint);
+      } catch (error) {
+        return handleProviderMutationError(res, error);
+      }
+    }
+
+    const parsed = marketplaceEndpointUpdateSchema.safeParse(req.body ?? {});
     if (!parsed.success) {
       return res.status(400).json({ error: "Endpoint validation failed.", issues: parsed.error.issues });
+    }
+
+    if (existingEndpoint.endpointType !== "marketplace_proxy") {
+      return res.status(409).json({ error: "Endpoint type does not match the parent service." });
     }
 
     const validation = await validateProviderEndpointInput({
@@ -909,6 +1073,10 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
     const service = await options.store.getProviderServiceForOwner(req.params.id, session.wallet);
     if (!service) {
       return res.status(404).json({ error: "Provider service not found." });
+    }
+
+    if (service.service.serviceType === "external_registry") {
+      return res.status(400).json({ error: "External registry services do not support OpenAPI import." });
     }
 
     const parsed = openApiImportSchema.safeParse(req.body ?? {});
@@ -1273,15 +1441,20 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
       return res.status(404).json({ error: "Provider service not found." });
     }
 
-    const settlementMode = parsed.data.settlementMode ?? detail.service.settlementMode;
     const validationDetail = (await options.store.getSubmittedProviderService(req.params.id)) ?? detail;
-    const publishValidation = await validateProviderServiceForSettlement({
-      detail: validationDetail,
-      store: options.store,
-      settlementMode
-    });
-    if (!publishValidation.ok) {
-      return res.status(publishValidation.statusCode).json({ error: publishValidation.error });
+    const settlementMode = detail.service.serviceType === "marketplace_proxy"
+      ? (parsed.data.settlementMode ?? detail.service.settlementMode ?? "verified_escrow")
+      : null;
+
+    if (detail.service.serviceType === "marketplace_proxy") {
+      const publishValidation = await validateProviderServiceForSettlement({
+        detail: validationDetail,
+        store: options.store,
+        settlementMode
+      });
+      if (!publishValidation.ok) {
+        return res.status(publishValidation.statusCode).json({ error: publishValidation.error });
+      }
     }
 
     const updated = await options.store.publishProviderService(req.params.id, {
@@ -1309,6 +1482,10 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
     const detail = await options.store.getAdminProviderService(req.params.id);
     if (!detail) {
       return res.status(404).json({ error: "Provider service not found." });
+    }
+
+    if (detail.service.serviceType === "external_registry") {
+      return res.status(400).json({ error: "External registry services do not use settlement modes." });
     }
 
     const validationDetail = (await options.store.getSubmittedProviderService(req.params.id)) ?? detail;
@@ -1454,45 +1631,45 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
 }
 
 async function loadPublishedCatalog(store: MarketplaceStore): Promise<{
-  services: PublishedServiceVersionRecord[];
+  services: PublishedCatalogService[];
   routes: PublishedEndpointVersionRecord[];
 }> {
   const [services, routes] = await Promise.all([store.listPublishedServices(), store.listPublishedRoutes()]);
-  return { services, routes };
+  const serviceDetails = (
+    await Promise.all(services.map((service) => store.getPublishedServiceBySlug(service.slug)))
+  ).filter((service): service is PublishedCatalogService => Boolean(service));
+
+  return { services: serviceDetails, routes };
 }
 
-function isRouteVisible(route: Pick<MarketplaceRoute, "executorKind">, tavilyEnabled: boolean): boolean {
-  if (route.executorKind === "tavily") {
-    return tavilyEnabled;
+function isExternalPublishedEndpoint(
+  endpoint: PublishedServiceEndpointVersionRecord
+): endpoint is Extract<PublishedServiceEndpointVersionRecord, { endpointType: "external_registry" }> {
+  return endpoint.endpointType === "external_registry";
+}
+
+function filterVisiblePublishedService(
+  input: PublishedCatalogService,
+  tavilyEnabled: boolean
+): PublishedCatalogService | null {
+  if (input.service.serviceType === "external_registry") {
+    const endpoints = input.endpoints.filter(isExternalPublishedEndpoint);
+    if (endpoints.length === 0) {
+      return null;
+    }
+
+    return {
+      service: {
+        ...input.service,
+        routeIds: []
+      },
+      endpoints
+    };
   }
 
-  return true;
-}
-
-function filterVisibleCatalog(input: {
-  services: PublishedServiceVersionRecord[];
-  routes: PublishedEndpointVersionRecord[];
-}, tavilyEnabled: boolean): {
-  services: PublishedServiceVersionRecord[];
-  routes: PublishedEndpointVersionRecord[];
-} {
-  const routes = input.routes.filter((route) => isRouteVisible(route, tavilyEnabled));
-  const routeIds = new Set(routes.map((route) => route.routeId));
-  const services = input.services
-    .map((service) => ({
-      ...service,
-      routeIds: service.routeIds.filter((routeId) => routeIds.has(routeId))
-    }))
-    .filter((service) => service.routeIds.length > 0);
-
-  return { services, routes };
-}
-
-function filterVisibleServiceDetail(
-  input: { service: PublishedServiceVersionRecord; endpoints: PublishedEndpointVersionRecord[] },
-  tavilyEnabled: boolean
-): { service: PublishedServiceVersionRecord; endpoints: PublishedEndpointVersionRecord[] } | null {
-  const endpoints = input.endpoints.filter((endpoint) => isRouteVisible(endpoint, tavilyEnabled));
+  const endpoints = input.endpoints.filter((endpoint): endpoint is PublishedEndpointVersionRecord =>
+    endpoint.endpointType === "marketplace_proxy" && isRouteVisible(endpoint, tavilyEnabled)
+  );
   if (endpoints.length === 0) {
     return null;
   }
@@ -1505,6 +1682,36 @@ function filterVisibleServiceDetail(
     },
     endpoints
   };
+}
+
+function isRouteVisible(route: Pick<MarketplaceRoute, "executorKind">, tavilyEnabled: boolean): boolean {
+  if (route.executorKind === "tavily") {
+    return tavilyEnabled;
+  }
+
+  return true;
+}
+
+function filterVisibleCatalog(input: {
+  services: PublishedCatalogService[];
+  routes: PublishedEndpointVersionRecord[];
+}, tavilyEnabled: boolean): {
+  services: PublishedCatalogService[];
+  routes: PublishedEndpointVersionRecord[];
+} {
+  const routes = input.routes.filter((route) => isRouteVisible(route, tavilyEnabled));
+  const services = input.services
+    .map((service) => filterVisiblePublishedService(service, tavilyEnabled))
+    .filter((service): service is PublishedCatalogService => Boolean(service));
+
+  return { services, routes };
+}
+
+function filterVisibleServiceDetail(
+  input: PublishedCatalogService,
+  tavilyEnabled: boolean
+): PublishedCatalogService | null {
+  return filterVisiblePublishedService(input, tavilyEnabled);
 }
 
 async function handlePrepaidCreditRoute(input: {
@@ -2432,7 +2639,7 @@ function encryptSecretForStore(secret: string, secretsKey: string) {
 
 async function validateProviderEndpointInput(input: {
   mode: "create" | "update";
-  service: { websiteUrl: string | null; apiNamespace: string };
+  service: { websiteUrl: string | null };
   existingEndpoint: {
     billing: MarketplaceRoute["billing"];
     upstreamBaseUrl: string | null;
@@ -2442,8 +2649,8 @@ async function validateProviderEndpointInput(input: {
     upstreamSecretRef: string | null;
   } | null;
   input:
-    | z.infer<typeof endpointCreateSchema>
-    | z.infer<typeof endpointUpdateSchema>;
+    | z.infer<typeof marketplaceEndpointSchemaInput>
+    | z.infer<typeof marketplaceEndpointUpdateSchema>;
 }): Promise<{ ok: true } | { ok: false; statusCode: number; error: string }> {
   const billingType = (input.input.billingType ??
     input.existingEndpoint?.billing.type) as RouteBillingType | undefined;
@@ -2527,13 +2734,46 @@ async function validateProviderEndpointInput(input: {
   return { ok: true };
 }
 
+function validateExternalEndpointInput(input: {
+  service: Pick<ProviderServiceRecord, "websiteUrl">;
+  existingEndpoint?: Pick<ExternalProviderEndpointDraftRecord, "method" | "publicUrl" | "docsUrl"> | null;
+  input: z.infer<typeof externalEndpointSchemaInput> | z.infer<typeof externalEndpointUpdateSchema>;
+}): { ok: true } | { ok: false; statusCode: number; error: string } {
+  const websiteUrl = input.service.websiteUrl;
+  if (!websiteUrl) {
+    return { ok: false, statusCode: 400, error: "websiteUrl is required before managing endpoints." };
+  }
+
+  const serviceHost = new URL(websiteUrl).hostname;
+  const publicUrl = input.input.publicUrl ?? input.existingEndpoint?.publicUrl;
+  const docsUrl = input.input.docsUrl ?? input.existingEndpoint?.docsUrl;
+
+  if (!publicUrl || !docsUrl) {
+    return { ok: false, statusCode: 400, error: "publicUrl and docsUrl are required." };
+  }
+
+  if (!isSameOrSubdomain(serviceHost, new URL(publicUrl).hostname)) {
+    return {
+      ok: false,
+      statusCode: 400,
+      error: "publicUrl host must match the service website host or one of its subdomains."
+    };
+  }
+
+  if (!isSameOrSubdomain(serviceHost, new URL(docsUrl).hostname)) {
+    return {
+      ok: false,
+      statusCode: 400,
+      error: "docsUrl host must match the service website host or one of its subdomains."
+    };
+  }
+
+  return { ok: true };
+}
+
 async function validateProviderServiceForSubmit(detail: ProviderServiceDetailRecord) {
   if (!detail.service.websiteUrl) {
     return { ok: false as const, statusCode: 400, error: "websiteUrl is required before submit." };
-  }
-
-  if (!detail.service.payoutWallet) {
-    return { ok: false as const, statusCode: 400, error: "payoutWallet is required before submit." };
   }
 
   if (detail.endpoints.length === 0) {
@@ -2554,7 +2794,49 @@ async function validateProviderServiceForSubmit(detail: ProviderServiceDetailRec
     };
   }
 
+  if (detail.service.serviceType === "external_registry") {
+    for (const endpoint of detail.endpoints) {
+      if (endpoint.endpointType !== "external_registry") {
+        return {
+          ok: false as const,
+          statusCode: 400,
+          error: "External registry services can only publish external endpoints."
+        };
+      }
+
+      if (!isSameOrSubdomain(serviceHost, new URL(endpoint.publicUrl).hostname)) {
+        return {
+          ok: false as const,
+          statusCode: 400,
+          error: "All external endpoint URLs must match the verified website host or a subdomain."
+        };
+      }
+
+      if (!isSameOrSubdomain(serviceHost, new URL(endpoint.docsUrl).hostname)) {
+        return {
+          ok: false as const,
+          statusCode: 400,
+          error: "All external docs URLs must match the verified website host or a subdomain."
+        };
+      }
+    }
+
+    return { ok: true as const };
+  }
+
+  if (!detail.service.payoutWallet) {
+    return { ok: false as const, statusCode: 400, error: "payoutWallet is required before submit." };
+  }
+
   for (const endpoint of detail.endpoints) {
+    if (endpoint.endpointType !== "marketplace_proxy") {
+      return {
+        ok: false as const,
+        statusCode: 400,
+        error: "Marketplace proxy services can only publish marketplace endpoints."
+      };
+    }
+
     if (endpoint.mode !== "sync") {
       return { ok: false as const, statusCode: 400, error: "Provider-authored endpoints must be sync-only in v1." };
     }
@@ -2577,7 +2859,8 @@ async function validateProviderServiceForSubmit(detail: ProviderServiceDetailRec
 
 function isCommunityDirectPublishCompatible(detail: ProviderServiceDetailRecord): boolean {
   return detail.endpoints.every((endpoint) =>
-    endpoint.mode === "sync"
+    endpoint.endpointType === "marketplace_proxy"
+    && endpoint.mode === "sync"
     && endpoint.billing.type === "fixed_x402"
     && endpoint.executorKind === "http"
   );
@@ -2586,11 +2869,19 @@ function isCommunityDirectPublishCompatible(detail: ProviderServiceDetailRecord)
 async function validateProviderServiceForSettlement(input: {
   detail: ProviderServiceDetailRecord;
   store: MarketplaceStore;
-  settlementMode: SettlementMode;
+  settlementMode: SettlementMode | null;
 }) {
   const baseValidation = await validateProviderServiceForSubmit(input.detail);
   if (!baseValidation.ok) {
     return baseValidation;
+  }
+
+  if (input.detail.service.serviceType === "external_registry") {
+    return { ok: true as const };
+  }
+
+  if (!input.settlementMode) {
+    return { ok: false as const, statusCode: 400, error: "settlementMode is required for marketplace proxy services." };
   }
 
   const runtimeKey = await input.store.getProviderRuntimeKeyForOwner(
@@ -2618,7 +2909,7 @@ async function validateProviderServiceForSettlement(input: {
   }
 
   if (
-    input.detail.endpoints.some((endpoint) => endpoint.billing.type === "prepaid_credit")
+    input.detail.endpoints.some((endpoint) => endpoint.endpointType === "marketplace_proxy" && endpoint.billing.type === "prepaid_credit")
     && !runtimeKey
   ) {
     return {

--- a/apps/web/app/actions.test.ts
+++ b/apps/web/app/actions.test.ts
@@ -84,6 +84,25 @@ describe("admin service actions", () => {
     expect(mocks.redirect).toHaveBeenCalledTimes(1);
   });
 
+  it("publishes external registry listings without requiring a settlement tier", async () => {
+    mocks.publishAdminProviderService.mockResolvedValue({});
+    const formData = new FormData();
+    formData.set("id", "service_external");
+    formData.set("returnTo", "/admin/services/service_external");
+
+    await expect(publishProviderServiceAction(formData)).rejects.toThrow(
+      "REDIRECT:/admin/services/service_external?message=Published%20service."
+    );
+
+    expect(mocks.publishAdminProviderService).toHaveBeenCalledWith("service_external", {
+      reviewerIdentity: null,
+      settlementMode: null
+    });
+    expect(mocks.revalidatePath).toHaveBeenNthCalledWith(1, "/admin/services");
+    expect(mocks.revalidatePath).toHaveBeenNthCalledWith(2, "/admin/services/service_external");
+    expect(mocks.redirect).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps admin mutation failures on the error redirect path", async () => {
     mocks.suspendAdminProviderService.mockRejectedValue(new Error("upstream failed"));
     const formData = new FormData();

--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -180,8 +180,8 @@ export async function publishProviderServiceAction(formData: FormData): Promise<
   const reviewerIdentity = getString(formData, "reviewerIdentity") || null;
   const returnTo = getString(formData, "returnTo") || `/admin/services/${serviceId}`;
 
-  if (!serviceId || !settlementMode) {
-    redirect(buildAdminRedirect(returnTo, "error", "Service id and settlement tier are required."));
+  if (!serviceId) {
+    redirect(buildAdminRedirect(returnTo, "error", "Service id is required."));
   }
 
   await finalizeAdminServiceMutation({
@@ -190,7 +190,9 @@ export async function publishProviderServiceAction(formData: FormData): Promise<
     successMessage:
       settlementMode === "verified_escrow"
         ? "Published service as Verified."
-        : "Published service as Community.",
+        : settlementMode === "community_direct"
+          ? "Published service as Community."
+          : "Published service.",
     fallbackErrorMessage: "Failed to publish provider service.",
     mutate: () => publishAdminProviderService(serviceId, {
       reviewerIdentity,

--- a/apps/web/app/admin/services/[id]/page.tsx
+++ b/apps/web/app/admin/services/[id]/page.tsx
@@ -84,6 +84,7 @@ export default async function AdminProviderServiceDetailPage({
   const error = getSingleParam(query.error);
   const returnTo = `/admin/services/${id}`;
   const hasSubmittedSnapshot = Boolean(submittedDetail?.latestReview?.submittedVersionId);
+  const isMarketplaceService = currentDetail.service.serviceType === "marketplace_proxy";
 
   return (
     <main className="page-shell">
@@ -113,9 +114,13 @@ export default async function AdminProviderServiceDetailPage({
 
           <div className="mt-4 flex flex-wrap items-center gap-2">
             <Badge variant="secondary">{currentDetail.service.status}</Badge>
-            <Badge variant={currentDetail.service.settlementMode === "verified_escrow" ? "default" : "outline"}>
-              {currentDetail.service.settlementMode === "verified_escrow" ? "Verified" : "Community"}
-            </Badge>
+            {isMarketplaceService ? (
+              <Badge variant={currentDetail.service.settlementMode === "verified_escrow" ? "default" : "outline"}>
+                {currentDetail.service.settlementMode === "verified_escrow" ? "Verified" : "Community"}
+              </Badge>
+            ) : (
+              <Badge variant="outline">External API</Badge>
+            )}
             {currentDetail.verification ? (
               <Badge variant="outline">verification: {currentDetail.verification.status}</Badge>
             ) : null}
@@ -148,7 +153,11 @@ export default async function AdminProviderServiceDetailPage({
               <CardContent className="grid gap-4 text-sm">
                 <div className="rounded-card border border-border bg-background/70 p-5 dark:bg-background/20">
                   <div className="font-medium">Service metadata</div>
-                  <div className="mt-2 text-muted-foreground">{reviewDetail.service.apiNamespace}</div>
+                  <div className="mt-2 text-muted-foreground">
+                    {reviewDetail.service.serviceType === "marketplace_proxy"
+                      ? reviewDetail.service.apiNamespace
+                      : "discovery-only external registry"}
+                  </div>
                   <div className="mt-2 text-muted-foreground">{reviewDetail.service.tagline}</div>
                   <div className="mt-2 whitespace-pre-wrap text-muted-foreground">{reviewDetail.service.about}</div>
                 </div>
@@ -157,7 +166,9 @@ export default async function AdminProviderServiceDetailPage({
                   <div className="mt-2 text-muted-foreground">{reviewDetail.account.displayName}</div>
                   <div className="mt-2 text-muted-foreground">{reviewDetail.account.ownerWallet}</div>
                   <div className="mt-2 text-muted-foreground">Website: {reviewDetail.service.websiteUrl ?? "not set"}</div>
-                  <div className="mt-2 text-muted-foreground">Payout wallet: {reviewDetail.service.payoutWallet ?? "not set"}</div>
+                  {reviewDetail.service.serviceType === "marketplace_proxy" ? (
+                    <div className="mt-2 text-muted-foreground">Payout wallet: {reviewDetail.service.payoutWallet ?? "not set"}</div>
+                  ) : null}
                 </div>
                 <div className="rounded-card border border-border bg-background/70 p-5 dark:bg-background/20">
                   <div className="font-medium">Verification and review</div>
@@ -178,23 +189,29 @@ export default async function AdminProviderServiceDetailPage({
               <Card variant="frosted">
                 <CardHeader>
                   <CardTitle className="text-3xl">Review actions</CardTitle>
-                  <CardDescription>Publish with a settlement tier or send the draft back with notes.</CardDescription>
+                  <CardDescription>
+                    {isMarketplaceService
+                      ? "Publish with a settlement tier or send the draft back with notes."
+                      : "Publish the discovery-only listing or send the draft back with notes."}
+                  </CardDescription>
                 </CardHeader>
                 <CardContent className="grid gap-6">
                   <form action={publishProviderServiceAction} className="grid gap-4">
                     <input type="hidden" name="id" value={id} />
                     <input type="hidden" name="returnTo" value={returnTo} />
-                    <label className="grid gap-2 text-sm font-medium">
-                      Settlement tier
-                      <select
-                        name="settlementMode"
-                        defaultValue={currentDetail.service.settlementMode}
-                        className="fast-select min-h-12"
-                      >
-                        <option value="community_direct">Community</option>
-                        <option value="verified_escrow">Verified</option>
-                      </select>
-                    </label>
+                    {isMarketplaceService ? (
+                      <label className="grid gap-2 text-sm font-medium">
+                        Settlement tier
+                        <select
+                          name="settlementMode"
+                          defaultValue={currentDetail.service.settlementMode ?? "verified_escrow"}
+                          className="fast-select min-h-12"
+                        >
+                          <option value="community_direct">Community</option>
+                          <option value="verified_escrow">Verified</option>
+                        </select>
+                      </label>
+                    ) : null}
                     <label className="grid gap-2 text-sm font-medium">
                       Reviewer identity
                       <input
@@ -245,37 +262,47 @@ export default async function AdminProviderServiceDetailPage({
               <Card variant="frosted">
                 <CardHeader>
                   <CardTitle className="text-3xl">Published controls</CardTitle>
-                  <CardDescription>Adjust the current settlement tier or suspend the public listing.</CardDescription>
+                  <CardDescription>
+                    {isMarketplaceService
+                      ? "Adjust the current settlement tier or suspend the public listing."
+                      : "Suspend the public listing. External APIs do not use settlement tiers."}
+                  </CardDescription>
                 </CardHeader>
                 <CardContent className="grid gap-6">
-                  <form action={updateProviderServiceSettlementModeAction} className="grid gap-4">
-                    <input type="hidden" name="id" value={id} />
-                    <input type="hidden" name="returnTo" value={returnTo} />
-                    <label className="grid gap-2 text-sm font-medium">
-                      Current live settlement tier
-                      <select
-                        name="settlementMode"
-                        defaultValue={currentDetail.service.settlementMode}
-                        className="fast-select min-h-12"
-                      >
-                        <option value="community_direct">Community</option>
-                        <option value="verified_escrow">Verified</option>
-                      </select>
-                    </label>
-                    <label className="grid gap-2 text-sm font-medium">
-                      Reviewer identity
-                      <input
-                        name="reviewerIdentity"
-                        type="text"
-                        defaultValue=""
-                        className="fast-input min-h-12"
-                        placeholder="operator@fast.xyz"
-                      />
-                    </label>
-                    <Button type="submit" variant="outline">
-                      Save settlement tier
-                    </Button>
-                  </form>
+                  {isMarketplaceService ? (
+                    <form action={updateProviderServiceSettlementModeAction} className="grid gap-4">
+                      <input type="hidden" name="id" value={id} />
+                      <input type="hidden" name="returnTo" value={returnTo} />
+                      <label className="grid gap-2 text-sm font-medium">
+                        Current live settlement tier
+                        <select
+                          name="settlementMode"
+                          defaultValue={currentDetail.service.settlementMode ?? "verified_escrow"}
+                          className="fast-select min-h-12"
+                        >
+                          <option value="community_direct">Community</option>
+                          <option value="verified_escrow">Verified</option>
+                        </select>
+                      </label>
+                      <label className="grid gap-2 text-sm font-medium">
+                        Reviewer identity
+                        <input
+                          name="reviewerIdentity"
+                          type="text"
+                          defaultValue=""
+                          className="fast-input min-h-12"
+                          placeholder="operator@fast.xyz"
+                        />
+                      </label>
+                      <Button type="submit" variant="outline">
+                        Save settlement tier
+                      </Button>
+                    </form>
+                  ) : (
+                    <div className="rounded-card border border-border bg-background/70 px-4 py-3 text-sm text-muted-foreground dark:bg-background/20">
+                      External registry services do not use marketplace settlement tiers or runtime payout handling.
+                    </div>
+                  )}
 
                   <form action={suspendProviderServiceAction} className="grid gap-4">
                     <input type="hidden" name="id" value={id} />
@@ -321,19 +348,34 @@ export default async function AdminProviderServiceDetailPage({
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
                       <div className="text-lg font-medium tracking-headline">{endpoint.title}</div>
-                      <div className="mt-1 text-sm text-muted-foreground">{endpoint.operation}</div>
+                      <div className="mt-1 text-sm text-muted-foreground">
+                        {endpoint.endpointType === "marketplace_proxy" ? endpoint.operation : `${endpoint.method} ${endpoint.publicUrl}`}
+                      </div>
                     </div>
                     <div className="flex flex-wrap gap-2">
-                      <Badge variant="outline">{endpoint.mode}</Badge>
-                      <Badge variant="outline">{endpoint.executorKind}</Badge>
-                      <Badge variant="outline">{formatBillingLabel(endpoint.billing.type)}</Badge>
+                      {endpoint.endpointType === "marketplace_proxy" ? (
+                        <>
+                          <Badge variant="outline">{endpoint.mode}</Badge>
+                          <Badge variant="outline">{endpoint.executorKind}</Badge>
+                          <Badge variant="outline">{formatBillingLabel(endpoint.billing.type)}</Badge>
+                        </>
+                      ) : (
+                        <Badge variant="outline">External API</Badge>
+                      )}
                     </div>
                   </div>
                   <div className="mt-3 text-sm text-muted-foreground">{endpoint.description}</div>
-                  <div className="mt-3 grid gap-2 text-sm text-muted-foreground md:grid-cols-2">
-                    <div>Price: {endpoint.price}</div>
-                    <div>Upstream: {endpoint.upstreamBaseUrl ?? "marketplace-managed"}</div>
-                  </div>
+                  {endpoint.endpointType === "marketplace_proxy" ? (
+                    <div className="mt-3 grid gap-2 text-sm text-muted-foreground md:grid-cols-2">
+                      <div>Price: {endpoint.price}</div>
+                      <div>Upstream: {endpoint.upstreamBaseUrl ?? "marketplace-managed"}</div>
+                    </div>
+                  ) : (
+                    <div className="mt-3 grid gap-2 text-sm text-muted-foreground md:grid-cols-2">
+                      <div>Docs: {endpoint.docsUrl}</div>
+                      <div>Auth: {endpoint.authNotes ?? "Provider-defined"}</div>
+                    </div>
+                  )}
                 </div>
               ))}
             </CardContent>

--- a/apps/web/app/admin/services/page.test.tsx
+++ b/apps/web/app/admin/services/page.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  redirect: vi.fn(),
+  isAdminAuthenticated: vi.fn(),
+  fetchAdminProviderServices: vi.fn(),
+  adminLogoutAction: vi.fn()
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  )
+}));
+
+vi.mock("@/lib/admin-auth", () => ({
+  isAdminAuthenticated: mocks.isAdminAuthenticated
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchAdminProviderServices: mocks.fetchAdminProviderServices
+}));
+
+vi.mock("@/app/actions", () => ({
+  adminLogoutAction: mocks.adminLogoutAction
+}));
+
+import AdminProviderServicesPage from "./page";
+
+describe("AdminProviderServicesPage", () => {
+  beforeEach(() => {
+    mocks.redirect.mockReset();
+    mocks.isAdminAuthenticated.mockReset();
+    mocks.fetchAdminProviderServices.mockReset();
+    mocks.adminLogoutAction.mockReset();
+
+    mocks.isAdminAuthenticated.mockResolvedValue(true);
+  });
+
+  it("renders external registry services as external APIs instead of community marketplace services", async () => {
+    mocks.fetchAdminProviderServices.mockResolvedValue([
+      {
+        service: {
+          id: "service_external",
+          providerAccountId: "provider_1",
+          serviceType: "external_registry",
+          settlementMode: null,
+          slug: "signal-labs-direct",
+          apiNamespace: null,
+          name: "Signal Labs Direct",
+          tagline: "Direct provider APIs",
+          about: "Discovery-only direct APIs.",
+          categories: ["Research"],
+          promptIntro: "Use the direct API.",
+          setupInstructions: ["Read the docs."],
+          websiteUrl: "https://provider.example.com",
+          payoutWallet: null,
+          featured: false,
+          status: "pending_review",
+          latestSubmittedVersionId: "version_1",
+          latestPublishedVersionId: null,
+          latestReviewId: null,
+          createdAt: "2026-03-21T00:00:00.000Z",
+          updatedAt: "2026-03-21T00:00:00.000Z"
+        },
+        account: {
+          id: "provider_1",
+          ownerWallet: "fast1provider",
+          displayName: "Signal Labs",
+          bio: null,
+          websiteUrl: "https://provider.example.com",
+          contactEmail: null,
+          createdAt: "2026-03-21T00:00:00.000Z",
+          updatedAt: "2026-03-21T00:00:00.000Z"
+        },
+        endpoints: [
+          {
+            endpointType: "external_registry",
+            id: "endpoint_1",
+            serviceId: "service_external",
+            routeId: null,
+            operation: null,
+            title: "Status",
+            description: "Returns service status.",
+            price: null,
+            billing: null,
+            mode: null,
+            requestSchemaJson: null,
+            responseSchemaJson: null,
+            method: "GET",
+            publicUrl: "https://provider.example.com/api/status",
+            docsUrl: "https://provider.example.com/docs/status",
+            authNotes: "Bearer token required.",
+            requestExample: {},
+            responseExample: { status: "ok" },
+            usageNotes: null,
+            executorKind: null,
+            upstreamBaseUrl: null,
+            upstreamPath: null,
+            upstreamAuthMode: null,
+            upstreamAuthHeaderName: null,
+            upstreamSecretRef: null,
+            hasUpstreamSecret: false,
+            payout: null,
+            createdAt: "2026-03-21T00:00:00.000Z",
+            updatedAt: "2026-03-21T00:00:00.000Z"
+          }
+        ],
+        verification: null,
+        latestReview: null,
+        latestPublishedVersionId: null
+      }
+    ]);
+
+    render(await AdminProviderServicesPage({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByText("External API")).toBeTruthy();
+    expect(screen.getByText(/discovery-only external registry/i)).toBeTruthy();
+    expect(screen.getByText("Access model: discovery-only external API listing")).toBeTruthy();
+    expect(screen.queryByText("Community")).toBeNull();
+  });
+});

--- a/apps/web/app/admin/services/page.tsx
+++ b/apps/web/app/admin/services/page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import type { ProviderServiceStatus } from "@marketplace/shared";
@@ -63,7 +64,7 @@ export default async function AdminProviderServicesPage({
                 <p className="eyebrow">Admin review</p>
                 <h1 className="section-title">Provider services</h1>
                 <p className="body-copy">
-                  Review submitted provider supply, assign Community or Verified settlement, and publish or suspend services.
+                  Review submitted provider supply, assign settlement for marketplace-proxied services, and publish or suspend services.
                 </p>
               </div>
             </div>
@@ -105,9 +106,13 @@ export default async function AdminProviderServicesPage({
                     <div className="space-y-2">
                       <div className="flex flex-wrap gap-2">
                         <Badge variant="secondary">{detail.service.status}</Badge>
-                        <Badge variant={detail.service.settlementMode === "verified_escrow" ? "default" : "outline"}>
-                          {detail.service.settlementMode === "verified_escrow" ? "Verified" : "Community"}
-                        </Badge>
+                        {detail.service.serviceType === "marketplace_proxy" ? (
+                          <Badge variant={detail.service.settlementMode === "verified_escrow" ? "default" : "outline"}>
+                            {detail.service.settlementMode === "verified_escrow" ? "Verified" : "Community"}
+                          </Badge>
+                        ) : (
+                          <Badge variant="outline">External API</Badge>
+                        )}
                         {detail.verification ? (
                           <Badge variant="outline">verification: {detail.verification.status}</Badge>
                         ) : null}
@@ -117,7 +122,10 @@ export default async function AdminProviderServicesPage({
                       </div>
                       <CardTitle>{detail.service.name}</CardTitle>
                       <CardDescription>
-                        {detail.service.apiNamespace} · {detail.account.displayName} · {detail.endpoints.length} endpoint
+                        {detail.service.serviceType === "marketplace_proxy"
+                          ? detail.service.apiNamespace
+                          : "discovery-only external registry"}{" "}
+                        · {detail.account.displayName} · {detail.endpoints.length} endpoint
                         {detail.endpoints.length === 1 ? "" : "s"}
                       </CardDescription>
                     </div>
@@ -130,7 +138,11 @@ export default async function AdminProviderServicesPage({
                 </CardHeader>
                 <CardContent className="grid gap-2 text-sm text-muted-foreground">
                   <div>Website: {detail.service.websiteUrl ?? "not set"}</div>
-                  <div>Payout wallet: {detail.service.payoutWallet ?? "not set"}</div>
+                  {detail.service.serviceType === "marketplace_proxy" ? (
+                    <div>Payout wallet: {detail.service.payoutWallet ?? "not set"}</div>
+                  ) : (
+                    <div>Access model: discovery-only external API listing</div>
+                  )}
                   <div>Updated: {detail.service.updatedAt.slice(0, 10)}</div>
                 </CardContent>
               </Card>

--- a/apps/web/components/admin-nav.tsx
+++ b/apps/web/components/admin-nav.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Link from "next/link";
 
 export function AdminNav({

--- a/apps/web/components/catalog-snapshot-card.test.tsx
+++ b/apps/web/components/catalog-snapshot-card.test.tsx
@@ -12,6 +12,7 @@ describe("CatalogSnapshotCard", () => {
       <CatalogSnapshotCard
         services={[
           {
+            serviceType: "marketplace_proxy",
             slug: "mock-research-signals",
             name: "Mock Research Signals",
             ownerName: "Fast Marketplace",
@@ -29,6 +30,7 @@ describe("CatalogSnapshotCard", () => {
             volume30d: []
           },
           {
+            serviceType: "marketplace_proxy",
             slug: "weather-wire",
             name: "Weather Wire",
             ownerName: "Sky Data",

--- a/apps/web/components/catalog-snapshot-card.tsx
+++ b/apps/web/components/catalog-snapshot-card.tsx
@@ -6,8 +6,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 function buildMarketplaceTotals(services: ServiceSummary[]) {
   return services.reduce(
     (totals, service) => {
-      totals.calls += service.totalCalls;
-      totals.revenue += Number(service.revenue);
+      if (service.serviceType === "marketplace_proxy") {
+        totals.calls += service.totalCalls;
+        totals.revenue += Number(service.revenue);
+      }
       totals.endpoints += service.endpointCount;
       return totals;
     },

--- a/apps/web/components/endpoint-browser-runner.tsx
+++ b/apps/web/components/endpoint-browser-runner.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { LoaderCircle, RefreshCcw, TriangleAlert, Wallet } from "lucide-react";
-import type { ServiceCatalogEndpoint } from "@marketplace/shared";
+import type { MarketplaceServiceCatalogEndpoint } from "@marketplace/shared";
 import type { WebDeploymentNetwork } from "@/lib/network";
 
 import { CopyButton } from "@/components/copy-button";
@@ -46,7 +46,7 @@ export function EndpointBrowserRunner({
   endpoint,
   deploymentNetwork
 }: {
-  endpoint: ServiceCatalogEndpoint;
+  endpoint: MarketplaceServiceCatalogEndpoint;
   deploymentNetwork: WebDeploymentNetwork;
 }) {
   const [requestBody, setRequestBody] = React.useState(() => JSON.stringify(endpoint.requestExample, null, 2));

--- a/apps/web/components/marketplace-home.test.tsx
+++ b/apps/web/components/marketplace-home.test.tsx
@@ -24,6 +24,7 @@ describe("MarketplaceHome", () => {
       <MarketplaceHome
         services={[
           {
+            serviceType: "marketplace_proxy",
             slug: "mock-research-signals",
             name: "Mock Research Signals",
             ownerName: "Fast Marketplace",
@@ -41,6 +42,7 @@ describe("MarketplaceHome", () => {
             volume30d: []
           },
           {
+            serviceType: "marketplace_proxy",
             slug: "weather-wire",
             name: "Weather Wire",
             ownerName: "Sky Data",

--- a/apps/web/components/marketplace-home.tsx
+++ b/apps/web/components/marketplace-home.tsx
@@ -90,10 +90,16 @@ export function MarketplaceHome({ services }: { services: ServiceSummary[] }) {
                   <CardHeader>
                     <div className="flex flex-wrap items-center gap-2">
                       <Badge variant="outline">{service.ownerName}</Badge>
-                      <Badge variant={service.settlementMode === "verified_escrow" ? "default" : "secondary"}>
-                        {service.settlementLabel}
-                      </Badge>
-                      <span className="text-sm tracking-headline text-muted-foreground">{service.priceRange}</span>
+                      {service.serviceType === "marketplace_proxy" ? (
+                        <>
+                          <Badge variant={service.settlementMode === "verified_escrow" ? "default" : "secondary"}>
+                            {service.settlementLabel}
+                          </Badge>
+                          <span className="text-sm tracking-headline text-muted-foreground">{service.priceRange}</span>
+                        </>
+                      ) : (
+                        <Badge variant="secondary">{service.accessModelLabel}</Badge>
+                      )}
                     </div>
                     <div className="space-y-3">
                       <CardTitle className="text-3xl">{service.name}</CardTitle>
@@ -109,14 +115,24 @@ export function MarketplaceHome({ services }: { services: ServiceSummary[] }) {
                       ))}
                     </div>
 
-                    <p className="text-sm leading-7 text-muted-foreground">{service.settlementDescription}</p>
+                    <p className="text-sm leading-7 text-muted-foreground">
+                      {service.serviceType === "marketplace_proxy" ? service.settlementDescription : service.accessModelDescription}
+                    </p>
 
-                    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-                      <Metric label="Calls" value={String(service.totalCalls)} compact />
-                      <Metric label="Revenue" value={`$${service.revenue}`} compact />
-                      <Metric label="Endpoints" value={String(service.endpointCount)} compact />
-                      <Metric label="30d success" value={`${service.successRate30d.toFixed(1)}%`} compact />
-                    </div>
+                    {service.serviceType === "marketplace_proxy" ? (
+                      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                        <Metric label="Calls" value={String(service.totalCalls)} compact />
+                        <Metric label="Revenue" value={`$${service.revenue}`} compact />
+                        <Metric label="Endpoints" value={String(service.endpointCount)} compact />
+                        <Metric label="30d success" value={`${service.successRate30d.toFixed(1)}%`} compact />
+                      </div>
+                    ) : (
+                      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                        <Metric label="Endpoints" value={String(service.endpointCount)} compact />
+                        <Metric label="Access" value="Direct API" compact />
+                        <Metric label="Website" value={service.websiteUrl ? new URL(service.websiteUrl).hostname : "N/A"} compact />
+                      </div>
+                    )}
 
                     <div className="flex items-center justify-between border-t border-border pt-5 text-sm tracking-headline text-muted-foreground">
                       <span>Open service</span>

--- a/apps/web/components/provider-service-editor.test.tsx
+++ b/apps/web/components/provider-service-editor.test.tsx
@@ -40,6 +40,7 @@ function buildServiceDetail(overrides?: {
     service: {
       id: "service_1",
       providerAccountId: "provider_1",
+      serviceType: "marketplace_proxy" as const,
       settlementMode: "community_direct" as const,
       slug: "signal-labs",
       apiNamespace: "signals",
@@ -258,6 +259,7 @@ describe("ProviderServiceEditor", () => {
     fetchProviderService.mockResolvedValue(buildServiceDetail({
       endpoints: [
         {
+          endpointType: "marketplace_proxy" as const,
           id: "endpoint_1",
           serviceId: "service_1",
           routeId: "signal-labs.search.v1",

--- a/apps/web/components/provider-service-editor.tsx
+++ b/apps/web/components/provider-service-editor.tsx
@@ -2,11 +2,14 @@
 
 import React from "react";
 import type {
-  CreateProviderEndpointDraftInput,
+  CreateExternalProviderEndpointDraftInput,
+  CreateMarketplaceProviderEndpointDraftInput,
   MarketplaceDeploymentNetwork,
   OpenApiImportPreview,
+  ProviderEndpointDraftRecord,
   RouteBillingType,
-  UpdateProviderEndpointDraftInput
+  UpdateExternalProviderEndpointDraftInput,
+  UpdateMarketplaceProviderEndpointDraftInput,
 } from "@marketplace/shared";
 
 import { CopyButton } from "@/components/copy-button";
@@ -45,6 +48,17 @@ function usesUpstreamConfig(billingType: RouteBillingType): boolean {
 
 function usesUpstreamSecret(authMode: EndpointFormState["upstreamAuthMode"]): boolean {
   return authMode === "bearer" || authMode === "header";
+}
+
+type MarketplaceDraftEndpoint = Extract<ProviderEndpointDraftRecord, { endpointType: "marketplace_proxy" }>;
+type ExternalDraftEndpoint = Extract<ProviderEndpointDraftRecord, { endpointType: "external_registry" }>;
+
+function isMarketplaceEndpointDraft(endpoint: ProviderEndpointDraftRecord): endpoint is MarketplaceDraftEndpoint {
+  return endpoint.endpointType === "marketplace_proxy";
+}
+
+function isExternalEndpointDraft(endpoint: ProviderEndpointDraftRecord): endpoint is ExternalDraftEndpoint {
+  return endpoint.endpointType === "external_registry";
 }
 
 export function ProviderServiceEditor({
@@ -107,6 +121,7 @@ function ProviderServiceEditorInner({
   }, [accessToken, apiBaseUrl, serviceId]);
 
   const [newEndpoint, setNewEndpoint] = React.useState(defaultEndpointFormState());
+  const [newExternalEndpoint, setNewExternalEndpoint] = React.useState(defaultExternalEndpointFormState());
   const [openApiUrl, setOpenApiUrl] = React.useState("");
   const [openApiPreview, setOpenApiPreview] = React.useState<OpenApiImportPreview | null>(null);
 
@@ -137,6 +152,8 @@ function ProviderServiceEditorInner({
       </Card>
     );
   }
+
+  const loadedDetail = detail;
 
   async function refresh() {
     const [nextDetail, nextRuntimeKey] = await Promise.all([
@@ -169,7 +186,9 @@ function ProviderServiceEditorInner({
             .map((value) => value.trim())
             .filter(Boolean),
           websiteUrl: String(form.get("websiteUrl") ?? "") || null,
-          payoutWallet: String(form.get("payoutWallet") ?? "") || null
+          payoutWallet: loadedDetail.service.serviceType === "marketplace_proxy"
+            ? (String(form.get("payoutWallet") ?? "") || null)
+            : null
         });
         await refresh();
         setMessage("Service draft updated.");
@@ -186,8 +205,13 @@ function ProviderServiceEditorInner({
 
     startTransition(async () => {
       try {
-        await createProviderEndpoint(apiBaseUrl, accessToken, serviceId, buildEndpointInput(newEndpoint));
-        setNewEndpoint(defaultEndpointFormState());
+        if (loadedDetail.service.serviceType === "marketplace_proxy") {
+          await createProviderEndpoint(apiBaseUrl, accessToken, serviceId, buildEndpointInput(newEndpoint));
+          setNewEndpoint(defaultEndpointFormState());
+        } else {
+          await createProviderEndpoint(apiBaseUrl, accessToken, serviceId, buildExternalEndpointInput(newExternalEndpoint));
+          setNewExternalEndpoint(defaultExternalEndpointFormState());
+        }
         await refresh();
         setMessage("Endpoint draft created.");
       } catch (nextError) {
@@ -275,12 +299,19 @@ function ProviderServiceEditorInner({
     });
   }
 
+  const marketplaceEndpoints = detail.endpoints.filter(isMarketplaceEndpointDraft);
+  const externalEndpoints = detail.endpoints.filter(isExternalEndpointDraft);
+
   return (
     <div className="grid gap-6">
       <Card variant="frosted">
         <CardHeader>
           <CardTitle className="text-3xl">{detail.service.name}</CardTitle>
-          <CardDescription>{detail.service.apiNamespace} · {detail.service.status}</CardDescription>
+          <CardDescription>
+            {detail.service.serviceType === "marketplace_proxy"
+              ? `${detail.service.apiNamespace} · ${detail.service.status}`
+              : `external registry · ${detail.service.status}`}
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <form className="grid gap-4" onSubmit={onSaveService}>
@@ -316,10 +347,12 @@ function ProviderServiceEditorInner({
               Setup instructions
               <Textarea name="setupInstructions" defaultValue={detail.service.setupInstructions.join("\n")} />
             </label>
-            <label className="grid gap-2 text-sm font-medium">
-              Payout wallet
-              <Input name="payoutWallet" defaultValue={detail.service.payoutWallet ?? ""} />
-            </label>
+            {detail.service.serviceType === "marketplace_proxy" ? (
+              <label className="grid gap-2 text-sm font-medium">
+                Payout wallet
+                <Input name="payoutWallet" defaultValue={detail.service.payoutWallet ?? ""} />
+              </label>
+            ) : null}
             <div className="flex flex-wrap gap-3">
               <Button type="submit" disabled={pending}>{pending ? "Saving..." : "Save metadata"}</Button>
               <Button type="button" variant="outline" onClick={() => window.location.assign(`/providers/services/${serviceId}/review`)}>
@@ -330,40 +363,54 @@ function ProviderServiceEditorInner({
         </CardContent>
       </Card>
 
-      <Card variant="frosted">
-        <CardHeader>
-          <CardTitle className="text-3xl">Settlement tier</CardTitle>
-          <CardDescription>
-            Current tier: {detail.service.settlementMode === "verified_escrow" ? "Verified" : "Community"}.
-            Providers cannot switch this themselves in v1.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4 text-sm text-muted-foreground">
-          <div className="rounded-card border border-border bg-background/70 p-5 dark:bg-background/20">
-            {detail.service.settlementMode === "verified_escrow"
-              ? "Verified services use marketplace escrow, marketplace refunds, and marketplace payout settlement."
-              : "Community services are paid directly, require a runtime key for signed buyer identity headers, and provider-owned refund handling."}
-          </div>
-          <div className="rounded-card border border-border bg-background/70 p-5 dark:bg-background/20 space-y-3">
-            <div className="font-medium text-foreground">Provider runtime key</div>
-            <div>{runtimeKey ? `Active key: ${runtimeKey.keyPrefix}` : "No runtime key created yet."}</div>
-            <div className="flex flex-wrap gap-3">
-              <Button type="button" variant="outline" onClick={onRotateRuntimeKey} disabled={pending}>
-                {runtimeKey ? "Rotate runtime key" : "Create runtime key"}
-              </Button>
+      {detail.service.serviceType === "marketplace_proxy" ? (
+        <Card variant="frosted">
+          <CardHeader>
+            <CardTitle className="text-3xl">Settlement tier</CardTitle>
+            <CardDescription>
+              Current tier: {detail.service.settlementMode === "verified_escrow" ? "Verified" : "Community"}.
+              Providers cannot switch this themselves in v1.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm text-muted-foreground">
+            <div className="rounded-card border border-border bg-background/70 p-5 dark:bg-background/20">
+              {detail.service.settlementMode === "verified_escrow"
+                ? "Verified services use marketplace escrow, marketplace refunds, and marketplace payout settlement."
+                : "Community services are paid directly, require a runtime key for signed buyer identity headers, and provider-owned refund handling."}
             </div>
-            {runtimeSecret ? (
-              <div className="flex items-center justify-between gap-3 rounded-card border border-border bg-background/80 p-4 dark:bg-background/30">
-                <div>
-                  <div className="text-xs text-muted-foreground">Plaintext runtime key</div>
-                  <div className="break-all font-mono text-sm text-foreground">{runtimeSecret}</div>
-                </div>
-                <CopyButton value={runtimeSecret} />
+            <div className="rounded-card border border-border bg-background/70 p-5 dark:bg-background/20 space-y-3">
+              <div className="font-medium text-foreground">Provider runtime key</div>
+              <div>{runtimeKey ? `Active key: ${runtimeKey.keyPrefix}` : "No runtime key created yet."}</div>
+              <div className="flex flex-wrap gap-3">
+                <Button type="button" variant="outline" onClick={onRotateRuntimeKey} disabled={pending}>
+                  {runtimeKey ? "Rotate runtime key" : "Create runtime key"}
+                </Button>
               </div>
-            ) : null}
-          </div>
-        </CardContent>
-      </Card>
+              {runtimeSecret ? (
+                <div className="flex items-center justify-between gap-3 rounded-card border border-border bg-background/80 p-4 dark:bg-background/30">
+                  <div>
+                    <div className="text-xs text-muted-foreground">Plaintext runtime key</div>
+                    <div className="break-all font-mono text-sm text-foreground">{runtimeSecret}</div>
+                  </div>
+                  <CopyButton value={runtimeSecret} />
+                </div>
+              ) : null}
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card variant="frosted">
+          <CardHeader>
+            <CardTitle className="text-3xl">Access model</CardTitle>
+            <CardDescription>Discovery-only listing. The marketplace does not proxy, charge for, or authenticate these calls.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm text-muted-foreground">
+            <div className="rounded-card border border-border bg-background/70 p-5 dark:bg-background/20">
+              External registry services publish direct endpoint metadata only: method, public URL, docs URL, auth notes, and examples.
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       <Card variant="frosted">
         <CardHeader>
@@ -409,108 +456,145 @@ function ProviderServiceEditorInner({
       <Card variant="frosted">
         <CardHeader>
           <CardTitle className="text-3xl">Endpoint drafts</CardTitle>
-          <CardDescription>Provider-authored endpoints are POST JSON and sync-only in v1.</CardDescription>
+          <CardDescription>
+            {detail.service.serviceType === "marketplace_proxy"
+              ? "Provider-authored endpoints are POST JSON and sync-only in v1."
+              : "Discovery-only services publish direct provider endpoint metadata."}
+          </CardDescription>
         </CardHeader>
         <CardContent className="grid gap-6">
-          {detail.endpoints.map((endpoint) => (
-            <EndpointDraftCard
-              key={endpoint.id}
-              apiBaseUrl={apiBaseUrl}
-              accessToken={accessToken}
-              serviceId={serviceId}
-              endpoint={endpoint}
-              onChange={async () => {
-                await refresh();
-                setMessage("Endpoint draft updated.");
-              }}
-              onDelete={async () => {
-                await deleteProviderEndpoint(apiBaseUrl, accessToken, serviceId, endpoint.id);
-                await refresh();
-                setMessage("Endpoint draft deleted.");
-              }}
-            />
-          ))}
+          {detail.service.serviceType === "marketplace_proxy" ? (
+            <>
+              {marketplaceEndpoints.map((endpoint) => (
+                <EndpointDraftCard
+                  key={endpoint.id}
+                  apiBaseUrl={apiBaseUrl}
+                  accessToken={accessToken}
+                  serviceId={serviceId}
+                  endpoint={endpoint}
+                  onChange={async () => {
+                    await refresh();
+                    setMessage("Endpoint draft updated.");
+                  }}
+                  onDelete={async () => {
+                    await deleteProviderEndpoint(apiBaseUrl, accessToken, serviceId, endpoint.id);
+                    await refresh();
+                    setMessage("Endpoint draft deleted.");
+                  }}
+                />
+              ))}
 
-          <form
-            className="grid gap-4 rounded-card border border-border bg-background/70 p-5 dark:bg-background/20"
-            onSubmit={onImportOpenApi}
-          >
-            <div className="metric-label">Import from OpenAPI</div>
-            <label className="grid gap-2 text-sm font-medium">
-              OpenAPI JSON URL
-              <Input
-                value={openApiUrl}
-                type="url"
-                placeholder="https://api.example.com/openapi.json"
-                required
-                onChange={(event) => setOpenApiUrl(event.target.value)}
-              />
-            </label>
-            <div className="text-sm text-muted-foreground">
-              Import previews only. Load a candidate into the new endpoint form, then choose billing, set price if needed,
-              and add any upstream secret before creating the draft.
-            </div>
-            <div className="flex flex-wrap gap-3">
-              <Button type="submit" variant="outline" disabled={pending}>
-                {pending ? "Loading..." : "Load OpenAPI"}
-              </Button>
-            </div>
-            {openApiPreview ? (
-              <div className="grid gap-4 rounded-card border border-border bg-background/80 p-4 dark:bg-background/30">
-                <div>
-                  <div className="text-sm font-medium text-foreground">
-                    {openApiPreview.title ?? "Imported OpenAPI document"}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    {openApiPreview.version ? `Version ${openApiPreview.version} · ` : ""}
-                    {openApiPreview.documentUrl}
-                  </div>
+              <form
+                className="grid gap-4 rounded-card border border-border bg-background/70 p-5 dark:bg-background/20"
+                onSubmit={onImportOpenApi}
+              >
+                <div className="metric-label">Import from OpenAPI</div>
+                <label className="grid gap-2 text-sm font-medium">
+                  OpenAPI JSON URL
+                  <Input
+                    value={openApiUrl}
+                    type="url"
+                    placeholder="https://api.example.com/openapi.json"
+                    required
+                    onChange={(event) => setOpenApiUrl(event.target.value)}
+                  />
+                </label>
+                <div className="text-sm text-muted-foreground">
+                  Import previews only. Load a candidate into the new endpoint form, then choose billing, set price if needed,
+                  and add any upstream secret before creating the draft.
                 </div>
-                {openApiPreview.warnings.length > 0 ? (
-                  <div className="grid gap-2 text-sm text-muted-foreground">
-                    {openApiPreview.warnings.map((warning) => (
-                      <div key={warning}>{warning}</div>
-                    ))}
-                  </div>
-                ) : null}
-                {openApiPreview.endpoints.map((candidate) => (
-                  <div key={`${candidate.operation}:${candidate.upstreamPath}`} className="grid gap-3 rounded-card border border-border p-4">
-                    <div className="flex flex-wrap items-start justify-between gap-3">
-                      <div>
-                        <div className="font-medium text-foreground">{candidate.title}</div>
-                        <div className="text-xs text-muted-foreground">
-                          {candidate.operation} · POST {candidate.upstreamPath}
-                        </div>
+                <div className="flex flex-wrap gap-3">
+                  <Button type="submit" variant="outline" disabled={pending}>
+                    {pending ? "Loading..." : "Load OpenAPI"}
+                  </Button>
+                </div>
+                {openApiPreview ? (
+                  <div className="grid gap-4 rounded-card border border-border bg-background/80 p-4 dark:bg-background/30">
+                    <div>
+                      <div className="text-sm font-medium text-foreground">
+                        {openApiPreview.title ?? "Imported OpenAPI document"}
                       </div>
-                      <Button type="button" variant="outline" onClick={() => setNewEndpoint(openApiCandidateToFormState(candidate))}>
-                        Load into new draft
-                      </Button>
+                      <div className="text-xs text-muted-foreground">
+                        {openApiPreview.version ? `Version ${openApiPreview.version} · ` : ""}
+                        {openApiPreview.documentUrl}
+                      </div>
                     </div>
-                    <div className="text-sm text-muted-foreground">{candidate.description}</div>
-                    <div className="text-xs text-muted-foreground">
-                      Base URL: {candidate.upstreamBaseUrl} · Auth: {candidate.upstreamAuthMode}
-                      {candidate.upstreamAuthHeaderName ? ` (${candidate.upstreamAuthHeaderName})` : ""}
-                    </div>
-                    {candidate.warnings.length > 0 ? (
-                      <div className="grid gap-2 text-xs text-muted-foreground">
-                        {candidate.warnings.map((warning) => (
+                    {openApiPreview.warnings.length > 0 ? (
+                      <div className="grid gap-2 text-sm text-muted-foreground">
+                        {openApiPreview.warnings.map((warning) => (
                           <div key={warning}>{warning}</div>
                         ))}
                       </div>
                     ) : null}
+                    {openApiPreview.endpoints.map((candidate) => (
+                      <div key={`${candidate.operation}:${candidate.upstreamPath}`} className="grid gap-3 rounded-card border border-border p-4">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div>
+                            <div className="font-medium text-foreground">{candidate.title}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {candidate.operation} · POST {candidate.upstreamPath}
+                            </div>
+                          </div>
+                          <Button type="button" variant="outline" onClick={() => setNewEndpoint(openApiCandidateToFormState(candidate))}>
+                            Load into new draft
+                          </Button>
+                        </div>
+                        <div className="text-sm text-muted-foreground">{candidate.description}</div>
+                        <div className="text-xs text-muted-foreground">
+                          Base URL: {candidate.upstreamBaseUrl} · Auth: {candidate.upstreamAuthMode}
+                          {candidate.upstreamAuthHeaderName ? ` (${candidate.upstreamAuthHeaderName})` : ""}
+                        </div>
+                        {candidate.warnings.length > 0 ? (
+                          <div className="grid gap-2 text-xs text-muted-foreground">
+                            {candidate.warnings.map((warning) => (
+                              <div key={warning}>{warning}</div>
+                            ))}
+                          </div>
+                        ) : null}
+                      </div>
+                    ))}
                   </div>
-                ))}
-              </div>
-            ) : null}
-          </form>
+                ) : null}
+              </form>
 
-          <form className="grid gap-4 rounded-card border border-border bg-background/70 p-5 dark:bg-background/20" onSubmit={onCreateEndpoint}>
-            <div className="metric-label">New endpoint</div>
-            <EndpointDraftFields state={newEndpoint} onChange={setNewEndpoint} />
-            <Button type="submit" disabled={pending}>
-              {pending ? "Creating..." : "Create endpoint"}
-            </Button>
-          </form>
+              <form className="grid gap-4 rounded-card border border-border bg-background/70 p-5 dark:bg-background/20" onSubmit={onCreateEndpoint}>
+                <div className="metric-label">New endpoint</div>
+                <EndpointDraftFields state={newEndpoint} onChange={setNewEndpoint} />
+                <Button type="submit" disabled={pending}>
+                  {pending ? "Creating..." : "Create endpoint"}
+                </Button>
+              </form>
+            </>
+          ) : (
+            <>
+              {externalEndpoints.map((endpoint) => (
+                <ExternalEndpointDraftCard
+                  key={endpoint.id}
+                  apiBaseUrl={apiBaseUrl}
+                  accessToken={accessToken}
+                  serviceId={serviceId}
+                  endpoint={endpoint}
+                  onChange={async () => {
+                    await refresh();
+                    setMessage("Endpoint draft updated.");
+                  }}
+                  onDelete={async () => {
+                    await deleteProviderEndpoint(apiBaseUrl, accessToken, serviceId, endpoint.id);
+                    await refresh();
+                    setMessage("Endpoint draft deleted.");
+                  }}
+                />
+              ))}
+
+              <form className="grid gap-4 rounded-card border border-border bg-background/70 p-5 dark:bg-background/20" onSubmit={onCreateEndpoint}>
+                <div className="metric-label">New external endpoint</div>
+                <ExternalEndpointDraftFields state={newExternalEndpoint} onChange={setNewExternalEndpoint} />
+                <Button type="submit" disabled={pending}>
+                  {pending ? "Creating..." : "Create endpoint"}
+                </Button>
+              </form>
+            </>
+          )}
         </CardContent>
       </Card>
 
@@ -531,13 +615,7 @@ function EndpointDraftCard({
   apiBaseUrl: string;
   accessToken: string;
   serviceId: string;
-  endpoint: Awaited<ReturnType<typeof fetchProviderService>> extends infer T
-    ? T extends { endpoints: infer U }
-      ? U extends Array<infer V>
-        ? V
-        : never
-      : never
-    : never;
+  endpoint: MarketplaceDraftEndpoint;
   onChange: () => Promise<void>;
   onDelete: () => Promise<void>;
 }) {
@@ -595,6 +673,80 @@ function EndpointDraftCard({
         </div>
       </div>
       <EndpointDraftFields state={state} onChange={setState} />
+      {error ? <p className="text-sm text-muted-foreground">{error}</p> : null}
+    </form>
+  );
+}
+
+function ExternalEndpointDraftCard({
+  apiBaseUrl,
+  accessToken,
+  serviceId,
+  endpoint,
+  onChange,
+  onDelete
+}: {
+  apiBaseUrl: string;
+  accessToken: string;
+  serviceId: string;
+  endpoint: ExternalDraftEndpoint;
+  onChange: () => Promise<void>;
+  onDelete: () => Promise<void>;
+}) {
+  const [state, setState] = React.useState(() => externalEndpointToFormState(endpoint));
+  const [pending, startTransition] = React.useTransition();
+  const [error, setError] = React.useState<string | null>(null);
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+
+    startTransition(async () => {
+      try {
+        await updateProviderEndpoint(
+          apiBaseUrl,
+          accessToken,
+          serviceId,
+          endpoint.id,
+          buildExternalEndpointUpdateInput(state)
+        );
+        await onChange();
+      } catch (nextError) {
+        setError(nextError instanceof Error ? nextError.message : "Endpoint update failed.");
+      }
+    });
+  }
+
+  return (
+    <form className="grid gap-4 rounded-card border border-border bg-background/70 p-5 dark:bg-background/20" onSubmit={onSubmit}>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="text-lg font-medium tracking-headline">{endpoint.title}</div>
+          <div className="text-xs text-muted-foreground">{endpoint.method} · {endpoint.publicUrl}</div>
+        </div>
+        <div className="flex gap-2">
+          <Button type="submit" variant="outline" disabled={pending}>
+            {pending ? "Saving..." : "Save"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={pending}
+            onClick={() => {
+              startTransition(async () => {
+                try {
+                  await onDelete();
+                } catch (nextError) {
+                  setError(nextError instanceof Error ? nextError.message : "Endpoint delete failed.");
+                }
+              });
+            }}
+          >
+            Delete
+          </Button>
+        </div>
+      </div>
+      <ExternalEndpointDraftFields state={state} onChange={setState} />
       {error ? <p className="text-sm text-muted-foreground">{error}</p> : null}
     </form>
   );
@@ -883,27 +1035,7 @@ const RESPONSE_EXAMPLE_PLACEHOLDER = `{
   "price": 42.5
 }`;
 
-function endpointToFormState(endpoint: {
-  operation: string;
-  title: string;
-  description: string;
-  billing: {
-    type: RouteBillingType;
-    price?: string;
-    minAmount?: string;
-    maxAmount?: string;
-  };
-  price: string;
-  requestSchemaJson: unknown;
-  responseSchemaJson: unknown;
-  requestExample: unknown;
-  responseExample: unknown;
-  usageNotes: string | null;
-  upstreamBaseUrl: string | null;
-  upstreamPath: string | null;
-  upstreamAuthMode: "none" | "bearer" | "header" | null;
-  upstreamAuthHeaderName: string | null;
-}): EndpointFormState {
+function endpointToFormState(endpoint: MarketplaceDraftEndpoint): EndpointFormState {
   return {
     operation: endpoint.operation,
     title: endpoint.title,
@@ -947,8 +1079,9 @@ function openApiCandidateToFormState(candidate: OpenApiImportPreview["endpoints"
   };
 }
 
-function buildEndpointInput(state: EndpointFormState): CreateProviderEndpointDraftInput {
-  const input: CreateProviderEndpointDraftInput = {
+function buildEndpointInput(state: EndpointFormState): CreateMarketplaceProviderEndpointDraftInput {
+  const input: CreateMarketplaceProviderEndpointDraftInput = {
+    endpointType: "marketplace_proxy",
     operation: state.operation,
     title: state.title,
     description: state.description,
@@ -979,7 +1112,7 @@ function buildEndpointInput(state: EndpointFormState): CreateProviderEndpointDra
   return input;
 }
 
-function buildEndpointUpdateInput(state: EndpointFormState, hasSecret: boolean): UpdateProviderEndpointDraftInput {
+function buildEndpointUpdateInput(state: EndpointFormState, hasSecret: boolean): UpdateMarketplaceProviderEndpointDraftInput {
   const clearUpstreamSecret =
     hasSecret && (
       state.billingType === "topup_x402_variable"
@@ -988,7 +1121,8 @@ function buildEndpointUpdateInput(state: EndpointFormState, hasSecret: boolean):
       ? true
       : undefined;
 
-  const input: UpdateProviderEndpointDraftInput = {
+  const input: UpdateMarketplaceProviderEndpointDraftInput = {
+    endpointType: "marketplace_proxy",
     operation: state.operation,
     title: state.title,
     description: state.description,
@@ -1021,4 +1155,174 @@ function buildEndpointUpdateInput(state: EndpointFormState, hasSecret: boolean):
   input.upstreamAuthHeaderName = state.upstreamAuthMode === "header" ? (state.upstreamAuthHeaderName || null) : null;
   input.upstreamSecret = usesUpstreamSecret(state.upstreamAuthMode) ? (state.upstreamSecret || undefined) : undefined;
   return input;
+}
+
+interface ExternalEndpointFormState {
+  title: string;
+  description: string;
+  method: "GET" | "POST";
+  publicUrl: string;
+  docsUrl: string;
+  authNotes: string;
+  requestExample: string;
+  responseExample: string;
+  usageNotes: string;
+}
+
+function defaultExternalEndpointFormState(): ExternalEndpointFormState {
+  return {
+    title: "",
+    description: "",
+    method: "GET",
+    publicUrl: "",
+    docsUrl: "",
+    authNotes: "",
+    requestExample: "{}",
+    responseExample: "{}",
+    usageNotes: ""
+  };
+}
+
+function externalEndpointToFormState(endpoint: ExternalDraftEndpoint): ExternalEndpointFormState {
+  return {
+    title: endpoint.title,
+    description: endpoint.description,
+    method: endpoint.method,
+    publicUrl: endpoint.publicUrl,
+    docsUrl: endpoint.docsUrl,
+    authNotes: endpoint.authNotes ?? "",
+    requestExample: JSON.stringify(endpoint.requestExample, null, 2),
+    responseExample: JSON.stringify(endpoint.responseExample, null, 2),
+    usageNotes: endpoint.usageNotes ?? ""
+  };
+}
+
+function buildExternalEndpointInput(state: ExternalEndpointFormState): CreateExternalProviderEndpointDraftInput {
+  return {
+    endpointType: "external_registry",
+    title: state.title,
+    description: state.description,
+    method: state.method,
+    publicUrl: state.publicUrl,
+    docsUrl: state.docsUrl,
+    authNotes: state.authNotes || null,
+    requestExample: JSON.parse(state.requestExample),
+    responseExample: JSON.parse(state.responseExample),
+    usageNotes: state.usageNotes || null
+  };
+}
+
+function buildExternalEndpointUpdateInput(state: ExternalEndpointFormState): UpdateExternalProviderEndpointDraftInput {
+  return {
+    endpointType: "external_registry",
+    title: state.title,
+    description: state.description,
+    method: state.method,
+    publicUrl: state.publicUrl,
+    docsUrl: state.docsUrl,
+    authNotes: state.authNotes || null,
+    requestExample: JSON.parse(state.requestExample),
+    responseExample: JSON.parse(state.responseExample),
+    usageNotes: state.usageNotes || null
+  };
+}
+
+function ExternalEndpointDraftFields({
+  state,
+  onChange
+}: {
+  state: ExternalEndpointFormState;
+  onChange: React.Dispatch<React.SetStateAction<ExternalEndpointFormState>>;
+}) {
+  return (
+    <>
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="grid gap-2 text-sm font-medium">
+          Title
+          <Input
+            value={state.title}
+            placeholder="Current status"
+            required
+            onChange={(event) => onChange((current) => ({ ...current, title: event.target.value }))}
+          />
+        </label>
+        <label className="grid gap-2 text-sm font-medium">
+          Method
+          <select
+            value={state.method}
+            className={SELECT_CLASS_NAME}
+            onChange={(event) => onChange((current) => ({ ...current, method: event.target.value as ExternalEndpointFormState["method"] }))}
+          >
+            <option value="GET">GET</option>
+            <option value="POST">POST</option>
+          </select>
+        </label>
+      </div>
+      <label className="grid gap-2 text-sm font-medium">
+        Description
+        <Textarea
+          value={state.description}
+          placeholder="Describe the direct provider endpoint."
+          required
+          onChange={(event) => onChange((current) => ({ ...current, description: event.target.value }))}
+        />
+      </label>
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="grid gap-2 text-sm font-medium">
+          Public URL
+          <Input
+            value={state.publicUrl}
+            type="url"
+            placeholder="https://api.example.com/v1/status"
+            required
+            onChange={(event) => onChange((current) => ({ ...current, publicUrl: event.target.value }))}
+          />
+        </label>
+        <label className="grid gap-2 text-sm font-medium">
+          Docs URL
+          <Input
+            value={state.docsUrl}
+            type="url"
+            placeholder="https://docs.example.com/status"
+            required
+            onChange={(event) => onChange((current) => ({ ...current, docsUrl: event.target.value }))}
+          />
+        </label>
+      </div>
+      <label className="grid gap-2 text-sm font-medium">
+        Auth notes
+        <Textarea
+          value={state.authNotes}
+          placeholder="Explain how callers authenticate directly with the provider."
+          onChange={(event) => onChange((current) => ({ ...current, authNotes: event.target.value }))}
+        />
+      </label>
+      <label className="grid gap-2 text-sm font-medium">
+        Usage notes
+        <Textarea
+          value={state.usageNotes}
+          placeholder="Explain rate limits, expected parameters, or special integration notes."
+          onChange={(event) => onChange((current) => ({ ...current, usageNotes: event.target.value }))}
+        />
+      </label>
+      <label className="grid gap-2 text-sm font-medium">
+        Request example JSON
+        <Textarea
+          value={state.requestExample}
+          required
+          onChange={(event) => onChange((current) => ({ ...current, requestExample: event.target.value }))}
+          className="min-h-32 font-mono"
+        />
+      </label>
+      <label className="grid gap-2 text-sm font-medium">
+        Response example JSON
+        <Textarea
+          value={state.responseExample}
+          required
+          onChange={(event) => onChange((current) => ({ ...current, responseExample: event.target.value }))}
+          className="min-h-32 font-mono"
+        />
+      </label>
+    </>
+  );
 }

--- a/apps/web/components/provider-service-review.tsx
+++ b/apps/web/components/provider-service-review.tsx
@@ -89,23 +89,35 @@ function ProviderServiceReviewInner({
     );
   }
 
+  const isMarketplaceService = detail.service.serviceType === "marketplace_proxy";
   const checklist = [
-    {
-      label: `Settlement tier is ${detail.service.settlementMode === "verified_escrow" ? "Verified" : "Community"}`,
-      ok: true
-    },
+    isMarketplaceService
+      ? {
+          label: `Settlement tier is ${detail.service.settlementMode === "verified_escrow" ? "Verified" : "Community"}`,
+          ok: true
+        }
+      : {
+          label: "Service is marked as a discovery-only external API",
+          ok: true
+        },
     { label: "Website URL is set", ok: Boolean(detail.service.websiteUrl) },
-    { label: "Payout wallet is set", ok: Boolean(detail.service.payoutWallet) },
+    {
+      label: isMarketplaceService ? "Payout wallet is set" : "Direct endpoint metadata is set on the service",
+      ok: isMarketplaceService ? Boolean(detail.service.payoutWallet) : true
+    },
     { label: "At least one endpoint exists", ok: detail.endpoints.length > 0 },
     { label: "Website verification succeeded", ok: detail.verification?.status === "verified" },
     {
-      label: "Runtime key is ready for Community or prepaid flows",
-      ok:
-        Boolean(runtimeKey)
-        || (
-          detail.service.settlementMode === "verified_escrow"
-          && !detail.endpoints.some((endpoint) => endpoint.billing.type === "prepaid_credit")
-        )
+      label: isMarketplaceService ? "Runtime key is ready for Community or prepaid flows" : "Marketplace runtime key is not required",
+      ok: isMarketplaceService
+        ? (
+            Boolean(runtimeKey)
+            || (
+              detail.service.settlementMode === "verified_escrow"
+              && !detail.endpoints.some((endpoint) => endpoint.endpointType === "marketplace_proxy" && endpoint.billing.type === "prepaid_credit")
+            )
+          )
+        : true
     }
   ];
 
@@ -129,7 +141,10 @@ function ProviderServiceReviewInner({
       <Card variant="frosted">
         <CardHeader>
           <CardTitle className="text-3xl">{detail.service.name}</CardTitle>
-          <CardDescription>{detail.service.status} · {detail.service.settlementMode === "verified_escrow" ? "Verified" : "Community"}</CardDescription>
+          <CardDescription>
+            {detail.service.status}
+            {isMarketplaceService ? ` · ${detail.service.settlementMode === "verified_escrow" ? "Verified" : "Community"}` : " · External API"}
+          </CardDescription>
         </CardHeader>
         <CardContent className="grid gap-4 text-sm">
           <div className="rounded-card border border-border bg-background/70 p-5 dark:bg-background/20">

--- a/apps/web/components/provider-services-dashboard.tsx
+++ b/apps/web/components/provider-services-dashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import type { MarketplaceDeploymentNetwork } from "@marketplace/shared";
+import type { MarketplaceDeploymentNetwork, ProviderServiceType } from "@marketplace/shared";
 
 import { ProviderSessionGate } from "@/components/provider-session-gate";
 import { Button } from "@/components/ui/button";
@@ -41,6 +41,7 @@ function ProviderServicesDashboardInner({
   accessToken: string;
 }) {
   type ServiceDraftField =
+    | "serviceType"
     | "slug"
     | "apiNamespace"
     | "name"
@@ -57,6 +58,7 @@ function ProviderServicesDashboardInner({
   const [error, setError] = React.useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = React.useState<Partial<Record<ServiceDraftField, string>>>({});
   const [form, setForm] = React.useState({
+    serviceType: "marketplace_proxy" as ProviderServiceType,
     slug: "",
     apiNamespace: "",
     name: "",
@@ -99,8 +101,9 @@ function ProviderServicesDashboardInner({
       try {
         setFieldErrors({});
         const detail = await createProviderService(apiBaseUrl, accessToken, {
+          serviceType: form.serviceType,
           slug: form.slug,
-          apiNamespace: form.apiNamespace,
+          apiNamespace: form.serviceType === "marketplace_proxy" ? form.apiNamespace : undefined,
           name: form.name,
           tagline: form.tagline,
           about: form.about,
@@ -114,7 +117,7 @@ function ProviderServicesDashboardInner({
             .map((value) => value.trim())
             .filter(Boolean),
           websiteUrl: form.websiteUrl || undefined,
-          payoutWallet: form.payoutWallet
+          payoutWallet: form.serviceType === "marketplace_proxy" ? form.payoutWallet : undefined
         });
         window.location.assign(`/providers/services/${detail.service.id}`);
       } catch (nextError) {
@@ -154,7 +157,9 @@ function ProviderServicesDashboardInner({
                 <div>
                   <div className="text-lg font-medium tracking-headline">{service.service.name}</div>
                   <div className="text-sm leading-6 text-muted-foreground">
-                    {service.service.apiNamespace} / {service.service.status}
+                    {service.service.serviceType === "marketplace_proxy"
+                      ? `${service.service.apiNamespace} / ${service.service.status}`
+                      : `external registry / ${service.service.status}`}
                   </div>
                 </div>
                 <div className="flex gap-2">
@@ -181,6 +186,23 @@ function ProviderServicesDashboardInner({
         </CardHeader>
         <CardContent>
           <form className="grid gap-4" onSubmit={onCreateService}>
+            <label className="grid gap-2 text-sm font-medium">
+              Service type
+              <select
+                value={form.serviceType}
+                className="fast-select min-h-12"
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    serviceType: event.target.value as ProviderServiceType,
+                    apiNamespace: event.target.value === "marketplace_proxy" ? current.apiNamespace : "",
+                    payoutWallet: event.target.value === "marketplace_proxy" ? current.payoutWallet : ""
+                  }))}
+              >
+                <option value="marketplace_proxy">Marketplace proxy</option>
+                <option value="external_registry">External registry</option>
+              </select>
+            </label>
             <div className="grid gap-4 md:grid-cols-2">
               <label className="grid gap-2 text-sm font-medium">
                 Service name
@@ -222,19 +244,25 @@ function ProviderServicesDashboardInner({
                 />
                 {fieldErrors.slug ? <span className="text-xs text-destructive">{fieldErrors.slug}</span> : null}
               </label>
-              <label className="grid gap-2 text-sm font-medium">
-                API namespace
-                <Input
-                  value={form.apiNamespace}
-                  minLength={3}
-                  maxLength={64}
-                  pattern="^[a-z0-9-]{3,64}$"
-                  placeholder="test-service"
-                  onChange={(event) => setForm((current) => ({ ...current, apiNamespace: event.target.value }))}
-                  required
-                />
-                {fieldErrors.apiNamespace ? <span className="text-xs text-destructive">{fieldErrors.apiNamespace}</span> : null}
-              </label>
+              {form.serviceType === "marketplace_proxy" ? (
+                <label className="grid gap-2 text-sm font-medium">
+                  API namespace
+                  <Input
+                    value={form.apiNamespace}
+                    minLength={3}
+                    maxLength={64}
+                    pattern="^[a-z0-9-]{3,64}$"
+                    placeholder="test-service"
+                    onChange={(event) => setForm((current) => ({ ...current, apiNamespace: event.target.value }))}
+                    required
+                  />
+                  {fieldErrors.apiNamespace ? <span className="text-xs text-destructive">{fieldErrors.apiNamespace}</span> : null}
+                </label>
+              ) : (
+                <div className="rounded-card border border-border bg-background/70 px-4 py-3 text-sm text-muted-foreground dark:bg-background/20">
+                  External registry services do not define a marketplace API namespace.
+                </div>
+              )}
             </div>
 
             <label className="grid gap-2 text-sm font-medium">
@@ -297,16 +325,22 @@ function ProviderServicesDashboardInner({
               {fieldErrors.setupInstructions ? <span className="text-xs text-destructive">{fieldErrors.setupInstructions}</span> : null}
             </label>
 
-            <label className="grid gap-2 text-sm font-medium">
-              Payout wallet
-              <Input
-                value={form.payoutWallet}
-                placeholder="fast1rv8wsdd5pnkit4u637g2yj4tpuyq26rzw8380rfapnsnljz7v3tqv4ajuq"
-                onChange={(event) => setForm((current) => ({ ...current, payoutWallet: event.target.value }))}
-                required
-              />
-              {fieldErrors.payoutWallet ? <span className="text-xs text-destructive">{fieldErrors.payoutWallet}</span> : null}
-            </label>
+            {form.serviceType === "marketplace_proxy" ? (
+              <label className="grid gap-2 text-sm font-medium">
+                Payout wallet
+                <Input
+                  value={form.payoutWallet}
+                  placeholder="fast1rv8wsdd5pnkit4u637g2yj4tpuyq26rzw8380rfapnsnljz7v3tqv4ajuq"
+                  onChange={(event) => setForm((current) => ({ ...current, payoutWallet: event.target.value }))}
+                  required
+                />
+                {fieldErrors.payoutWallet ? <span className="text-xs text-destructive">{fieldErrors.payoutWallet}</span> : null}
+              </label>
+            ) : (
+              <div className="rounded-card border border-border bg-background/70 px-4 py-3 text-sm text-muted-foreground dark:bg-background/20">
+                External registry services stay discovery-only and do not use marketplace payouts.
+              </div>
+            )}
 
             <Button type="submit" disabled={pending}>
               {pending ? "Creating..." : "Create draft"}
@@ -320,6 +354,7 @@ function ProviderServicesDashboardInner({
 }
 
 function validateServiceDraftForm(form: {
+  serviceType: ProviderServiceType;
   slug: string;
   apiNamespace: string;
   name: string;
@@ -359,7 +394,7 @@ function validateServiceDraftForm(form: {
     fieldErrors.slug = "Use 3-64 lowercase letters, numbers, or hyphens.";
   }
 
-  if (!slugPattern.test(form.apiNamespace.trim())) {
+  if (form.serviceType === "marketplace_proxy" && !slugPattern.test(form.apiNamespace.trim())) {
     fieldErrors.apiNamespace = "Use 3-64 lowercase letters, numbers, or hyphens.";
   }
 
@@ -399,7 +434,7 @@ function validateServiceDraftForm(form: {
     }
   }
 
-  if (!form.payoutWallet.trim()) {
+  if (form.serviceType === "marketplace_proxy" && !form.payoutWallet.trim()) {
     fieldErrors.payoutWallet = "Payout wallet is required.";
   }
 

--- a/apps/web/components/service-page.test.tsx
+++ b/apps/web/components/service-page.test.tsx
@@ -24,7 +24,9 @@ describe("ServicePage", () => {
       <ServicePage
         deploymentNetwork="mainnet"
         service={{
+          serviceType: "marketplace_proxy",
           summary: {
+            serviceType: "marketplace_proxy",
             slug: "mock-research-signals",
             name: "Mock Research Signals",
             ownerName: "Fast Marketplace",
@@ -46,6 +48,7 @@ describe("ServicePage", () => {
           skillUrl: "https://marketplace.example.com/skill.md",
           endpoints: [
             {
+              endpointType: "marketplace_proxy",
               routeId: "mock.quick-insight.v1",
               title: "Quick Insight",
               description: "Instant paid insight.",

--- a/apps/web/components/service-page.tsx
+++ b/apps/web/components/service-page.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { ArrowLeftRight, ArrowUpRight, Command, DatabaseZap, Sparkle } from "lucide-react";
-import type { ServiceDetail } from "@marketplace/shared";
+import type { MarketplaceServiceCatalogEndpoint, ServiceDetail } from "@marketplace/shared";
 import type { WebDeploymentNetwork } from "@/lib/network";
 
 import { CopyButton } from "@/components/copy-button";
@@ -15,7 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
-function usesTokenPrice(billingType: ServiceDetail["endpoints"][number]["billingType"]): boolean {
+function usesTokenPrice(billingType: MarketplaceServiceCatalogEndpoint["billingType"]): boolean {
   return billingType === "fixed_x402" || billingType === "topup_x402_variable";
 }
 
@@ -30,11 +30,13 @@ export function ServicePage({
   service: ServiceDetail;
   deploymentNetwork: WebDeploymentNetwork;
 }) {
+  const isMarketplaceService = service.serviceType === "marketplace_proxy";
+
   return (
     <main className="page-shell">
       <section className="section-sep">
         <div className="section-container section-stack">
-          <div className="grid gap-10 lg:grid-cols-[1.12fr_0.88fr]">
+          <div className={`grid gap-10 ${isMarketplaceService ? "lg:grid-cols-[1.12fr_0.88fr]" : "lg:grid-cols-[1fr_0.9fr]"}`}>
             <div className="space-y-8">
               <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
                 <Link href="/" className="fast-link">
@@ -47,17 +49,30 @@ export function ServicePage({
               <div className="space-y-5">
                 <div className="flex flex-wrap items-center gap-3">
                   <Badge variant="outline">{service.summary.ownerName}</Badge>
-                  <Badge variant={service.summary.settlementMode === "verified_escrow" ? "default" : "secondary"}>
-                    {service.summary.settlementLabel}
-                  </Badge>
-                  <span className="text-sm tracking-headline text-muted-foreground">
-                    {formatSummaryPriceRange(service.summary.priceRange)}
-                  </span>
+                  {isMarketplaceService ? (
+                    <>
+                      <Badge variant={service.summary.settlementMode === "verified_escrow" ? "default" : "secondary"}>
+                        {service.summary.settlementLabel}
+                      </Badge>
+                      <span className="text-sm tracking-headline text-muted-foreground">
+                        {formatSummaryPriceRange(service.summary.priceRange)}
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      <Badge variant="secondary">{service.summary.accessModelLabel}</Badge>
+                      {service.websiteUrl ? (
+                        <Badge variant="outline">{new URL(service.websiteUrl).hostname}</Badge>
+                      ) : null}
+                    </>
+                  )}
                 </div>
                 <div className="space-y-4">
                   <h1 className="section-title">{service.summary.name}</h1>
                   <p className="body-copy">{service.summary.tagline}</p>
-                  <p className="text-sm leading-7 text-muted-foreground">{service.summary.settlementDescription}</p>
+                  <p className="text-sm leading-7 text-muted-foreground">
+                    {isMarketplaceService ? service.summary.settlementDescription : service.summary.accessModelDescription}
+                  </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {service.summary.categories.map((category) => (
@@ -68,28 +83,53 @@ export function ServicePage({
                 </div>
               </div>
 
-              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-                <StatCard label="Total Calls" value={String(service.summary.totalCalls)} icon={<Sparkle className="h-4 w-4" />} />
-                <StatCard label="Revenue" value={`$${service.summary.revenue}`} icon={<DatabaseZap className="h-4 w-4" />} />
-                <StatCard label="Endpoints" value={String(service.summary.endpointCount)} icon={<ArrowLeftRight className="h-4 w-4" />} />
-                <StatCard
-                  label="Success Rate (30d)"
-                  value={`${service.summary.successRate30d.toFixed(1)}%`}
-                  icon={<Command className="h-4 w-4" />}
-                />
-              </div>
+              {isMarketplaceService ? (
+                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                  <StatCard label="Total Calls" value={String(service.summary.totalCalls)} icon={<Sparkle className="h-4 w-4" />} />
+                  <StatCard label="Revenue" value={`$${service.summary.revenue}`} icon={<DatabaseZap className="h-4 w-4" />} />
+                  <StatCard label="Endpoints" value={String(service.summary.endpointCount)} icon={<ArrowLeftRight className="h-4 w-4" />} />
+                  <StatCard
+                    label="Success Rate (30d)"
+                    value={`${service.summary.successRate30d.toFixed(1)}%`}
+                    icon={<Command className="h-4 w-4" />}
+                  />
+                </div>
+              ) : (
+                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                  <StatCard label="Endpoints" value={String(service.summary.endpointCount)} icon={<ArrowLeftRight className="h-4 w-4" />} />
+                  <StatCard label="Access" value="Direct API" icon={<ArrowUpRight className="h-4 w-4" />} />
+                  <StatCard label="Marketplace role" value="Discovery" icon={<Command className="h-4 w-4" />} />
+                </div>
+              )}
             </div>
 
-            <Card variant="frosted">
-              <CardHeader>
-                <Badge variant="eyebrow">Transaction volume</Badge>
-                <CardTitle className="text-3xl">Marketplace call flow over time</CardTitle>
-                <CardDescription>Thirty-day volume across live marketplace traffic.</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <VolumeChart points={service.summary.volume30d} tokenSymbol={service.summary.settlementToken} />
-              </CardContent>
-            </Card>
+            {isMarketplaceService ? (
+              <Card variant="frosted">
+                <CardHeader>
+                  <Badge variant="eyebrow">Transaction volume</Badge>
+                  <CardTitle className="text-3xl">Marketplace call flow over time</CardTitle>
+                  <CardDescription>Thirty-day volume across live marketplace traffic.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <VolumeChart points={service.summary.volume30d} tokenSymbol={service.summary.settlementToken} />
+                </CardContent>
+              </Card>
+            ) : (
+              <Card variant="frosted">
+                <CardHeader>
+                  <Badge variant="eyebrow">Direct Access</Badge>
+                  <CardTitle className="text-3xl">Provider-owned integration</CardTitle>
+                  <CardDescription>
+                    This listing is discovery-only. Calls go straight to the provider and follow the provider&apos;s docs and auth model.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm text-muted-foreground">
+                  <div>Marketplace execution: disabled</div>
+                  <div>Auth and payment: provider-defined</div>
+                  <div>Use the endpoint docs below for exact direct URLs.</div>
+                </CardContent>
+              </Card>
+            )}
           </div>
         </div>
       </section>
@@ -128,13 +168,17 @@ export function ServicePage({
               <div className="terminal-body space-y-5">
                 <div className="terminal-kicker">Setup and exact call parameters</div>
                 <p className="max-w-3xl text-sm leading-7 text-white/70">
-                  Includes setup, the marketplace skill, and exact call parameters for each available endpoint.
+                  {isMarketplaceService
+                    ? "Includes setup, the marketplace skill, and exact call parameters for each available endpoint."
+                    : "Includes setup, direct endpoint URLs, and provider-auth details for each available endpoint."}
                 </p>
                 <pre className="terminal-command overflow-x-auto whitespace-pre-wrap">{service.useThisServicePrompt}</pre>
-                <Link href={service.skillUrl} className="terminal-meta inline-flex items-center gap-2">
-                  Open canonical SKILL.md
-                  <ArrowUpRight className="h-4 w-4" />
-                </Link>
+                {service.skillUrl ? (
+                  <Link href={service.skillUrl} className="terminal-meta inline-flex items-center gap-2">
+                    Open canonical SKILL.md
+                    <ArrowUpRight className="h-4 w-4" />
+                  </Link>
+                ) : null}
               </div>
             </div>
           </div>
@@ -146,49 +190,94 @@ export function ServicePage({
           <Card variant="frosted">
             <CardHeader>
               <Badge variant="eyebrow">Available endpoints ({service.endpoints.length})</Badge>
-              <CardTitle className="text-3xl">Request docs, pricing, and examples</CardTitle>
+              <CardTitle className="text-3xl">
+                {isMarketplaceService ? "Request docs, pricing, and examples" : "Direct endpoint docs and examples"}
+              </CardTitle>
             </CardHeader>
             <CardContent>
               <Accordion type="single" collapsible className="w-full">
-                {service.endpoints.map((endpoint) => (
-                  <AccordionItem key={endpoint.routeId} value={endpoint.routeId}>
-                    <AccordionTrigger>
-                      <div className="grid flex-1 gap-3 md:grid-cols-[auto_1fr_auto] md:items-center">
-                        <div className="metric-label">{endpoint.method}</div>
-                        <div>
-                          <div className="text-lg font-medium tracking-headline text-foreground">{endpoint.title}</div>
-                          <div className="text-sm leading-7 text-muted-foreground">{endpoint.description}</div>
-                        </div>
-                        <div className="text-sm font-medium tracking-headline text-foreground">
-                          {endpoint.price}{usesTokenPrice(endpoint.billingType) ? ` ${endpoint.tokenSymbol}` : ""}
-                        </div>
-                      </div>
-                    </AccordionTrigger>
-                    <AccordionContent>
-                      <div className="grid gap-5 lg:grid-cols-2">
-                        <Card className="h-full">
-                          <CardHeader className="pb-4">
-                            <Badge variant="eyebrow">Proxy URL</Badge>
-                            <CardTitle className="text-xl">Direct marketplace route</CardTitle>
-                          </CardHeader>
-                          <CardContent className="space-y-4">
-                            <div className="flex items-start justify-between gap-4">
-                              <div className="break-all text-sm leading-7 text-muted-foreground">{endpoint.proxyUrl}</div>
-                              <CopyButton value={endpoint.proxyUrl} />
+                {isMarketplaceService
+                  ? service.endpoints.map((endpoint) => (
+                      <AccordionItem key={endpoint.routeId} value={endpoint.routeId}>
+                        <AccordionTrigger>
+                          <div className="grid flex-1 gap-3 md:grid-cols-[auto_1fr_auto] md:items-center">
+                            <div className="metric-label">{endpoint.method}</div>
+                            <div>
+                              <div className="text-lg font-medium tracking-headline text-foreground">{endpoint.title}</div>
+                              <div className="text-sm leading-7 text-muted-foreground">{endpoint.description}</div>
                             </div>
-                            {endpoint.usageNotes ? (
-                              <p className="text-sm leading-7 text-muted-foreground">{endpoint.usageNotes}</p>
-                            ) : null}
-                          </CardContent>
-                        </Card>
+                            <div className="text-sm font-medium tracking-headline text-foreground">
+                              {endpoint.price}{usesTokenPrice(endpoint.billingType) ? ` ${endpoint.tokenSymbol}` : ""}
+                            </div>
+                          </div>
+                        </AccordionTrigger>
+                        <AccordionContent>
+                          <div className="grid gap-5 lg:grid-cols-2">
+                            <Card className="h-full">
+                              <CardHeader className="pb-4">
+                                <Badge variant="eyebrow">Proxy URL</Badge>
+                                <CardTitle className="text-xl">Direct marketplace route</CardTitle>
+                              </CardHeader>
+                              <CardContent className="space-y-4">
+                                <div className="flex items-start justify-between gap-4">
+                                  <div className="break-all text-sm leading-7 text-muted-foreground">{endpoint.proxyUrl}</div>
+                                  <CopyButton value={endpoint.proxyUrl} />
+                                </div>
+                                {endpoint.usageNotes ? (
+                                  <p className="text-sm leading-7 text-muted-foreground">{endpoint.usageNotes}</p>
+                                ) : null}
+                              </CardContent>
+                            </Card>
 
-                        <ExampleBlock label="Request Example" value={JSON.stringify(endpoint.requestExample, null, 2)} />
-                        <ExampleBlock label="Response Example" value={JSON.stringify(endpoint.responseExample, null, 2)} />
-                        <EndpointBrowserRunner endpoint={endpoint} deploymentNetwork={deploymentNetwork} />
-                      </div>
-                    </AccordionContent>
-                  </AccordionItem>
-                ))}
+                            <ExampleBlock label="Request Example" value={JSON.stringify(endpoint.requestExample, null, 2)} />
+                            <ExampleBlock label="Response Example" value={JSON.stringify(endpoint.responseExample, null, 2)} />
+                            <EndpointBrowserRunner endpoint={endpoint} deploymentNetwork={deploymentNetwork} />
+                          </div>
+                        </AccordionContent>
+                      </AccordionItem>
+                    ))
+                  : service.endpoints.map((endpoint) => (
+                      <AccordionItem key={endpoint.endpointId} value={endpoint.endpointId}>
+                        <AccordionTrigger>
+                          <div className="grid flex-1 gap-3 md:grid-cols-[auto_1fr] md:items-center">
+                            <div className="metric-label">{endpoint.method}</div>
+                            <div>
+                              <div className="text-lg font-medium tracking-headline text-foreground">{endpoint.title}</div>
+                              <div className="text-sm leading-7 text-muted-foreground">{endpoint.description}</div>
+                            </div>
+                          </div>
+                        </AccordionTrigger>
+                        <AccordionContent>
+                          <div className="grid gap-5 lg:grid-cols-2">
+                            <Card className="h-full">
+                              <CardHeader className="pb-4">
+                                <Badge variant="eyebrow">Direct URL</Badge>
+                                <CardTitle className="text-xl">Provider endpoint</CardTitle>
+                              </CardHeader>
+                              <CardContent className="space-y-4">
+                                <div className="flex items-start justify-between gap-4">
+                                  <div className="break-all text-sm leading-7 text-muted-foreground">{endpoint.publicUrl}</div>
+                                  <CopyButton value={endpoint.publicUrl} />
+                                </div>
+                                <div className="flex items-start justify-between gap-4">
+                                  <div className="break-all text-sm leading-7 text-muted-foreground">{endpoint.docsUrl}</div>
+                                  <CopyButton value={endpoint.docsUrl} />
+                                </div>
+                                {endpoint.authNotes ? (
+                                  <p className="text-sm leading-7 text-muted-foreground">Auth: {endpoint.authNotes}</p>
+                                ) : null}
+                                {endpoint.usageNotes ? (
+                                  <p className="text-sm leading-7 text-muted-foreground">{endpoint.usageNotes}</p>
+                                ) : null}
+                              </CardContent>
+                            </Card>
+
+                            <ExampleBlock label="Request Example" value={JSON.stringify(endpoint.requestExample, null, 2)} />
+                            <ExampleBlock label="Response Example" value={JSON.stringify(endpoint.responseExample, null, 2)} />
+                          </div>
+                        </AccordionContent>
+                      </AccordionItem>
+                    ))}
               </Accordion>
             </CardContent>
           </Card>

--- a/packages/shared/src/billing.ts
+++ b/packages/shared/src/billing.ts
@@ -1,6 +1,6 @@
 import { decimalToRawString, rawToDecimalString } from "./amounts.js";
 import type {
-  CreateProviderEndpointDraftInput,
+  CreateMarketplaceProviderEndpointDraftInput,
   FixedX402Billing,
   FreeBilling,
   MarketplaceRoute,
@@ -182,7 +182,7 @@ export function priceLabelForBilling(billing: RouteBilling): string {
   return "Prepaid credit";
 }
 
-export function createDraftRouteBilling(input: Pick<CreateProviderEndpointDraftInput, "billingType" | "price" | "minAmount" | "maxAmount">): {
+export function createDraftRouteBilling(input: Pick<CreateMarketplaceProviderEndpointDraftInput, "billingType" | "price" | "minAmount" | "maxAmount">): {
   billing: RouteBilling;
   price: string;
 } {

--- a/packages/shared/src/catalog.ts
+++ b/packages/shared/src/catalog.ts
@@ -3,9 +3,15 @@ import { isFixedX402Billing, isFreeBilling, isPrepaidCreditBilling, isTopupX402B
 import { getDefaultMarketplaceNetworkConfig } from "./network.js";
 import { settlementModeDescription, settlementModeLabel } from "./settlement.js";
 import type {
+  ExternalRegistryServiceSummary,
+  ExternalServiceCatalogEndpoint,
   MarketplaceRoute,
+  MarketplaceServiceCatalogEndpoint,
+  MarketplaceServiceSummary,
+  PublishedExternalEndpointVersionRecord,
+  PublishedEndpointVersionRecord,
+  PublishedServiceEndpointVersionRecord,
   ServiceAnalytics,
-  ServiceCatalogEndpoint,
   ServiceDefinition,
   ServiceDetail,
   ServiceSummary
@@ -23,8 +29,20 @@ function formatPriceLabelFromRaw(rawAmount: string, tokenSymbol = getDefaultMark
   return `$${rawToDecimalString(rawAmount, 6)} ${tokenSymbol}`;
 }
 
-function billingTypeUsesTokenPrice(billingType: ServiceCatalogEndpoint["billingType"]): boolean {
+function billingTypeUsesTokenPrice(billingType: MarketplaceServiceCatalogEndpoint["billingType"]): boolean {
   return billingType === "fixed_x402" || billingType === "topup_x402_variable";
+}
+
+function isMarketplaceEndpoint(
+  endpoint: PublishedServiceEndpointVersionRecord
+): endpoint is PublishedEndpointVersionRecord {
+  return endpoint.endpointType === "marketplace_proxy";
+}
+
+function isExternalEndpoint(
+  endpoint: PublishedServiceEndpointVersionRecord
+): endpoint is PublishedExternalEndpointVersionRecord {
+  return endpoint.endpointType === "external_registry";
 }
 
 export function formatRevenueLabel(rawAmount: string): string {
@@ -70,11 +88,15 @@ export function buildPriceRange(routes: MarketplaceRoute[]): string {
   return labels.join(" + ") || "Free";
 }
 
-export function buildServiceEndpoint(route: MarketplaceRoute, apiBaseUrl: string): ServiceCatalogEndpoint {
+export function buildMarketplaceServiceEndpoint(
+  route: MarketplaceRoute & { endpointType?: "marketplace_proxy" },
+  apiBaseUrl: string
+): MarketplaceServiceCatalogEndpoint {
   const path = `/api/${route.provider}/${route.operation}`;
   const tokenSymbol = getDefaultMarketplaceNetworkConfig().tokenSymbol;
 
   return {
+    endpointType: "marketplace_proxy",
     routeId: route.routeId,
     title: route.title,
     description: route.description,
@@ -91,9 +113,27 @@ export function buildServiceEndpoint(route: MarketplaceRoute, apiBaseUrl: string
   };
 }
 
-export function buildUseThisServicePrompt(input: {
+export function buildExternalServiceEndpoint(
+  endpoint: PublishedExternalEndpointVersionRecord
+): ExternalServiceCatalogEndpoint {
+  return {
+    endpointType: "external_registry",
+    endpointId: endpoint.endpointVersionId,
+    title: endpoint.title,
+    description: endpoint.description,
+    method: endpoint.method,
+    publicUrl: endpoint.publicUrl,
+    docsUrl: endpoint.docsUrl,
+    authNotes: endpoint.authNotes,
+    requestExample: endpoint.requestExample,
+    responseExample: endpoint.responseExample,
+    usageNotes: endpoint.usageNotes
+  };
+}
+
+function buildMarketplaceUseThisServicePrompt(input: {
   service: ServiceDefinition;
-  endpoints: ServiceCatalogEndpoint[];
+  endpoints: MarketplaceServiceCatalogEndpoint[];
   skillUrl: string;
 }): string {
   const lines = [
@@ -144,23 +184,100 @@ export function buildUseThisServicePrompt(input: {
   return lines.join("\n");
 }
 
+function buildExternalUseThisServicePrompt(input: {
+  service: ServiceDefinition;
+  endpoints: ExternalServiceCatalogEndpoint[];
+}): string {
+  const lines = [
+    input.service.promptIntro,
+    "",
+    "## Access model",
+    "This is a discovery-only external API. Calls go directly to the provider; the marketplace does not proxy, authenticate, or settle them.",
+    "",
+    "## Setup",
+    ...input.service.setupInstructions.map((step, index) => `${index + 1}. ${step}`),
+    "",
+    "## External Endpoints"
+  ];
+
+  for (const endpoint of input.endpoints) {
+    lines.push(
+      "",
+      `### ${endpoint.title}`,
+      `Method: ${endpoint.method}`,
+      `Direct URL: ${endpoint.publicUrl}`,
+      `Docs: ${endpoint.docsUrl}`
+    );
+
+    if (endpoint.authNotes) {
+      lines.push(`Auth: ${endpoint.authNotes}`);
+    }
+
+    if (endpoint.method === "GET") {
+      lines.push(`curl -X GET "${endpoint.publicUrl}"`);
+    } else {
+      lines.push(
+        `curl -X POST "${endpoint.publicUrl}" \\`,
+        '  -H "Content-Type: application/json" \\',
+        `  -d '${JSON.stringify(endpoint.requestExample, null, 2)}'`
+      );
+    }
+
+    if (endpoint.usageNotes) {
+      lines.push("", endpoint.usageNotes);
+    }
+  }
+
+  return lines.join("\n");
+}
+
 export function buildServiceSummary(input: {
   service: ServiceDefinition;
-  endpoints: MarketplaceRoute[];
+  endpoints: PublishedServiceEndpointVersionRecord[];
   analytics: ServiceAnalytics;
 }): ServiceSummary {
-  return {
+  if (input.service.serviceType === "external_registry") {
+    const summary: ExternalRegistryServiceSummary = {
+      serviceType: "external_registry",
+      slug: input.service.slug,
+      name: input.service.name,
+      ownerName: input.service.ownerName,
+      tagline: input.service.tagline,
+      categories: input.service.categories,
+      settlementMode: null,
+      settlementLabel: "External API",
+      settlementDescription: "Calls go directly to the provider. The marketplace lists discovery metadata only.",
+      priceRange: "See provider docs",
+      settlementToken: null,
+      totalCalls: null,
+      revenue: null,
+      successRate30d: null,
+      volume30d: [],
+      accessModelLabel: "External API",
+      accessModelDescription: "Calls go directly to the provider. The marketplace only lists docs and direct endpoints.",
+      endpointCount: input.endpoints.filter(isExternalEndpoint).length,
+      websiteUrl: input.service.websiteUrl
+    };
+
+    return summary;
+  }
+
+  const routes = input.endpoints.filter(isMarketplaceEndpoint);
+  const settlementMode = input.service.settlementMode ?? "verified_escrow";
+
+  const summary: MarketplaceServiceSummary = {
+    serviceType: "marketplace_proxy",
     slug: input.service.slug,
     name: input.service.name,
     ownerName: input.service.ownerName,
     tagline: input.service.tagline,
     categories: input.service.categories,
-    settlementMode: input.service.settlementMode,
-    settlementLabel: settlementModeLabel(input.service.settlementMode),
-    settlementDescription: settlementModeDescription(input.service.settlementMode),
-    priceRange: buildPriceRange(input.endpoints),
+    settlementMode,
+    settlementLabel: settlementModeLabel(settlementMode),
+    settlementDescription: settlementModeDescription(settlementMode),
+    priceRange: buildPriceRange(routes),
     settlementToken: getDefaultMarketplaceNetworkConfig().tokenSymbol,
-    endpointCount: input.endpoints.length,
+    endpointCount: routes.length,
     totalCalls: input.analytics.totalCalls,
     revenue: formatRevenueLabel(input.analytics.revenueRaw),
     successRate30d: roundToSingleDecimal(input.analytics.successRate30d),
@@ -169,26 +286,58 @@ export function buildServiceSummary(input: {
       amount: rawToDecimalString(point.amountRaw, 6)
     }))
   };
+
+  return summary;
 }
 
 export function buildServiceDetail(input: {
   service: ServiceDefinition;
-  endpoints: MarketplaceRoute[];
+  endpoints: PublishedServiceEndpointVersionRecord[];
   analytics: ServiceAnalytics;
   apiBaseUrl: string;
   webBaseUrl: string;
 }): ServiceDetail {
-  const endpoints = input.endpoints.map((route) => buildServiceEndpoint(route, input.apiBaseUrl));
-  const skillUrl = joinUrl(input.webBaseUrl, "/skill.md");
-
-  return {
-    summary: buildServiceSummary({
+  if (input.service.serviceType === "external_registry") {
+    const endpoints = input.endpoints.filter(isExternalEndpoint).map((endpoint) => buildExternalServiceEndpoint(endpoint));
+    const summary = buildServiceSummary({
       service: input.service,
       endpoints: input.endpoints,
       analytics: input.analytics
-    }),
+    });
+    if (summary.serviceType !== "external_registry") {
+      throw new Error("Expected an external registry service summary.");
+    }
+
+    return {
+      serviceType: "external_registry",
+      summary,
+      about: input.service.about,
+      useThisServicePrompt: buildExternalUseThisServicePrompt({
+        service: input.service,
+        endpoints
+      }),
+      skillUrl: null,
+      websiteUrl: input.service.websiteUrl,
+      endpoints
+    };
+  }
+
+  const endpoints = input.endpoints.filter(isMarketplaceEndpoint).map((route) => buildMarketplaceServiceEndpoint(route, input.apiBaseUrl));
+  const skillUrl = joinUrl(input.webBaseUrl, "/skill.md");
+  const summary = buildServiceSummary({
+    service: input.service,
+    endpoints: input.endpoints,
+    analytics: input.analytics
+  });
+  if (summary.serviceType !== "marketplace_proxy") {
+    throw new Error("Expected a marketplace proxy service summary.");
+  }
+
+  return {
+    serviceType: "marketplace_proxy",
+    summary,
     about: input.service.about,
-    useThisServicePrompt: buildUseThisServicePrompt({
+    useThisServicePrompt: buildMarketplaceUseThisServicePrompt({
       service: input.service,
       endpoints,
       skillUrl

--- a/packages/shared/src/docs.ts
+++ b/packages/shared/src/docs.ts
@@ -10,7 +10,26 @@ import {
 } from "./constants.js";
 import { getDefaultMarketplaceNetworkConfig } from "./network.js";
 import { settlementModeDescription, settlementModeLabel } from "./settlement.js";
-import type { MarketplaceRoute, ServiceDefinition } from "./types.js";
+import type {
+  ExternalRegistryServiceSummary,
+  MarketplaceRoute,
+  MarketplaceServiceSummary,
+  PublishedServiceEndpointVersionRecord,
+  ServiceDefinition
+} from "./types.js";
+
+type PublishedCatalogService = {
+  service: ServiceDefinition;
+  endpoints: PublishedServiceEndpointVersionRecord[];
+};
+
+function isMarketplaceCatalogService(input: PublishedCatalogService): boolean {
+  return input.service.serviceType === "marketplace_proxy";
+}
+
+function isExternalCatalogService(input: PublishedCatalogService): boolean {
+  return input.service.serviceType === "external_registry";
+}
 
 export function buildOpenApiDocument(input: {
   baseUrl?: string;
@@ -288,7 +307,7 @@ export function buildOpenApiDocument(input: {
 
 export function buildLlmsTxt(input: {
   baseUrl?: string;
-  services: ServiceDefinition[];
+  services: PublishedCatalogService[];
   routes: MarketplaceRoute[];
 }): string {
   const network = getDefaultMarketplaceNetworkConfig();
@@ -296,7 +315,7 @@ export function buildLlmsTxt(input: {
   const lines = [
     `# ${MARKETPLACE_NAME}`,
     "",
-    "Fast-only API marketplace with free, x402-paid, and prepaid-credit trigger routes.",
+    "Fast-only API marketplace with executable marketplace routes plus discovery-only external API listings.",
     "",
     `Base URL: ${baseUrl}`,
     `Fast network: ${network.displayName}`,
@@ -307,13 +326,13 @@ export function buildLlmsTxt(input: {
     "Repeat retrieval auth: wallet challenge session",
     "Marketplace skill: serve from the public web app at /skill.md",
     "",
-    "## Services"
+    "## Marketplace Services"
   ];
 
-  for (const service of input.services) {
-    const routes = input.routes.filter((route) => service.routeIds.includes(route.routeId));
+  for (const serviceDetail of input.services.filter(isMarketplaceCatalogService)) {
+    const routes = serviceDetail.endpoints.filter((endpoint) => endpoint.endpointType === "marketplace_proxy");
     const summary = buildServiceSummary({
-      service,
+      service: serviceDetail.service,
       endpoints: routes,
       analytics: {
         totalCalls: 0,
@@ -322,17 +341,63 @@ export function buildLlmsTxt(input: {
         volume30d: []
       }
     });
+    if (summary.serviceType !== "marketplace_proxy") {
+      throw new Error("Expected a marketplace service summary.");
+    }
 
     lines.push(
-      `- ${service.name}`,
-      `  owner: ${service.ownerName}`,
-      `  slug: ${service.slug}`,
-      `  settlement: ${settlementModeLabel(service.settlementMode)}`,
-      `  guarantees: ${settlementModeDescription(service.settlementMode)}`,
+      `- ${serviceDetail.service.name}`,
+      `  owner: ${serviceDetail.service.ownerName}`,
+      `  slug: ${serviceDetail.service.slug}`,
+      `  settlement: ${summary.settlementLabel}`,
+      `  guarantees: ${summary.settlementDescription}`,
       `  priceRange: ${summary.priceRange}`,
       `  endpointCount: ${routes.length}`,
-      `  categories: ${service.categories.join(", ")}`
+      `  categories: ${serviceDetail.service.categories.join(", ")}`
     );
+  }
+
+  const externalServices = input.services.filter(isExternalCatalogService);
+  if (externalServices.length > 0) {
+    lines.push("", "## Discovery-Only External APIs");
+  }
+
+  for (const serviceDetail of externalServices) {
+    const summary = buildServiceSummary({
+      service: serviceDetail.service,
+      endpoints: serviceDetail.endpoints,
+      analytics: {
+        totalCalls: 0,
+        revenueRaw: "0",
+        successRate30d: 0,
+        volume30d: []
+      }
+    });
+    if (summary.serviceType !== "external_registry") {
+      throw new Error("Expected an external registry summary.");
+    }
+
+    lines.push(
+      `- ${serviceDetail.service.name}`,
+      `  owner: ${serviceDetail.service.ownerName}`,
+      `  slug: ${serviceDetail.service.slug}`,
+      `  website: ${serviceDetail.service.websiteUrl ?? "not provided"}`,
+      `  access: ${summary.accessModelDescription}`,
+      `  endpointCount: ${summary.endpointCount}`,
+      `  categories: ${serviceDetail.service.categories.join(", ")}`
+    );
+
+    for (const endpoint of serviceDetail.endpoints.filter((candidate) => candidate.endpointType === "external_registry")) {
+      lines.push(
+        `  - ${endpoint.method} ${endpoint.publicUrl}`,
+        `    docs: ${endpoint.docsUrl}`,
+        `    executableByMarketplace: false`
+      );
+
+      if (endpoint.authNotes) {
+        lines.push(`    auth: ${endpoint.authNotes}`);
+      }
+    }
   }
 
   lines.push("", "## Routes");
@@ -357,7 +422,7 @@ export function buildLlmsTxt(input: {
 
 export function buildMarketplaceCatalog(input: {
   baseUrl?: string;
-  services: ServiceDefinition[];
+  services: PublishedCatalogService[];
   routes: MarketplaceRoute[];
 }) {
   const network = getDefaultMarketplaceNetworkConfig();
@@ -389,16 +454,65 @@ export function buildMarketplaceCatalog(input: {
       walletChallengeEndpoint: "/auth/wallet/challenge",
       walletSessionEndpoint: "/auth/wallet/session"
     },
-    services: input.services.map((service) => ({
-      slug: service.slug,
-      name: service.name,
-      ownerName: service.ownerName,
-      settlementMode: service.settlementMode,
-      settlementLabel: settlementModeLabel(service.settlementMode),
-      settlementDescription: settlementModeDescription(service.settlementMode),
-      categories: service.categories,
-      routeIds: service.routeIds
-    })),
+    services: input.services.filter(isMarketplaceCatalogService).map((serviceDetail) => {
+      const summary = buildServiceSummary({
+        service: serviceDetail.service,
+        endpoints: serviceDetail.endpoints,
+        analytics: {
+          totalCalls: 0,
+          revenueRaw: "0",
+          successRate30d: 0,
+          volume30d: []
+        }
+      }) as MarketplaceServiceSummary;
+
+      return {
+        serviceType: "marketplace_proxy",
+        executableByMarketplace: true,
+        slug: serviceDetail.service.slug,
+        name: serviceDetail.service.name,
+        ownerName: serviceDetail.service.ownerName,
+        settlementMode: summary.settlementMode,
+        settlementLabel: summary.settlementLabel,
+        settlementDescription: summary.settlementDescription,
+        categories: serviceDetail.service.categories,
+        routeIds: serviceDetail.service.routeIds
+      };
+    }),
+    discoveryOnlyServices: input.services.filter(isExternalCatalogService).map((serviceDetail) => {
+      const summary = buildServiceSummary({
+        service: serviceDetail.service,
+        endpoints: serviceDetail.endpoints,
+        analytics: {
+          totalCalls: 0,
+          revenueRaw: "0",
+          successRate30d: 0,
+          volume30d: []
+        }
+      }) as ExternalRegistryServiceSummary;
+
+      return {
+        serviceType: "external_registry",
+        executableByMarketplace: false,
+        slug: serviceDetail.service.slug,
+        name: serviceDetail.service.name,
+        ownerName: serviceDetail.service.ownerName,
+        websiteUrl: serviceDetail.service.websiteUrl,
+        accessModelLabel: summary.accessModelLabel,
+        accessModelDescription: summary.accessModelDescription,
+        categories: serviceDetail.service.categories,
+        endpoints: serviceDetail.endpoints
+          .filter((endpoint) => endpoint.endpointType === "external_registry")
+          .map((endpoint) => ({
+            endpointId: endpoint.endpointVersionId,
+            method: endpoint.method,
+            publicUrl: endpoint.publicUrl,
+            docsUrl: endpoint.docsUrl,
+            authNotes: endpoint.authNotes,
+            executableByMarketplace: false
+          }))
+      };
+    }),
     routes: input.routes.map((route) => ({
       routeId: route.routeId,
       provider: route.provider,

--- a/packages/shared/src/seed.ts
+++ b/packages/shared/src/seed.ts
@@ -1,4 +1,5 @@
 import type {
+  MarketplaceProviderEndpointDraftRecord,
   MarketplaceRoute,
   ProviderAccountRecord,
   ProviderEndpointDraftRecord,
@@ -25,6 +26,7 @@ export const MARKETPLACE_PROVIDER_ACCOUNT_SEED: ProviderAccountRecord = {
 export const MOCK_PROVIDER_SERVICE_SEED: ProviderServiceRecord = {
   id: "service_mock_research_signals",
   providerAccountId: MARKETPLACE_PROVIDER_ACCOUNT_SEED.id,
+  serviceType: "marketplace_proxy",
   settlementMode: "verified_escrow",
   slug: "mock-research-signals",
   apiNamespace: "mock",
@@ -50,6 +52,7 @@ export const MOCK_PROVIDER_SERVICE_SEED: ProviderServiceRecord = {
 export const TAVILY_PROVIDER_SERVICE_SEED: ProviderServiceRecord = {
   id: "service_tavily_search",
   providerAccountId: MARKETPLACE_PROVIDER_ACCOUNT_SEED.id,
+  serviceType: "marketplace_proxy",
   settlementMode: "verified_escrow",
   slug: "tavily-search",
   apiNamespace: "tavily",
@@ -659,8 +662,9 @@ export const MARKETPLACE_PROVIDER_SERVICE_SEEDS: ProviderServiceRecord[] = [
   TAVILY_PROVIDER_SERVICE_SEED
 ];
 
-function buildProviderEndpointDraft(serviceId: string, route: MarketplaceRoute): ProviderEndpointDraftRecord {
+function buildProviderEndpointDraft(serviceId: string, route: MarketplaceRoute): MarketplaceProviderEndpointDraftRecord {
   return {
+    endpointType: "marketplace_proxy",
     id: `draft_${route.routeId}`,
     serviceId,
     routeId: route.routeId,
@@ -700,6 +704,7 @@ function buildPublishedServiceVersion(input: {
     serviceId: input.service.id,
     providerAccountId: input.service.providerAccountId,
     settlementMode: input.service.settlementMode,
+    serviceType: input.service.serviceType,
     slug: input.service.slug,
     apiNamespace: input.service.apiNamespace,
     name: input.service.name,
@@ -776,15 +781,16 @@ export function buildSeededPublishedEndpointVersions(
       const draft = buildProviderEndpointDraft(group.service.id, route);
 
       return {
+        endpointType: "marketplace_proxy",
         endpointVersionId: `published_${draft.routeId}`,
         serviceId: draft.serviceId,
         serviceVersionId: group.publishedService.versionId,
         endpointDraftId: draft.id,
         routeId: draft.routeId,
-        provider: group.publishedService.apiNamespace,
+        provider: group.publishedService.apiNamespace ?? "unknown",
         operation: draft.operation,
         version: "v1",
-        settlementMode: group.publishedService.settlementMode,
+        settlementMode: group.publishedService.settlementMode ?? "verified_escrow",
         mode: draft.mode,
         network: config.paymentNetwork,
         price: draft.price,

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -837,6 +837,82 @@ describe("shared marketplace helpers", () => {
     expect(route).toBeNull();
   });
 
+  it("resolves published services by the published snapshot slug even after draft slug edits", async () => {
+    const store = new InMemoryMarketplaceStore();
+    const wallet = "fast1provider000000000000000000000000000000000000000000000000000000";
+
+    await store.upsertProviderAccount(wallet, {
+      displayName: "Signal Labs",
+      websiteUrl: "https://provider.example.com"
+    });
+
+    const created = await store.createProviderService(wallet, {
+      serviceType: "marketplace_proxy",
+      slug: "signal-labs",
+      apiNamespace: "signals",
+      name: "Signal Labs",
+      tagline: "Short-form market signals",
+      about: "Provider-authored signal endpoints.",
+      categories: ["Research"],
+      promptIntro: 'I want to use the "Signal Labs" service on Fast Marketplace.',
+      setupInstructions: ["Use a funded Fast wallet."],
+      websiteUrl: "https://provider.example.com",
+      payoutWallet: wallet
+    });
+
+    await store.createProviderEndpointDraft(created.service.id, wallet, {
+      endpointType: "marketplace_proxy",
+      operation: "quote",
+      title: "Quote",
+      description: "Return a single quote snapshot.",
+      billingType: "fixed_x402",
+      price: "$0.25",
+      mode: "sync",
+      requestSchemaJson: {
+        type: "object",
+        properties: {
+          symbol: { type: "string" }
+        },
+        required: ["symbol"],
+        additionalProperties: false
+      },
+      responseSchemaJson: {
+        type: "object",
+        properties: {
+          symbol: { type: "string" },
+          price: { type: "number" }
+        },
+        required: ["symbol", "price"],
+        additionalProperties: false
+      },
+      requestExample: { symbol: "FAST" },
+      responseExample: { symbol: "FAST", price: 42.5 },
+      upstreamBaseUrl: "https://provider.example.com",
+      upstreamPath: "/api/quote",
+      upstreamAuthMode: "none"
+    });
+
+    await store.createProviderVerificationChallenge(created.service.id, wallet);
+    await store.markProviderVerificationResult(created.service.id, "verified", {
+      verifiedHost: "provider.example.com"
+    });
+    await store.submitProviderService(created.service.id, wallet);
+    await store.publishProviderService(created.service.id, {
+      reviewerIdentity: "ops@test"
+    });
+
+    await store.updateProviderServiceForOwner(created.service.id, wallet, {
+      slug: "signal-labs-next"
+    });
+
+    const publishedByOriginalSlug = await store.getPublishedServiceBySlug("signal-labs");
+    const publishedByDraftSlug = await store.getPublishedServiceBySlug("signal-labs-next");
+
+    expect(publishedByOriginalSlug?.service.slug).toBe("signal-labs");
+    expect(publishedByOriginalSlug?.endpoints).toHaveLength(1);
+    expect(publishedByDraftSlug).toBeNull();
+  });
+
   it("propagates service payout-wallet changes into existing endpoint drafts before submit", async () => {
     const store = new InMemoryMarketplaceStore();
     const wallet = "fast1provider000000000000000000000000000000000000000000000000000000";

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -995,6 +995,91 @@ describe("shared marketplace helpers", () => {
     ).rejects.toThrow("Service slug already exists: signal-labs");
   });
 
+  it("keeps a live published apiNamespace reserved after the next draft namespace changes", async () => {
+    const store = new InMemoryMarketplaceStore();
+    const wallet = "fast1provider000000000000000000000000000000000000000000000000000000";
+
+    await store.upsertProviderAccount(wallet, {
+      displayName: "Signal Labs",
+      websiteUrl: "https://provider.example.com"
+    });
+
+    const created = await store.createProviderService(wallet, {
+      serviceType: "marketplace_proxy",
+      slug: "signal-labs-namespace",
+      apiNamespace: "signals-namespace",
+      name: "Signal Labs Namespace",
+      tagline: "Short-form market signals",
+      about: "Provider-authored signal endpoints.",
+      categories: ["Research"],
+      promptIntro: 'I want to use the "Signal Labs Namespace" service on Fast Marketplace.',
+      setupInstructions: ["Use a funded Fast wallet."],
+      websiteUrl: "https://provider.example.com",
+      payoutWallet: wallet
+    });
+
+    const endpoint = await store.createProviderEndpointDraft(created.service.id, wallet, {
+      endpointType: "marketplace_proxy",
+      operation: "quote",
+      title: "Quote",
+      description: "Return a single quote snapshot.",
+      billingType: "fixed_x402",
+      price: "$0.25",
+      mode: "sync",
+      requestSchemaJson: {
+        type: "object",
+        properties: {
+          symbol: { type: "string" }
+        },
+        required: ["symbol"],
+        additionalProperties: false
+      },
+      responseSchemaJson: {
+        type: "object",
+        properties: {
+          symbol: { type: "string" },
+          price: { type: "number" }
+        },
+        required: ["symbol", "price"],
+        additionalProperties: false
+      },
+      requestExample: { symbol: "FAST" },
+      responseExample: { symbol: "FAST", price: 42.5 },
+      upstreamBaseUrl: "https://provider.example.com",
+      upstreamPath: "/api/quote",
+      upstreamAuthMode: "none"
+    });
+
+    await store.createProviderVerificationChallenge(created.service.id, wallet);
+    await store.markProviderVerificationResult(created.service.id, "verified", {
+      verifiedHost: "provider.example.com"
+    });
+    await store.submitProviderService(created.service.id, wallet);
+    await store.publishProviderService(created.service.id, {
+      reviewerIdentity: "ops@test"
+    });
+    await store.deleteProviderEndpointDraft(created.service.id, endpoint.id, wallet);
+    await store.updateProviderServiceForOwner(created.service.id, wallet, {
+      apiNamespace: "signals-namespace-next"
+    });
+
+    await expect(
+      store.createProviderService(wallet, {
+        serviceType: "marketplace_proxy",
+        slug: "signal-labs-namespace-two",
+        apiNamespace: "signals-namespace",
+        name: "Signal Labs Namespace Two",
+        tagline: "Short-form market signals",
+        about: "Provider-authored signal endpoints.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs Namespace Two" service on Fast Marketplace.',
+        setupInstructions: ["Use a funded Fast wallet."],
+        websiteUrl: "https://provider.example.com",
+        payoutWallet: wallet
+      })
+    ).rejects.toThrow("API namespace already exists: signals-namespace");
+  });
+
   it("propagates service payout-wallet changes into existing endpoint drafts before submit", async () => {
     const store = new InMemoryMarketplaceStore();
     const wallet = "fast1provider000000000000000000000000000000000000000000000000000000";

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -913,6 +913,88 @@ describe("shared marketplace helpers", () => {
     expect(publishedByDraftSlug).toBeNull();
   });
 
+  it("keeps a live published slug reserved after the next draft slug changes", async () => {
+    const store = new InMemoryMarketplaceStore();
+    const wallet = "fast1provider000000000000000000000000000000000000000000000000000000";
+
+    await store.upsertProviderAccount(wallet, {
+      displayName: "Signal Labs",
+      websiteUrl: "https://provider.example.com"
+    });
+
+    const created = await store.createProviderService(wallet, {
+      serviceType: "marketplace_proxy",
+      slug: "signal-labs",
+      apiNamespace: "signals",
+      name: "Signal Labs",
+      tagline: "Short-form market signals",
+      about: "Provider-authored signal endpoints.",
+      categories: ["Research"],
+      promptIntro: 'I want to use the "Signal Labs" service on Fast Marketplace.',
+      setupInstructions: ["Use a funded Fast wallet."],
+      websiteUrl: "https://provider.example.com",
+      payoutWallet: wallet
+    });
+
+    await store.createProviderEndpointDraft(created.service.id, wallet, {
+      endpointType: "marketplace_proxy",
+      operation: "quote",
+      title: "Quote",
+      description: "Return a single quote snapshot.",
+      billingType: "fixed_x402",
+      price: "$0.25",
+      mode: "sync",
+      requestSchemaJson: {
+        type: "object",
+        properties: {
+          symbol: { type: "string" }
+        },
+        required: ["symbol"],
+        additionalProperties: false
+      },
+      responseSchemaJson: {
+        type: "object",
+        properties: {
+          symbol: { type: "string" },
+          price: { type: "number" }
+        },
+        required: ["symbol", "price"],
+        additionalProperties: false
+      },
+      requestExample: { symbol: "FAST" },
+      responseExample: { symbol: "FAST", price: 42.5 },
+      upstreamBaseUrl: "https://provider.example.com",
+      upstreamPath: "/api/quote",
+      upstreamAuthMode: "none"
+    });
+
+    await store.createProviderVerificationChallenge(created.service.id, wallet);
+    await store.markProviderVerificationResult(created.service.id, "verified", {
+      verifiedHost: "provider.example.com"
+    });
+    await store.submitProviderService(created.service.id, wallet);
+    await store.publishProviderService(created.service.id, {
+      reviewerIdentity: "ops@test"
+    });
+    await store.updateProviderServiceForOwner(created.service.id, wallet, {
+      slug: "signal-labs-next"
+    });
+
+    await expect(
+      store.createProviderService(wallet, {
+        serviceType: "external_registry",
+        slug: "signal-labs",
+        name: "Signal Labs Direct",
+        tagline: "Discovery-only external endpoints",
+        about: "Direct provider APIs listed in the marketplace catalog without proxy execution.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs Direct" service.',
+        setupInstructions: ["Read the provider docs before calling the API directly."],
+        websiteUrl: "https://provider.example.com"
+      })
+    ).rejects.toThrow("Service slug already exists: signal-labs");
+  });
+
   it("propagates service payout-wallet changes into existing endpoint drafts before submit", async () => {
     const store = new InMemoryMarketplaceStore();
     const wallet = "fast1provider000000000000000000000000000000000000000000000000000000";

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -18,8 +18,15 @@ import {
   validateJsonSchema,
   verifyWalletChallenge
 } from "./index.js";
+import type {
+  MarketplaceRoute,
+  ProviderEndpointDraftRecord,
+  PublishedEndpointVersionRecord,
+  PublishedServiceEndpointVersionRecord
+} from "./index.js";
 
 const TEST_PRIVATE_KEY = "11".repeat(32);
+const TEST_TIMESTAMP = "2026-03-20T00:00:00.000Z";
 
 async function createTestWallet() {
   const provider = new FastProvider({
@@ -62,6 +69,33 @@ function buildEscrowSplit(input: {
     providerBps: input.providerBps,
     providerAmount: input.providerAmount
   };
+}
+
+function buildPublishedEndpointFromRoute(
+  route: MarketplaceRoute,
+  overrides: Partial<PublishedEndpointVersionRecord> = {}
+): PublishedEndpointVersionRecord {
+  return {
+    endpointType: "marketplace_proxy",
+    endpointVersionId: overrides.endpointVersionId ?? `published_${route.routeId}`,
+    serviceId: overrides.serviceId ?? "service_test",
+    serviceVersionId: overrides.serviceVersionId ?? "service_version_test",
+    endpointDraftId: overrides.endpointDraftId ?? `draft_${route.routeId}`,
+    ...route,
+    createdAt: overrides.createdAt ?? TEST_TIMESTAMP,
+    updatedAt: overrides.updatedAt ?? TEST_TIMESTAMP,
+    ...overrides
+  };
+}
+
+function expectMarketplaceCatalogEndpoint(
+  endpoint: PublishedServiceEndpointVersionRecord | ProviderEndpointDraftRecord | undefined | null
+) {
+  expect(endpoint?.endpointType).toBe("marketplace_proxy");
+  return endpoint as Extract<
+    PublishedServiceEndpointVersionRecord | ProviderEndpointDraftRecord,
+    { endpointType: "marketplace_proxy" }
+  >;
 }
 
 describe("shared marketplace helpers", () => {
@@ -197,7 +231,7 @@ describe("shared marketplace helpers", () => {
 
     const detail = buildServiceDetail({
       service: freeService,
-      endpoints: [freeRoute],
+      endpoints: [buildPublishedEndpointFromRoute(freeRoute)],
       analytics: {
         totalCalls: 0,
         revenueRaw: "0",
@@ -244,9 +278,10 @@ describe("shared marketplace helpers", () => {
     }
 
     const endpoints = marketplaceRoutes.filter((route) => service.routeIds.includes(route.routeId));
+    const publishedEndpoints = endpoints.map((endpoint) => buildPublishedEndpointFromRoute(endpoint));
     const detail = buildServiceDetail({
       service,
-      endpoints,
+      endpoints: publishedEndpoints,
       analytics: {
         totalCalls: 12,
         revenueRaw: "420000",
@@ -281,7 +316,7 @@ describe("shared marketplace helpers", () => {
 
     const detail = buildServiceDetail({
       service: tavilyService,
-      endpoints: [tavilyRoute],
+      endpoints: [buildPublishedEndpointFromRoute(tavilyRoute)],
       analytics: {
         totalCalls: 3,
         revenueRaw: "150000",
@@ -293,7 +328,9 @@ describe("shared marketplace helpers", () => {
     });
 
     expect(detail.summary.endpointCount).toBe(1);
-    expect(detail.endpoints[0]?.proxyUrl).toBe("https://api.marketplace.example.com/api/tavily/search");
+    const endpoint = detail.endpoints[0];
+    expect(endpoint?.endpointType).toBe("marketplace_proxy");
+    expect(endpoint && "proxyUrl" in endpoint ? endpoint.proxyUrl : null).toBe("https://api.marketplace.example.com/api/tavily/search");
     expect(detail.useThisServicePrompt).toContain("https://api.marketplace.example.com/api/tavily/search");
   });
 
@@ -686,6 +723,7 @@ describe("shared marketplace helpers", () => {
     });
 
     const created = await store.createProviderService(wallet, {
+      serviceType: "marketplace_proxy",
       slug: "signal-labs",
       apiNamespace: "signals",
       name: "Signal Labs",
@@ -699,6 +737,7 @@ describe("shared marketplace helpers", () => {
     });
 
     await store.createProviderEndpointDraft(created.service.id, wallet, {
+      endpointType: "marketplace_proxy",
       operation: "quote",
       title: "Quote",
       description: "Return a single quote snapshot.",
@@ -746,6 +785,58 @@ describe("shared marketplace helpers", () => {
     expect(publicService?.endpoints).toHaveLength(1);
   });
 
+  it("publishes external registry services without creating executable marketplace routes", async () => {
+    const store = new InMemoryMarketplaceStore();
+    const wallet = "fast1provider000000000000000000000000000000000000000000000000000000";
+
+    await store.upsertProviderAccount(wallet, {
+      displayName: "Signal Labs",
+      websiteUrl: "https://provider.example.com"
+    });
+
+    const created = await store.createProviderService(wallet, {
+      serviceType: "external_registry",
+      slug: "signal-labs-direct",
+      name: "Signal Labs Direct",
+      tagline: "Discovery-only external endpoints",
+      about: "Direct provider APIs listed in the marketplace catalog without proxy execution.",
+      categories: ["Research"],
+      promptIntro: 'I want to use the "Signal Labs Direct" service.',
+      setupInstructions: ["Read the provider docs before calling the API directly."],
+      websiteUrl: "https://provider.example.com"
+    });
+
+    await store.createProviderEndpointDraft(created.service.id, wallet, {
+      endpointType: "external_registry",
+      title: "Status",
+      description: "Returns service status directly from the provider.",
+      method: "GET",
+      publicUrl: "https://provider.example.com/api/status",
+      docsUrl: "https://provider.example.com/docs/status",
+      authNotes: "Bearer token required.",
+      requestExample: {},
+      responseExample: { status: "ok" }
+    });
+
+    await store.createProviderVerificationChallenge(created.service.id, wallet);
+    await store.markProviderVerificationResult(created.service.id, "verified", {
+      verifiedHost: "provider.example.com"
+    });
+    await store.submitProviderService(created.service.id, wallet);
+    await store.publishProviderService(created.service.id, {
+      reviewerIdentity: "ops@test"
+    });
+
+    const published = await store.getPublishedServiceBySlug("signal-labs-direct");
+    expect(published?.service.serviceType).toBe("external_registry");
+    expect(published?.service.routeIds).toEqual([]);
+    expect(published?.endpoints).toHaveLength(1);
+    expect(published?.endpoints[0]?.endpointType).toBe("external_registry");
+
+    const route = await store.findPublishedRoute("signal-labs-direct", "status", "fast-mainnet");
+    expect(route).toBeNull();
+  });
+
   it("propagates service payout-wallet changes into existing endpoint drafts before submit", async () => {
     const store = new InMemoryMarketplaceStore();
     const wallet = "fast1provider000000000000000000000000000000000000000000000000000000";
@@ -757,6 +848,7 @@ describe("shared marketplace helpers", () => {
     });
 
     const created = await store.createProviderService(wallet, {
+      serviceType: "marketplace_proxy",
       slug: "signal-labs-wallet-sync",
       apiNamespace: "signals-wallet-sync",
       name: "Signal Labs Wallet Sync",
@@ -770,6 +862,7 @@ describe("shared marketplace helpers", () => {
     });
 
     const endpoint = await store.createProviderEndpointDraft(created.service.id, wallet, {
+      endpointType: "marketplace_proxy",
       operation: "quote",
       title: "Quote",
       description: "Return a single quote snapshot.",
@@ -800,7 +893,7 @@ describe("shared marketplace helpers", () => {
       upstreamAuthMode: "none"
     });
 
-    expect(endpoint.payout.providerWallet).toBe(wallet);
+    expect(expectMarketplaceCatalogEndpoint(endpoint).payout.providerWallet).toBe(wallet);
 
     await store.updateProviderServiceForOwner(created.service.id, wallet, {
       payoutWallet: replacementWallet
@@ -808,7 +901,7 @@ describe("shared marketplace helpers", () => {
 
     const updatedDetail = await store.getProviderServiceForOwner(created.service.id, wallet);
     expect(updatedDetail?.service.payoutWallet).toBe(replacementWallet);
-    expect(updatedDetail?.endpoints[0]?.payout.providerWallet).toBe(replacementWallet);
+    expect(expectMarketplaceCatalogEndpoint(updatedDetail?.endpoints[0]).payout.providerWallet).toBe(replacementWallet);
 
     await store.createProviderVerificationChallenge(created.service.id, wallet);
     await store.markProviderVerificationResult(created.service.id, "verified", {
@@ -822,6 +915,6 @@ describe("shared marketplace helpers", () => {
 
     const published = await store.getPublishedServiceBySlug("signal-labs-wallet-sync");
     expect(published?.service.payoutWallet).toBe(replacementWallet);
-    expect(published?.endpoints[0]?.payout.providerWallet).toBe(replacementWallet);
+    expect(expectMarketplaceCatalogEndpoint(published?.endpoints[0]).payout.providerWallet).toBe(replacementWallet);
   });
 });

--- a/packages/shared/src/store.ts
+++ b/packages/shared/src/store.ts
@@ -2564,6 +2564,8 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
+    this.assertServiceUniqueness(version.slug, version.apiNamespace, serviceId);
+
     const settlementMode = service.serviceType === "marketplace_proxy"
       ? normalizeSettlementMode(input?.settlementMode ?? service.settlementMode, service.settlementMode ?? "community_direct")
       : null;
@@ -2888,7 +2890,10 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
         throw new Error(`Service slug already exists: ${slug}`);
       }
 
-      if (apiNamespace && service.apiNamespace === apiNamespace) {
+      if (
+        apiNamespace
+        && (service.apiNamespace === apiNamespace || (service.status === "published" && latestPublishedVersion?.apiNamespace === apiNamespace))
+      ) {
         throw new Error(`API namespace already exists: ${apiNamespace}`);
       }
     }
@@ -6738,6 +6743,25 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
+    const versionResult = await this.pool.query(
+      `
+      SELECT slug, api_namespace
+      FROM published_service_versions
+      WHERE service_id = $1 AND version_id = $2
+      LIMIT 1
+      `,
+      [serviceId, submittedVersionId]
+    );
+    if (!versionResult.rowCount) {
+      return null;
+    }
+
+    await this.assertServiceUniqueness(
+      versionResult.rows[0].slug as string,
+      (versionResult.rows[0].api_namespace as string | null) ?? null,
+      serviceId
+    );
+
     const settlementMode = service.service.serviceType === "marketplace_proxy"
       ? normalizeSettlementMode(
         input?.settlementMode ?? service.service.settlementMode,
@@ -7076,8 +7100,11 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         EXISTS (
           SELECT 1
           FROM provider_services s
+          LEFT JOIN published_service_versions v
+            ON v.version_id = s.latest_published_version_id
+            AND s.status = 'published'
           WHERE $2::text IS NOT NULL
-            AND s.api_namespace = $2
+            AND (s.api_namespace = $2 OR v.api_namespace = $2)
             AND ($3::text IS NULL OR s.id <> $3)
         ) AS namespace_conflict
       `,

--- a/packages/shared/src/store.ts
+++ b/packages/shared/src/store.ts
@@ -173,6 +173,10 @@ function isSameOrSubdomain(input: { rootHost: string; candidateHost: string }): 
   return candidate === root || candidate.endsWith(`.${root}`);
 }
 
+function isPostgresUniqueViolation(error: unknown): boolean {
+  return (error as { code?: string }).code === "23505";
+}
+
 function mapPublishedServiceToDefinition(service: PublishedServiceVersionRecord): PublishedServiceVersionRecord {
   return clone(service);
 }
@@ -2876,7 +2880,11 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
         continue;
       }
 
-      if (service.slug === slug) {
+      const latestPublishedVersionId = this.latestPublishedVersionByServiceId.get(service.id);
+      const latestPublishedVersion = latestPublishedVersionId
+        ? this.publishedServicesByVersionId.get(latestPublishedVersionId) ?? null
+        : null;
+      if (service.slug === slug || (service.status === "published" && latestPublishedVersion?.slug === slug)) {
         throw new Error(`Service slug already exists: ${slug}`);
       }
 
@@ -4071,8 +4079,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         created: true
       };
     } catch (error) {
-      const pgError = error as { code?: string };
-      if (pgError.code !== "23505") {
+      if (!isPostgresUniqueViolation(error)) {
         throw error;
       }
 
@@ -6077,29 +6084,46 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         throw new Error("External services only accept external endpoint drafts.");
       }
 
-      const result = await this.pool.query(
-        `
-        INSERT INTO provider_external_endpoint_drafts (
-          id, service_id, title, description, method, public_url, docs_url, auth_notes, request_example, response_example, usage_notes
-        ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb, $11
-        )
-        RETURNING *
-        `,
-        [
-          randomUUID(),
-          serviceId,
-          input.title,
-          input.description,
-          input.method,
-          input.publicUrl,
-          input.docsUrl,
-          input.authNotes ?? null,
-          JSON.stringify(input.requestExample),
-          JSON.stringify(input.responseExample),
-          input.usageNotes ?? null
-        ]
-      );
+      if (detail.endpoints.some((endpoint) =>
+        isExternalEndpointDraft(endpoint)
+        && endpoint.method === input.method
+        && endpoint.publicUrl === input.publicUrl
+      )) {
+        throw new Error(`External endpoint already exists: ${input.method} ${input.publicUrl}`);
+      }
+
+      let result;
+      try {
+        result = await this.pool.query(
+          `
+          INSERT INTO provider_external_endpoint_drafts (
+            id, service_id, title, description, method, public_url, docs_url, auth_notes, request_example, response_example, usage_notes
+          ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb, $11
+          )
+          RETURNING *
+          `,
+          [
+            randomUUID(),
+            serviceId,
+            input.title,
+            input.description,
+            input.method,
+            input.publicUrl,
+            input.docsUrl,
+            input.authNotes ?? null,
+            JSON.stringify(input.requestExample),
+            JSON.stringify(input.responseExample),
+            input.usageNotes ?? null
+          ]
+        );
+      } catch (error) {
+        if (!isPostgresUniqueViolation(error)) {
+          throw error;
+        }
+
+        throw new Error(`External endpoint already exists: ${input.method} ${input.publicUrl}`);
+      }
 
       return mapProviderExternalEndpointDraftRow(result.rows[0]);
     }
@@ -6209,37 +6233,60 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       }
 
       const existing = mapProviderExternalEndpointDraftRow(existingExternalResult.rows[0]);
-      const result = await this.pool.query(
-        `
-        UPDATE provider_external_endpoint_drafts
-        SET
-          title = $3,
-          description = $4,
-          method = $5,
-          public_url = $6,
-          docs_url = $7,
-          auth_notes = $8,
-          request_example = $9::jsonb,
-          response_example = $10::jsonb,
-          usage_notes = $11,
-          updated_at = NOW()
-        WHERE id = $1 AND service_id = $2
-        RETURNING *
-        `,
-        [
-          endpointId,
-          serviceId,
-          input.title ?? existing.title,
-          input.description ?? existing.description,
-          input.method ?? existing.method,
-          input.publicUrl ?? existing.publicUrl,
-          input.docsUrl ?? existing.docsUrl,
-          input.authNotes === undefined ? existing.authNotes : input.authNotes,
-          JSON.stringify(input.requestExample === undefined ? existing.requestExample : input.requestExample),
-          JSON.stringify(input.responseExample === undefined ? existing.responseExample : input.responseExample),
-          input.usageNotes === undefined ? existing.usageNotes : input.usageNotes
-        ]
-      );
+      const nextMethod = input.method ?? existing.method;
+      const nextPublicUrl = input.publicUrl ?? existing.publicUrl;
+      if (
+        (nextMethod !== existing.method || nextPublicUrl !== existing.publicUrl)
+        && detail.endpoints.some((endpoint) =>
+          endpoint.id !== endpointId
+          && isExternalEndpointDraft(endpoint)
+          && endpoint.method === nextMethod
+          && endpoint.publicUrl === nextPublicUrl
+        )
+      ) {
+        throw new Error(`External endpoint already exists: ${nextMethod} ${nextPublicUrl}`);
+      }
+
+      let result;
+      try {
+        result = await this.pool.query(
+          `
+          UPDATE provider_external_endpoint_drafts
+          SET
+            title = $3,
+            description = $4,
+            method = $5,
+            public_url = $6,
+            docs_url = $7,
+            auth_notes = $8,
+            request_example = $9::jsonb,
+            response_example = $10::jsonb,
+            usage_notes = $11,
+            updated_at = NOW()
+          WHERE id = $1 AND service_id = $2
+          RETURNING *
+          `,
+          [
+            endpointId,
+            serviceId,
+            input.title ?? existing.title,
+            input.description ?? existing.description,
+            nextMethod,
+            nextPublicUrl,
+            input.docsUrl ?? existing.docsUrl,
+            input.authNotes === undefined ? existing.authNotes : input.authNotes,
+            JSON.stringify(input.requestExample === undefined ? existing.requestExample : input.requestExample),
+            JSON.stringify(input.responseExample === undefined ? existing.responseExample : input.responseExample),
+            input.usageNotes === undefined ? existing.usageNotes : input.usageNotes
+          ]
+        );
+      } catch (error) {
+        if (!isPostgresUniqueViolation(error)) {
+          throw error;
+        }
+
+        throw new Error(`External endpoint already exists: ${nextMethod} ${nextPublicUrl}`);
+      }
 
       return result.rowCount ? mapProviderExternalEndpointDraftRow(result.rows[0]) : null;
     }
@@ -7016,24 +7063,34 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
   private async assertServiceUniqueness(slug: string, apiNamespace: string | null, serviceId?: string) {
     const result = await this.pool.query(
       `
-      SELECT id, slug, api_namespace
-      FROM provider_services
-      WHERE (slug = $1 OR ($2::text IS NOT NULL AND api_namespace = $2))
-        AND ($3::text IS NULL OR id <> $3)
-      LIMIT 1
+      SELECT
+        EXISTS (
+          SELECT 1
+          FROM provider_services s
+          LEFT JOIN published_service_versions v
+            ON v.version_id = s.latest_published_version_id
+            AND s.status = 'published'
+          WHERE (s.slug = $1 OR v.slug = $1)
+            AND ($3::text IS NULL OR s.id <> $3)
+        ) AS slug_conflict,
+        EXISTS (
+          SELECT 1
+          FROM provider_services s
+          WHERE $2::text IS NOT NULL
+            AND s.api_namespace = $2
+            AND ($3::text IS NULL OR s.id <> $3)
+        ) AS namespace_conflict
       `,
       [slug, apiNamespace, serviceId ?? null]
     );
 
-    if (!result.rowCount) {
-      return;
-    }
-
-    if (result.rows[0].slug === slug) {
+    if (result.rows[0]?.slug_conflict) {
       throw new Error(`Service slug already exists: ${slug}`);
     }
 
-    throw new Error(`API namespace already exists: ${apiNamespace ?? ""}`);
+    if (result.rows[0]?.namespace_conflict) {
+      throw new Error(`API namespace already exists: ${apiNamespace ?? ""}`);
+    }
   }
 
   private async getProviderServiceDetailById(serviceId: string): Promise<ProviderServiceDetailRecord> {

--- a/packages/shared/src/store.ts
+++ b/packages/shared/src/store.ts
@@ -1768,20 +1768,30 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
     service: PublishedServiceVersionRecord;
     endpoints: PublishedServiceEndpointVersionRecord[];
   } | null> {
-    const service = Array.from(this.providerServicesById.values()).find(
-      (record) => record.slug === slug && record.status === "published"
-    );
-    if (!service) {
-      return null;
+    let version: PublishedServiceVersionRecord | null = null;
+    let versionId: string | null = null;
+
+    for (const service of this.providerServicesById.values()) {
+      if (service.status !== "published") {
+        continue;
+      }
+
+      const candidateVersionId = this.latestPublishedVersionByServiceId.get(service.id);
+      if (!candidateVersionId) {
+        continue;
+      }
+
+      const candidateVersion = this.publishedServicesByVersionId.get(candidateVersionId);
+      if (!candidateVersion || candidateVersion.slug !== slug) {
+        continue;
+      }
+
+      version = candidateVersion;
+      versionId = candidateVersionId;
+      break;
     }
 
-    const versionId = this.latestPublishedVersionByServiceId.get(service.id);
-    if (!versionId) {
-      return null;
-    }
-
-    const version = this.publishedServicesByVersionId.get(versionId);
-    if (!version) {
+    if (!version || !versionId) {
       return null;
     }
 
@@ -5767,7 +5777,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       FROM provider_services s
       JOIN published_service_versions v
         ON v.version_id = s.latest_published_version_id
-      WHERE s.slug = $1 AND s.status = 'published'
+      WHERE v.slug = $1 AND s.status = 'published'
       `,
       [slug]
     );

--- a/packages/shared/src/store.ts
+++ b/packages/shared/src/store.ts
@@ -25,10 +25,12 @@ import type {
   CreateProviderEndpointDraftInput,
   CreateProviderServiceInput,
   CreateSuggestionInput,
+  ExternalProviderEndpointDraftRecord,
   IdempotencyRecord,
   JobRecord,
   MarketplaceRoute,
   MarketplaceStore,
+  MarketplaceProviderEndpointDraftRecord,
   ProviderAccountRecord,
   ProviderAttemptRecord,
   ProviderEndpointDraftRecord,
@@ -40,9 +42,12 @@ import type {
   ProviderServiceDetailRecord,
   ProviderServiceRecord,
   ProviderServiceStatus,
+  ProviderServiceType,
   ProviderVerificationRecord,
   ProviderVerificationStatus,
+  PublishedExternalEndpointVersionRecord,
   PublishedEndpointVersionRecord,
+  PublishedServiceEndpointVersionRecord,
   PublishedServiceVersionRecord,
   ResourceType,
   RefundRecord,
@@ -72,6 +77,40 @@ function clone<T>(value: T): T {
 
 function buildRouteId(apiNamespace: string, operation: string): string {
   return `${apiNamespace}.${operation}.v1`;
+}
+
+function isMarketplaceServiceType(serviceType: ProviderServiceType): serviceType is "marketplace_proxy" {
+  return serviceType === "marketplace_proxy";
+}
+
+function isMarketplaceService(service: Pick<ProviderServiceRecord, "serviceType">): service is ProviderServiceRecord & {
+  serviceType: "marketplace_proxy";
+} {
+  return isMarketplaceServiceType(service.serviceType);
+}
+
+function isMarketplaceEndpointDraft(
+  endpoint: ProviderEndpointDraftRecord
+): endpoint is MarketplaceProviderEndpointDraftRecord {
+  return endpoint.endpointType === "marketplace_proxy";
+}
+
+function isExternalEndpointDraft(
+  endpoint: ProviderEndpointDraftRecord
+): endpoint is ExternalProviderEndpointDraftRecord {
+  return endpoint.endpointType === "external_registry";
+}
+
+function isMarketplacePublishedEndpoint(
+  endpoint: PublishedServiceEndpointVersionRecord
+): endpoint is PublishedEndpointVersionRecord {
+  return endpoint.endpointType === "marketplace_proxy";
+}
+
+function isExternalPublishedEndpoint(
+  endpoint: PublishedServiceEndpointVersionRecord
+): endpoint is PublishedExternalEndpointVersionRecord {
+  return endpoint.endpointType === "external_registry";
 }
 
 function sortByUpdatedDesc<T extends { updatedAt: string }>(records: T[]): T[] {
@@ -164,6 +203,7 @@ function mapPublishedServiceVersionToProviderService(version: PublishedServiceVe
   return {
     id: version.serviceId,
     providerAccountId: version.providerAccountId,
+    serviceType: version.serviceType,
     settlementMode: version.settlementMode,
     slug: version.slug,
     apiNamespace: version.apiNamespace,
@@ -184,8 +224,9 @@ function mapPublishedServiceVersionToProviderService(version: PublishedServiceVe
 
 function mapPublishedEndpointVersionToProviderDraft(
   endpoint: PublishedEndpointVersionRecord
-): ProviderEndpointDraftRecord {
+): MarketplaceProviderEndpointDraftRecord {
   return {
+    endpointType: "marketplace_proxy",
     id: endpoint.endpointDraftId ?? endpoint.endpointVersionId,
     serviceId: endpoint.serviceId,
     routeId: endpoint.routeId,
@@ -213,10 +254,46 @@ function mapPublishedEndpointVersionToProviderDraft(
   };
 }
 
+function mapPublishedExternalEndpointVersionToProviderDraft(
+  endpoint: PublishedExternalEndpointVersionRecord
+): ExternalProviderEndpointDraftRecord {
+  return {
+    endpointType: "external_registry",
+    id: endpoint.endpointDraftId ?? endpoint.endpointVersionId,
+    serviceId: endpoint.serviceId,
+    routeId: null,
+    operation: null,
+    title: endpoint.title,
+    description: endpoint.description,
+    price: null,
+    billing: null,
+    mode: null,
+    requestSchemaJson: null,
+    responseSchemaJson: null,
+    method: endpoint.method,
+    publicUrl: endpoint.publicUrl,
+    docsUrl: endpoint.docsUrl,
+    authNotes: endpoint.authNotes ?? null,
+    requestExample: clone(endpoint.requestExample),
+    responseExample: clone(endpoint.responseExample),
+    usageNotes: endpoint.usageNotes ?? null,
+    executorKind: null,
+    upstreamBaseUrl: null,
+    upstreamPath: null,
+    upstreamAuthMode: null,
+    upstreamAuthHeaderName: null,
+    upstreamSecretRef: null,
+    hasUpstreamSecret: false,
+    payout: null,
+    createdAt: endpoint.createdAt,
+    updatedAt: endpoint.updatedAt
+  };
+}
+
 function buildSubmittedProviderServiceDetail(input: {
   version: PublishedServiceVersionRecord;
   account: ProviderAccountRecord;
-  endpoints: PublishedEndpointVersionRecord[];
+  endpoints: PublishedServiceEndpointVersionRecord[];
   verification: ProviderVerificationRecord | null;
   latestReview: ProviderReviewRecord | null;
   latestPublishedVersionId: string | null;
@@ -224,7 +301,11 @@ function buildSubmittedProviderServiceDetail(input: {
   return buildProviderServiceDetail({
     service: mapPublishedServiceVersionToProviderService(input.version),
     account: input.account,
-    endpoints: input.endpoints.map(mapPublishedEndpointVersionToProviderDraft),
+    endpoints: input.endpoints.map((endpoint) =>
+      isMarketplacePublishedEndpoint(endpoint)
+        ? mapPublishedEndpointVersionToProviderDraft(endpoint)
+        : mapPublishedExternalEndpointVersionToProviderDraft(endpoint)
+    ),
     verification: input.verification,
     latestReview: input.latestReview,
     latestPublishedVersionId: input.latestPublishedVersionId
@@ -466,12 +547,14 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
   private readonly providerAccountsById = new Map<string, ProviderAccountRecord>();
   private readonly providerAccountIdByWallet = new Map<string, string>();
   private readonly providerServicesById = new Map<string, ProviderServiceRecord>();
-  private readonly endpointDraftsById = new Map<string, ProviderEndpointDraftRecord>();
+  private readonly endpointDraftsById = new Map<string, MarketplaceProviderEndpointDraftRecord>();
+  private readonly externalEndpointDraftsById = new Map<string, ExternalProviderEndpointDraftRecord>();
   private readonly verificationByService = new Map<string, ProviderVerificationRecord[]>();
   private readonly reviewsByService = new Map<string, ProviderReviewRecord[]>();
   private readonly providerSecretsById = new Map<string, ProviderSecretRecord>();
   private readonly publishedServicesByVersionId = new Map<string, PublishedServiceVersionRecord>();
   private readonly publishedEndpointsByVersionId = new Map<string, PublishedEndpointVersionRecord>();
+  private readonly publishedExternalEndpointsByVersionId = new Map<string, PublishedExternalEndpointVersionRecord>();
   private readonly latestSubmittedVersionByServiceId = new Map<string, string>();
   private readonly latestPublishedVersionByServiceId = new Map<string, string>();
 
@@ -500,7 +583,9 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       this.providerServicesById.set(service.id, service);
     }
     for (const endpoint of draftEndpoints) {
-      this.endpointDraftsById.set(endpoint.id, endpoint);
+      if (isMarketplaceEndpointDraft(endpoint)) {
+        this.endpointDraftsById.set(endpoint.id, endpoint);
+      }
     }
     for (const publishedService of publishedServices) {
       this.publishedServicesByVersionId.set(publishedService.versionId, publishedService);
@@ -1681,7 +1766,7 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
 
   async getPublishedServiceBySlug(slug: string): Promise<{
     service: PublishedServiceVersionRecord;
-    endpoints: PublishedEndpointVersionRecord[];
+    endpoints: PublishedServiceEndpointVersionRecord[];
   } | null> {
     const service = Array.from(this.providerServicesById.values()).find(
       (record) => record.slug === slug && record.status === "published"
@@ -1700,9 +1785,14 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
-    const endpoints = Array.from(this.publishedEndpointsByVersionId.values()).filter(
-      (endpoint) => endpoint.serviceVersionId === versionId
-    );
+    const endpoints: PublishedServiceEndpointVersionRecord[] = [
+      ...Array.from(this.publishedEndpointsByVersionId.values()).filter(
+        (endpoint) => endpoint.serviceVersionId === versionId
+      ),
+      ...Array.from(this.publishedExternalEndpointsByVersionId.values()).filter(
+        (endpoint) => endpoint.serviceVersionId === versionId
+      )
+    ];
 
     return {
       service: clone(version),
@@ -1787,14 +1877,15 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       throw new Error("Provider account not found.");
     }
 
-    this.assertServiceUniqueness(input.slug, input.apiNamespace);
+    this.assertServiceUniqueness(input.slug, input.apiNamespace ?? null);
 
     const record: ProviderServiceRecord = {
       id: randomUUID(),
       providerAccountId: account.id,
-      settlementMode: settlementModeForNewProviderService(),
+      serviceType: input.serviceType,
+      settlementMode: isMarketplaceServiceType(input.serviceType) ? settlementModeForNewProviderService() : null,
       slug: input.slug,
-      apiNamespace: input.apiNamespace,
+      apiNamespace: isMarketplaceServiceType(input.serviceType) ? input.apiNamespace ?? null : null,
       name: input.name,
       tagline: input.tagline,
       about: input.about,
@@ -1802,7 +1893,7 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       promptIntro: input.promptIntro,
       setupInstructions: clone(input.setupInstructions),
       websiteUrl: input.websiteUrl ?? account.websiteUrl ?? null,
-      payoutWallet: input.payoutWallet,
+      payoutWallet: isMarketplaceServiceType(input.serviceType) ? input.payoutWallet ?? null : null,
       featured: Boolean(input.featured),
       status: "draft",
       createdAt: timestamp(),
@@ -1836,10 +1927,34 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
+    const nextServiceType = input.serviceType ?? detail.service.serviceType;
+    if (nextServiceType !== detail.service.serviceType) {
+      if (
+        detail.endpoints.length > 0
+        || this.latestSubmittedVersionByServiceId.has(serviceId)
+        || this.latestPublishedVersionByServiceId.has(serviceId)
+        || this.providerRuntimeKeysByServiceId.has(serviceId)
+      ) {
+        throw new Error("serviceType can only change before endpoints, runtime keys, or published versions exist.");
+      }
+    }
+
+    const nextApiNamespace = isMarketplaceServiceType(nextServiceType)
+      ? (input.apiNamespace === undefined ? detail.service.apiNamespace : input.apiNamespace)
+      : null;
+    const nextPayoutWallet = isMarketplaceServiceType(nextServiceType)
+      ? (input.payoutWallet === undefined ? detail.service.payoutWallet : input.payoutWallet)
+      : null;
     const updated: ProviderServiceRecord = {
       ...detail.service,
+      serviceType: nextServiceType,
+      settlementMode: isMarketplaceServiceType(nextServiceType)
+        ? (nextServiceType === detail.service.serviceType
+          ? detail.service.settlementMode ?? settlementModeForNewProviderService()
+          : settlementModeForNewProviderService())
+        : null,
       slug: input.slug ?? detail.service.slug,
-      apiNamespace: input.apiNamespace ?? detail.service.apiNamespace,
+      apiNamespace: nextApiNamespace,
       name: input.name ?? detail.service.name,
       tagline: input.tagline ?? detail.service.tagline,
       about: input.about ?? detail.service.about,
@@ -1847,7 +1962,7 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       promptIntro: input.promptIntro ?? detail.service.promptIntro,
       setupInstructions: input.setupInstructions ? clone(input.setupInstructions) : detail.service.setupInstructions,
       websiteUrl: input.websiteUrl === undefined ? detail.service.websiteUrl : input.websiteUrl,
-      payoutWallet: input.payoutWallet === undefined ? detail.service.payoutWallet : input.payoutWallet,
+      payoutWallet: nextPayoutWallet,
       featured: input.featured ?? detail.service.featured,
       updatedAt: timestamp()
     };
@@ -1886,7 +2001,60 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       throw new Error("Provider service not found.");
     }
 
-    if (detail.endpoints.some((endpoint) => endpoint.operation === input.operation)) {
+    if (detail.service.serviceType === "external_registry") {
+      if (input.endpointType !== "external_registry") {
+        throw new Error("External services only accept external endpoint drafts.");
+      }
+
+      if (detail.endpoints.some((endpoint) =>
+        isExternalEndpointDraft(endpoint)
+        && endpoint.method === input.method
+        && endpoint.publicUrl === input.publicUrl
+      )) {
+        throw new Error(`External endpoint already exists: ${input.method} ${input.publicUrl}`);
+      }
+
+      const record: ExternalProviderEndpointDraftRecord = {
+        endpointType: "external_registry",
+        id: randomUUID(),
+        serviceId,
+        routeId: null,
+        operation: null,
+        title: input.title,
+        description: input.description,
+        price: null,
+        billing: null,
+        mode: null,
+        requestSchemaJson: null,
+        responseSchemaJson: null,
+        method: input.method,
+        publicUrl: input.publicUrl,
+        docsUrl: input.docsUrl,
+        authNotes: input.authNotes ?? null,
+        requestExample: clone(input.requestExample),
+        responseExample: clone(input.responseExample),
+        usageNotes: input.usageNotes ?? null,
+        executorKind: null,
+        upstreamBaseUrl: null,
+        upstreamPath: null,
+        upstreamAuthMode: null,
+        upstreamAuthHeaderName: null,
+        upstreamSecretRef: null,
+        hasUpstreamSecret: false,
+        payout: null,
+        createdAt: timestamp(),
+        updatedAt: timestamp()
+      };
+
+      this.externalEndpointDraftsById.set(record.id, record);
+      return clone(record);
+    }
+
+    if (input.endpointType !== "marketplace_proxy") {
+      throw new Error("Marketplace services only accept marketplace endpoint drafts.");
+    }
+
+    if (detail.endpoints.some((endpoint) => isMarketplaceEndpointDraft(endpoint) && endpoint.operation === input.operation)) {
       throw new Error(`Operation already exists: ${input.operation}`);
     }
 
@@ -1894,11 +2062,16 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       ? this.createProviderSecretRecord(detail.account.id, secretMaterial).id
       : null;
     const billing = createDraftRouteBilling(input);
+    const apiNamespace = detail.service.apiNamespace;
+    if (!apiNamespace) {
+      throw new Error("Marketplace services require an apiNamespace before creating endpoints.");
+    }
 
-    const record: ProviderEndpointDraftRecord = {
+    const record: MarketplaceProviderEndpointDraftRecord = {
+      endpointType: "marketplace_proxy",
       id: randomUUID(),
       serviceId,
-      routeId: buildRouteId(detail.service.apiNamespace, input.operation),
+      routeId: buildRouteId(apiNamespace, input.operation),
       operation: input.operation,
       title: input.title,
       description: input.description,
@@ -1942,15 +2115,60 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
-    const existing = this.endpointDraftsById.get(endpointId);
+    const existing = this.endpointDraftsById.get(endpointId) ?? this.externalEndpointDraftsById.get(endpointId);
     if (!existing || existing.serviceId !== serviceId) {
       return null;
+    }
+
+    if (existing.endpointType === "external_registry") {
+      if (input.endpointType !== "external_registry") {
+        throw new Error("External endpoint drafts only accept external updates.");
+      }
+
+      const nextMethod = input.method ?? existing.method;
+      const nextPublicUrl = input.publicUrl ?? existing.publicUrl;
+      if (
+        (nextMethod !== existing.method || nextPublicUrl !== existing.publicUrl)
+        && detail.endpoints.some((endpoint) =>
+          endpoint.id !== endpointId
+          && isExternalEndpointDraft(endpoint)
+          && endpoint.method === nextMethod
+          && endpoint.publicUrl === nextPublicUrl
+        )
+      ) {
+        throw new Error(`External endpoint already exists: ${nextMethod} ${nextPublicUrl}`);
+      }
+
+      const updated: ExternalProviderEndpointDraftRecord = {
+        ...existing,
+        title: input.title ?? existing.title,
+        description: input.description ?? existing.description,
+        method: nextMethod,
+        publicUrl: nextPublicUrl,
+        docsUrl: input.docsUrl ?? existing.docsUrl,
+        authNotes: input.authNotes === undefined ? existing.authNotes : input.authNotes,
+        requestExample: input.requestExample === undefined ? existing.requestExample : clone(input.requestExample),
+        responseExample: input.responseExample === undefined ? existing.responseExample : clone(input.responseExample),
+        usageNotes: input.usageNotes === undefined ? existing.usageNotes : input.usageNotes,
+        updatedAt: timestamp()
+      };
+
+      this.externalEndpointDraftsById.set(updated.id, updated);
+      return clone(updated);
+    }
+
+    if (input.endpointType !== "marketplace_proxy") {
+      throw new Error("Marketplace endpoint drafts only accept marketplace updates.");
     }
 
     const nextOperation = input.operation ?? existing.operation;
     if (
       nextOperation !== existing.operation &&
-      detail.endpoints.some((endpoint) => endpoint.id !== endpointId && endpoint.operation === nextOperation)
+      detail.endpoints.some((endpoint) =>
+        endpoint.id !== endpointId
+        && isMarketplaceEndpointDraft(endpoint)
+        && endpoint.operation === nextOperation
+      )
     ) {
       throw new Error(`Operation already exists: ${nextOperation}`);
     }
@@ -1968,10 +2186,14 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       minAmount: input.minAmount ?? (existing.billing.type === "topup_x402_variable" ? existing.billing.minAmount : null),
       maxAmount: input.maxAmount ?? (existing.billing.type === "topup_x402_variable" ? existing.billing.maxAmount : null)
     });
+    const apiNamespace = detail.service.apiNamespace;
+    if (!apiNamespace) {
+      throw new Error("Marketplace services require an apiNamespace before updating endpoints.");
+    }
 
-    const updated: ProviderEndpointDraftRecord = {
+    const updated: MarketplaceProviderEndpointDraftRecord = {
       ...existing,
-      routeId: buildRouteId(detail.service.apiNamespace, nextOperation),
+      routeId: buildRouteId(apiNamespace, nextOperation),
       operation: nextOperation,
       title: input.title ?? existing.title,
       description: input.description ?? existing.description,
@@ -2012,12 +2234,16 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       return false;
     }
 
-    const existing = this.endpointDraftsById.get(endpointId);
+    const existing = this.endpointDraftsById.get(endpointId) ?? this.externalEndpointDraftsById.get(endpointId);
     if (!existing || existing.serviceId !== serviceId) {
       return false;
     }
 
-    this.endpointDraftsById.delete(endpointId);
+    if (existing.endpointType === "marketplace_proxy") {
+      this.endpointDraftsById.delete(endpointId);
+    } else {
+      this.externalEndpointDraftsById.delete(endpointId);
+    }
     return true;
   }
 
@@ -2088,6 +2314,7 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       versionId: serviceVersionId,
       serviceId,
       providerAccountId: detail.account.id,
+      serviceType: detail.service.serviceType,
       settlementMode: detail.service.settlementMode,
       slug: detail.service.slug,
       apiNamespace: detail.service.apiNamespace,
@@ -2096,7 +2323,7 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       tagline: detail.service.tagline,
       about: detail.service.about,
       categories: clone(detail.service.categories),
-      routeIds: detail.endpoints.map((endpoint) => endpoint.routeId),
+      routeIds: detail.endpoints.filter(isMarketplaceEndpointDraft).map((endpoint) => endpoint.routeId),
       featured: detail.service.featured,
       promptIntro: detail.service.promptIntro,
       setupInstructions: clone(detail.service.setupInstructions),
@@ -2111,16 +2338,17 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
     };
 
     const network = getDefaultMarketplaceNetworkConfig();
-    const publishedEndpoints = detail.endpoints.map<PublishedEndpointVersionRecord>((endpoint) => ({
+    const publishedEndpoints = detail.endpoints.filter(isMarketplaceEndpointDraft).map<PublishedEndpointVersionRecord>((endpoint) => ({
+      endpointType: "marketplace_proxy",
       endpointVersionId: randomUUID(),
       serviceId,
       serviceVersionId,
       endpointDraftId: endpoint.id,
       routeId: endpoint.routeId,
-      provider: detail.service.apiNamespace,
+      provider: detail.service.apiNamespace ?? "unknown",
       operation: endpoint.operation,
       version: versionTag,
-      settlementMode: detail.service.settlementMode,
+      settlementMode: detail.service.settlementMode ?? "verified_escrow",
       mode: endpoint.mode,
       network: network.paymentNetwork,
       price: endpoint.price,
@@ -2142,6 +2370,42 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       createdAt: timestamp(),
       updatedAt: timestamp()
     }));
+    const publishedExternalEndpoints = detail.endpoints.filter(isExternalEndpointDraft).map<PublishedExternalEndpointVersionRecord>((endpoint) => ({
+      endpointType: "external_registry",
+      endpointVersionId: randomUUID(),
+      serviceId,
+      serviceVersionId,
+      endpointDraftId: endpoint.id,
+      routeId: null,
+      provider: null,
+      operation: null,
+      version: null,
+      settlementMode: null,
+      mode: null,
+      network: null,
+      price: null,
+      billing: null,
+      title: endpoint.title,
+      description: endpoint.description,
+      payout: null,
+      method: endpoint.method,
+      publicUrl: endpoint.publicUrl,
+      docsUrl: endpoint.docsUrl,
+      authNotes: endpoint.authNotes,
+      requestExample: clone(endpoint.requestExample),
+      responseExample: clone(endpoint.responseExample),
+      usageNotes: endpoint.usageNotes ?? undefined,
+      requestSchemaJson: null,
+      responseSchemaJson: null,
+      executorKind: null,
+      upstreamBaseUrl: null,
+      upstreamPath: null,
+      upstreamAuthMode: null,
+      upstreamAuthHeaderName: null,
+      upstreamSecretRef: null,
+      createdAt: timestamp(),
+      updatedAt: timestamp()
+    }));
 
     const review: ProviderReviewRecord = {
       id: reviewId,
@@ -2157,6 +2421,9 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
     this.publishedServicesByVersionId.set(serviceVersionId, publishedService);
     for (const endpoint of publishedEndpoints) {
       this.publishedEndpointsByVersionId.set(endpoint.endpointVersionId, endpoint);
+    }
+    for (const endpoint of publishedExternalEndpoints) {
+      this.publishedExternalEndpointsByVersionId.set(endpoint.endpointVersionId, endpoint);
     }
 
     const currentReviews = this.reviewsByService.get(serviceId) ?? [];
@@ -2201,9 +2468,14 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
-    const endpoints = Array.from(this.publishedEndpointsByVersionId.values())
-      .filter((endpoint) => endpoint.serviceVersionId === submittedVersionId)
-      .sort((left, right) => left.operation.localeCompare(right.operation));
+    const endpoints: PublishedServiceEndpointVersionRecord[] = [
+      ...Array.from(this.publishedEndpointsByVersionId.values()).filter(
+        (endpoint) => endpoint.serviceVersionId === submittedVersionId
+      ),
+      ...Array.from(this.publishedExternalEndpointsByVersionId.values()).filter(
+        (endpoint) => endpoint.serviceVersionId === submittedVersionId
+      )
+    ].sort((left, right) => left.title.localeCompare(right.title));
 
     return buildSubmittedProviderServiceDetail({
       version,
@@ -2278,7 +2550,9 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
-    const settlementMode = normalizeSettlementMode(input?.settlementMode ?? service.settlementMode, service.settlementMode);
+    const settlementMode = service.serviceType === "marketplace_proxy"
+      ? normalizeSettlementMode(input?.settlementMode ?? service.settlementMode, service.settlementMode ?? "community_direct")
+      : null;
 
     this.latestPublishedVersionByServiceId.set(serviceId, version.versionId);
     this.providerServicesById.set(serviceId, {
@@ -2294,16 +2568,18 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       publishedAt: timestamp(),
       updatedAt: timestamp()
     });
-    for (const [endpointVersionId, endpoint] of this.publishedEndpointsByVersionId.entries()) {
-      if (endpoint.serviceVersionId !== version.versionId) {
-        continue;
-      }
+    if (settlementMode) {
+      for (const [endpointVersionId, endpoint] of this.publishedEndpointsByVersionId.entries()) {
+        if (endpoint.serviceVersionId !== version.versionId) {
+          continue;
+        }
 
-      this.publishedEndpointsByVersionId.set(endpointVersionId, {
-        ...endpoint,
-        settlementMode,
-        updatedAt: timestamp()
-      });
+        this.publishedEndpointsByVersionId.set(endpointVersionId, {
+          ...endpoint,
+          settlementMode,
+          updatedAt: timestamp()
+        });
+      }
     }
     this.reviewsByService.set(
       serviceId,
@@ -2336,7 +2612,11 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
-    const settlementMode = normalizeSettlementMode(input.settlementMode, service.settlementMode);
+    if (service.serviceType === "external_registry") {
+      return this.buildProviderServiceDetail(serviceId);
+    }
+
+    const settlementMode = normalizeSettlementMode(input.settlementMode, service.settlementMode ?? "community_direct");
     this.providerServicesById.set(serviceId, {
       ...service,
       settlementMode,
@@ -2580,7 +2860,7 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
     return record;
   }
 
-  private assertServiceUniqueness(slug: string, apiNamespace: string, serviceId?: string) {
+  private assertServiceUniqueness(slug: string, apiNamespace: string | null, serviceId?: string) {
     for (const service of this.providerServicesById.values()) {
       if (service.id === serviceId) {
         continue;
@@ -2590,7 +2870,7 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
         throw new Error(`Service slug already exists: ${slug}`);
       }
 
-      if (service.apiNamespace === apiNamespace) {
+      if (apiNamespace && service.apiNamespace === apiNamespace) {
         throw new Error(`API namespace already exists: ${apiNamespace}`);
       }
     }
@@ -2607,7 +2887,10 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       throw new Error(`Provider account not found: ${service.providerAccountId}`);
     }
 
-    const endpoints = Array.from(this.endpointDraftsById.values()).filter((endpoint) => endpoint.serviceId === serviceId);
+    const endpoints = [
+      ...Array.from(this.endpointDraftsById.values()).filter((endpoint) => endpoint.serviceId === serviceId),
+      ...Array.from(this.externalEndpointDraftsById.values()).filter((endpoint) => endpoint.serviceId === serviceId)
+    ];
     const verification = latestByCreatedAt(this.verificationByService.get(serviceId) ?? []);
     const latestReview = latestByCreatedAt(this.reviewsByService.get(serviceId) ?? []);
 
@@ -2776,9 +3059,10 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       CREATE TABLE IF NOT EXISTS provider_services (
         id TEXT PRIMARY KEY,
         provider_account_id TEXT NOT NULL REFERENCES provider_accounts(id),
-        settlement_mode TEXT NOT NULL DEFAULT 'community_direct',
+        service_type TEXT NOT NULL DEFAULT 'marketplace_proxy',
+        settlement_mode TEXT DEFAULT 'community_direct',
         slug TEXT NOT NULL UNIQUE,
-        api_namespace TEXT NOT NULL UNIQUE,
+        api_namespace TEXT UNIQUE,
         name TEXT NOT NULL,
         tagline TEXT NOT NULL,
         about TEXT NOT NULL,
@@ -2834,6 +3118,23 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         UNIQUE(service_id, operation)
       );
 
+      CREATE TABLE IF NOT EXISTS provider_external_endpoint_drafts (
+        id TEXT PRIMARY KEY,
+        service_id TEXT NOT NULL REFERENCES provider_services(id) ON DELETE CASCADE,
+        title TEXT NOT NULL,
+        description TEXT NOT NULL,
+        method TEXT NOT NULL,
+        public_url TEXT NOT NULL,
+        docs_url TEXT NOT NULL,
+        auth_notes TEXT,
+        request_example JSONB NOT NULL,
+        response_example JSONB NOT NULL,
+        usage_notes TEXT,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        UNIQUE(service_id, method, public_url)
+      );
+
       CREATE TABLE IF NOT EXISTS provider_verifications (
         id TEXT PRIMARY KEY,
         service_id TEXT NOT NULL REFERENCES provider_services(id) ON DELETE CASCADE,
@@ -2849,9 +3150,10 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         version_id TEXT PRIMARY KEY,
         service_id TEXT NOT NULL REFERENCES provider_services(id) ON DELETE CASCADE,
         provider_account_id TEXT NOT NULL REFERENCES provider_accounts(id),
-        settlement_mode TEXT NOT NULL DEFAULT 'verified_escrow',
+        service_type TEXT NOT NULL DEFAULT 'marketplace_proxy',
+        settlement_mode TEXT DEFAULT 'verified_escrow',
         slug TEXT NOT NULL,
-        api_namespace TEXT NOT NULL,
+        api_namespace TEXT,
         name TEXT NOT NULL,
         owner_name TEXT NOT NULL,
         tagline TEXT NOT NULL,
@@ -2899,6 +3201,24 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         upstream_auth_mode TEXT,
         upstream_auth_header_name TEXT,
         upstream_secret_ref TEXT,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      );
+
+      CREATE TABLE IF NOT EXISTS published_external_endpoint_versions (
+        endpoint_version_id TEXT PRIMARY KEY,
+        service_id TEXT NOT NULL REFERENCES provider_services(id) ON DELETE CASCADE,
+        service_version_id TEXT NOT NULL REFERENCES published_service_versions(version_id) ON DELETE CASCADE,
+        endpoint_draft_id TEXT,
+        title TEXT NOT NULL,
+        description TEXT NOT NULL,
+        method TEXT NOT NULL,
+        public_url TEXT NOT NULL,
+        docs_url TEXT NOT NULL,
+        auth_notes TEXT,
+        request_example JSONB NOT NULL,
+        response_example JSONB NOT NULL,
+        usage_notes TEXT,
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       );
@@ -3080,7 +3400,13 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       ADD COLUMN IF NOT EXISTS billing JSONB NOT NULL DEFAULT '{}'::jsonb;
 
       ALTER TABLE provider_services
+      ADD COLUMN IF NOT EXISTS service_type TEXT NOT NULL DEFAULT 'marketplace_proxy';
+
+      ALTER TABLE provider_services
       ADD COLUMN IF NOT EXISTS settlement_mode TEXT;
+
+      ALTER TABLE published_service_versions
+      ADD COLUMN IF NOT EXISTS service_type TEXT NOT NULL DEFAULT 'marketplace_proxy';
 
       ALTER TABLE published_service_versions
       ADD COLUMN IF NOT EXISTS settlement_mode TEXT;
@@ -3090,6 +3416,14 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
 
       ALTER TABLE published_endpoint_versions
       ADD COLUMN IF NOT EXISTS billing JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+      UPDATE provider_services
+      SET service_type = 'marketplace_proxy'
+      WHERE service_type IS NULL;
+
+      UPDATE published_service_versions
+      SET service_type = 'marketplace_proxy'
+      WHERE service_type IS NULL;
 
       UPDATE provider_services
       SET settlement_mode = 'verified_escrow'
@@ -3147,16 +3481,22 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       ALTER COLUMN pending_recovery_action SET NOT NULL;
 
       ALTER TABLE provider_services
+      ALTER COLUMN api_namespace DROP NOT NULL;
+
+      ALTER TABLE provider_services
       ALTER COLUMN settlement_mode SET DEFAULT 'community_direct';
 
       ALTER TABLE provider_services
-      ALTER COLUMN settlement_mode SET NOT NULL;
+      ALTER COLUMN settlement_mode DROP NOT NULL;
+
+      ALTER TABLE published_service_versions
+      ALTER COLUMN api_namespace DROP NOT NULL;
 
       ALTER TABLE published_service_versions
       ALTER COLUMN settlement_mode SET DEFAULT 'verified_escrow';
 
       ALTER TABLE published_service_versions
-      ALTER COLUMN settlement_mode SET NOT NULL;
+      ALTER COLUMN settlement_mode DROP NOT NULL;
 
       ALTER TABLE published_endpoint_versions
       ALTER COLUMN settlement_mode SET DEFAULT 'verified_escrow';
@@ -3214,6 +3554,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       ["provider_accounts", "bio"],
       ["provider_accounts", "website_url"],
       ["provider_accounts", "contact_email"],
+      ["provider_services", "service_type"],
       ["provider_services", "slug"],
       ["provider_services", "api_namespace"],
       ["provider_services", "settlement_mode"],
@@ -3239,6 +3580,13 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       ["provider_endpoint_drafts", "upstream_auth_mode"],
       ["provider_endpoint_drafts", "upstream_auth_header_name"],
       ["provider_endpoint_drafts", "upstream_secret_ref"],
+      ["provider_external_endpoint_drafts", "title"],
+      ["provider_external_endpoint_drafts", "description"],
+      ["provider_external_endpoint_drafts", "method"],
+      ["provider_external_endpoint_drafts", "public_url"],
+      ["provider_external_endpoint_drafts", "docs_url"],
+      ["provider_external_endpoint_drafts", "auth_notes"],
+      ["provider_external_endpoint_drafts", "usage_notes"],
       ["provider_verifications", "token"],
       ["provider_verifications", "status"],
       ["provider_verifications", "verified_host"],
@@ -3246,6 +3594,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       ["provider_reviews", "status"],
       ["provider_reviews", "review_notes"],
       ["provider_reviews", "reviewer_identity"],
+      ["published_service_versions", "service_type"],
       ["published_service_versions", "slug"],
       ["published_service_versions", "api_namespace"],
       ["published_service_versions", "settlement_mode"],
@@ -3276,6 +3625,13 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       ["published_endpoint_versions", "upstream_auth_mode"],
       ["published_endpoint_versions", "upstream_auth_header_name"],
       ["published_endpoint_versions", "upstream_secret_ref"],
+      ["published_external_endpoint_versions", "title"],
+      ["published_external_endpoint_versions", "description"],
+      ["published_external_endpoint_versions", "method"],
+      ["published_external_endpoint_versions", "public_url"],
+      ["published_external_endpoint_versions", "docs_url"],
+      ["published_external_endpoint_versions", "auth_notes"],
+      ["published_external_endpoint_versions", "usage_notes"],
       ["provider_secrets", "label"],
       ["provider_secrets", "secret_ciphertext"],
       ["provider_secrets", "iv"],
@@ -3411,14 +3767,15 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         await client.query(
           `
           INSERT INTO provider_services (
-            id, provider_account_id, settlement_mode, slug, api_namespace, name, tagline, about, categories, prompt_intro,
+            id, provider_account_id, service_type, settlement_mode, slug, api_namespace, name, tagline, about, categories, prompt_intro,
             setup_instructions, website_url, payout_wallet, featured, status, latest_submitted_version_id,
             latest_published_version_id, latest_review_id, created_at, updated_at
           ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11::jsonb, $12, $13, $14, $15, $16, $17, NULL, $18, $19
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12::jsonb, $13, $14, $15, $16, $17, $18, NULL, $19, $20
           )
           ON CONFLICT (id) DO UPDATE SET
             provider_account_id = EXCLUDED.provider_account_id,
+            service_type = EXCLUDED.service_type,
             settlement_mode = EXCLUDED.settlement_mode,
             slug = EXCLUDED.slug,
             api_namespace = EXCLUDED.api_namespace,
@@ -3439,6 +3796,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
           [
             service.id,
             service.providerAccountId,
+            service.serviceType,
             service.settlementMode,
             service.slug,
             service.apiNamespace,
@@ -3525,14 +3883,15 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         await client.query(
           `
           INSERT INTO published_service_versions (
-            version_id, service_id, provider_account_id, settlement_mode, slug, api_namespace, name, owner_name, tagline, about,
+            version_id, service_id, provider_account_id, service_type, settlement_mode, slug, api_namespace, name, owner_name, tagline, about,
             categories, route_ids, featured, prompt_intro, setup_instructions, website_url, contact_email,
             payout_wallet, status, submitted_review_id, published_at, created_at, updated_at
           ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, $13, $14, $15::jsonb, $16, $17,
-            $18, $19, $20, $21, $22, $23
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13::jsonb, $14, $15, $16::jsonb, $17, $18,
+            $19, $20, $21, $22, $23, $24
           )
           ON CONFLICT (version_id) DO UPDATE SET
+            service_type = EXCLUDED.service_type,
             settlement_mode = EXCLUDED.settlement_mode,
             owner_name = EXCLUDED.owner_name,
             tagline = EXCLUDED.tagline,
@@ -3552,6 +3911,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
             publishedService.versionId,
             publishedService.serviceId,
             publishedService.providerAccountId,
+            publishedService.serviceType,
             publishedService.settlementMode,
             publishedService.slug,
             publishedService.apiNamespace,
@@ -5400,7 +5760,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
     return result.rows.map(mapPublishedServiceVersionRow);
   }
 
-  async getPublishedServiceBySlug(slug: string): Promise<{ service: PublishedServiceVersionRecord; endpoints: PublishedEndpointVersionRecord[] } | null> {
+  async getPublishedServiceBySlug(slug: string): Promise<{ service: PublishedServiceVersionRecord; endpoints: PublishedServiceEndpointVersionRecord[] } | null> {
     const serviceResult = await this.pool.query(
       `
       SELECT v.*
@@ -5417,18 +5777,31 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
     }
 
     const service = mapPublishedServiceVersionRow(serviceResult.rows[0]);
-    const endpointsResult = await this.pool.query(
-      `
-      SELECT * FROM published_endpoint_versions
-      WHERE service_version_id = $1
-      ORDER BY operation ASC
-      `,
-      [service.versionId]
-    );
+    const [endpointsResult, externalEndpointsResult] = await Promise.all([
+      this.pool.query(
+        `
+        SELECT * FROM published_endpoint_versions
+        WHERE service_version_id = $1
+        ORDER BY operation ASC
+        `,
+        [service.versionId]
+      ),
+      this.pool.query(
+        `
+        SELECT * FROM published_external_endpoint_versions
+        WHERE service_version_id = $1
+        ORDER BY title ASC
+        `,
+        [service.versionId]
+      )
+    ]);
 
     return {
       service,
-      endpoints: endpointsResult.rows.map(mapPublishedEndpointVersionRow)
+      endpoints: [
+        ...endpointsResult.rows.map(mapPublishedEndpointVersionRow),
+        ...externalEndpointsResult.rows.map(mapPublishedExternalEndpointVersionRow)
+      ]
     };
   }
 
@@ -5520,21 +5893,22 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       throw new Error("Provider account not found.");
     }
 
-    await this.assertServiceUniqueness(input.slug, input.apiNamespace);
+    await this.assertServiceUniqueness(input.slug, input.apiNamespace ?? null);
     const id = randomUUID();
     await this.pool.query(
       `
       INSERT INTO provider_services (
-        id, provider_account_id, settlement_mode, slug, api_namespace, name, tagline, about, categories,
+        id, provider_account_id, service_type, settlement_mode, slug, api_namespace, name, tagline, about, categories,
         prompt_intro, setup_instructions, website_url, payout_wallet, featured, status
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11::jsonb, $12, $13, $14, 'draft')
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12::jsonb, $13, $14, $15, 'draft')
       `,
       [
         id,
         account.id,
-        settlementModeForNewProviderService(),
+        input.serviceType,
+        isMarketplaceServiceType(input.serviceType) ? settlementModeForNewProviderService() : null,
         input.slug,
-        input.apiNamespace,
+        isMarketplaceServiceType(input.serviceType) ? input.apiNamespace ?? null : null,
         input.name,
         input.tagline,
         input.about,
@@ -5542,7 +5916,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         input.promptIntro,
         JSON.stringify(input.setupInstructions),
         input.websiteUrl ?? account.websiteUrl ?? null,
-        input.payoutWallet,
+        isMarketplaceServiceType(input.serviceType) ? input.payoutWallet ?? null : null,
         Boolean(input.featured)
       ]
     );
@@ -5573,9 +5947,25 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
+    const nextServiceType = input.serviceType ?? detail.service.serviceType;
+    if (nextServiceType !== detail.service.serviceType) {
+      if (
+        detail.endpoints.length > 0
+        || detail.latestPublishedVersionId
+        || detail.latestReview
+        || await this.getProviderRuntimeKeyForOwner(serviceId, wallet)
+      ) {
+        throw new Error("serviceType can only change before endpoints, runtime keys, or published versions exist.");
+      }
+    }
+
     const nextSlug = input.slug ?? detail.service.slug;
-    const nextNamespace = input.apiNamespace ?? detail.service.apiNamespace;
-    const nextPayoutWallet = input.payoutWallet === undefined ? detail.service.payoutWallet : input.payoutWallet;
+    const nextNamespace = isMarketplaceServiceType(nextServiceType)
+      ? (input.apiNamespace === undefined ? detail.service.apiNamespace : input.apiNamespace)
+      : null;
+    const nextPayoutWallet = isMarketplaceServiceType(nextServiceType)
+      ? (input.payoutWallet === undefined ? detail.service.payoutWallet : input.payoutWallet)
+      : null;
     await this.assertServiceUniqueness(nextSlug, nextNamespace, serviceId);
 
     const client = await this.pool.connect();
@@ -5586,23 +5976,31 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         `
         UPDATE provider_services
         SET
-          slug = $2,
-          api_namespace = $3,
-          name = $4,
-          tagline = $5,
-          about = $6,
-          categories = $7::jsonb,
-          prompt_intro = $8,
-          setup_instructions = $9::jsonb,
-          website_url = $10,
-          payout_wallet = $11,
-          featured = $12,
+          service_type = $2,
+          settlement_mode = $3,
+          slug = $4,
+          api_namespace = $5,
+          name = $6,
+          tagline = $7,
+          about = $8,
+          categories = $9::jsonb,
+          prompt_intro = $10,
+          setup_instructions = $11::jsonb,
+          website_url = $12,
+          payout_wallet = $13,
+          featured = $14,
           updated_at = NOW()
         WHERE id = $1
         RETURNING *
         `,
         [
           serviceId,
+          nextServiceType,
+          isMarketplaceServiceType(nextServiceType)
+            ? (nextServiceType === detail.service.serviceType
+              ? detail.service.settlementMode ?? settlementModeForNewProviderService()
+              : settlementModeForNewProviderService())
+            : null,
           nextSlug,
           nextNamespace,
           input.name ?? detail.service.name,
@@ -5664,6 +6062,42 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       throw new Error("Provider service not found.");
     }
 
+    if (detail.service.serviceType === "external_registry") {
+      if (input.endpointType !== "external_registry") {
+        throw new Error("External services only accept external endpoint drafts.");
+      }
+
+      const result = await this.pool.query(
+        `
+        INSERT INTO provider_external_endpoint_drafts (
+          id, service_id, title, description, method, public_url, docs_url, auth_notes, request_example, response_example, usage_notes
+        ) VALUES (
+          $1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb, $11
+        )
+        RETURNING *
+        `,
+        [
+          randomUUID(),
+          serviceId,
+          input.title,
+          input.description,
+          input.method,
+          input.publicUrl,
+          input.docsUrl,
+          input.authNotes ?? null,
+          JSON.stringify(input.requestExample),
+          JSON.stringify(input.responseExample),
+          input.usageNotes ?? null
+        ]
+      );
+
+      return mapProviderExternalEndpointDraftRow(result.rows[0]);
+    }
+
+    if (input.endpointType !== "marketplace_proxy") {
+      throw new Error("Marketplace services only accept marketplace endpoint drafts.");
+    }
+
     const secretRef = secretMaterial
       ? (
           await this.pool.query(
@@ -5684,6 +6118,10 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         ).rows[0].id as string
       : null;
     const billing = createDraftRouteBilling(input);
+    const apiNamespace = detail.service.apiNamespace;
+    if (!apiNamespace) {
+      throw new Error("Marketplace services require an apiNamespace before creating endpoints.");
+    }
 
     const result = await this.pool.query(
       `
@@ -5700,7 +6138,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       [
         randomUUID(),
         serviceId,
-        buildRouteId(detail.service.apiNamespace, input.operation),
+        buildRouteId(apiNamespace, input.operation),
         input.operation,
         input.title,
         input.description,
@@ -5741,12 +6179,63 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
-    const existingResult = await this.pool.query(
-      "SELECT * FROM provider_endpoint_drafts WHERE id = $1 AND service_id = $2",
-      [endpointId, serviceId]
-    );
-    if (!existingResult.rowCount) {
+    const [existingResult, existingExternalResult] = await Promise.all([
+      this.pool.query(
+        "SELECT * FROM provider_endpoint_drafts WHERE id = $1 AND service_id = $2",
+        [endpointId, serviceId]
+      ),
+      this.pool.query(
+        "SELECT * FROM provider_external_endpoint_drafts WHERE id = $1 AND service_id = $2",
+        [endpointId, serviceId]
+      )
+    ]);
+    if (!existingResult.rowCount && !existingExternalResult.rowCount) {
       return null;
+    }
+
+    if (existingExternalResult.rowCount) {
+      if (input.endpointType !== "external_registry") {
+        throw new Error("External endpoint drafts only accept external updates.");
+      }
+
+      const existing = mapProviderExternalEndpointDraftRow(existingExternalResult.rows[0]);
+      const result = await this.pool.query(
+        `
+        UPDATE provider_external_endpoint_drafts
+        SET
+          title = $3,
+          description = $4,
+          method = $5,
+          public_url = $6,
+          docs_url = $7,
+          auth_notes = $8,
+          request_example = $9::jsonb,
+          response_example = $10::jsonb,
+          usage_notes = $11,
+          updated_at = NOW()
+        WHERE id = $1 AND service_id = $2
+        RETURNING *
+        `,
+        [
+          endpointId,
+          serviceId,
+          input.title ?? existing.title,
+          input.description ?? existing.description,
+          input.method ?? existing.method,
+          input.publicUrl ?? existing.publicUrl,
+          input.docsUrl ?? existing.docsUrl,
+          input.authNotes === undefined ? existing.authNotes : input.authNotes,
+          JSON.stringify(input.requestExample === undefined ? existing.requestExample : input.requestExample),
+          JSON.stringify(input.responseExample === undefined ? existing.responseExample : input.responseExample),
+          input.usageNotes === undefined ? existing.usageNotes : input.usageNotes
+        ]
+      );
+
+      return result.rowCount ? mapProviderExternalEndpointDraftRow(result.rows[0]) : null;
+    }
+
+    if (input.endpointType !== "marketplace_proxy") {
+      throw new Error("Marketplace endpoint drafts only accept marketplace updates.");
     }
 
     const existing = mapProviderEndpointDraftRow(existingResult.rows[0]);
@@ -5775,6 +6264,10 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
     }
 
     const operation = input.operation ?? existing.operation;
+    const apiNamespace = detail.service.apiNamespace;
+    if (!apiNamespace) {
+      throw new Error("Marketplace services require an apiNamespace before updating endpoints.");
+    }
     const billing = createDraftRouteBilling({
       billingType: input.billingType ?? existing.billing.type,
       price: input.price ?? existing.price,
@@ -5810,7 +6303,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       [
         endpointId,
         serviceId,
-        buildRouteId(detail.service.apiNamespace, operation),
+        buildRouteId(apiNamespace, operation),
         operation,
         input.title ?? existing.title,
         input.description ?? existing.description,
@@ -5848,11 +6341,17 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       return false;
     }
 
-    const result = await this.pool.query(
-      "DELETE FROM provider_endpoint_drafts WHERE id = $1 AND service_id = $2",
-      [endpointId, serviceId]
-    );
-    return Boolean(result.rowCount);
+    const [result, externalResult] = await Promise.all([
+      this.pool.query(
+        "DELETE FROM provider_endpoint_drafts WHERE id = $1 AND service_id = $2",
+        [endpointId, serviceId]
+      ),
+      this.pool.query(
+        "DELETE FROM provider_external_endpoint_drafts WHERE id = $1 AND service_id = $2",
+        [endpointId, serviceId]
+      )
+    ]);
+    return Boolean(result.rowCount || externalResult.rowCount);
   }
 
   async createProviderVerificationChallenge(serviceId: string, wallet: string): Promise<ProviderVerificationRecord | null> {
@@ -5934,17 +6433,18 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       await client.query(
         `
         INSERT INTO published_service_versions (
-          version_id, service_id, provider_account_id, settlement_mode, slug, api_namespace, name, owner_name, tagline, about,
+          version_id, service_id, provider_account_id, service_type, settlement_mode, slug, api_namespace, name, owner_name, tagline, about,
           categories, route_ids, featured, prompt_intro, setup_instructions, website_url, contact_email,
           payout_wallet, status, submitted_review_id
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, $13, $14, $15::jsonb, $16, $17, $18, 'pending_review', $19
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13::jsonb, $14, $15, $16::jsonb, $17, $18, $19, 'pending_review', $20
         )
         `,
         [
           serviceVersionId,
           serviceId,
           detail.account.id,
+          detail.service.serviceType,
           detail.service.settlementMode,
           detail.service.slug,
           detail.service.apiNamespace,
@@ -5953,7 +6453,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
           detail.service.tagline,
           detail.service.about,
           JSON.stringify(detail.service.categories),
-          JSON.stringify(detail.endpoints.map((endpoint) => endpoint.routeId)),
+          JSON.stringify(detail.endpoints.filter(isMarketplaceEndpointDraft).map((endpoint) => endpoint.routeId)),
           detail.service.featured,
           detail.service.promptIntro,
           JSON.stringify(detail.service.setupInstructions),
@@ -5964,7 +6464,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         ]
       );
 
-      for (const endpoint of detail.endpoints) {
+      for (const endpoint of detail.endpoints.filter(isMarketplaceEndpointDraft)) {
         await client.query(
           `
           INSERT INTO published_endpoint_versions (
@@ -6005,6 +6505,34 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
             endpoint.upstreamAuthMode,
             endpoint.upstreamAuthHeaderName,
             endpoint.upstreamSecretRef
+          ]
+        );
+      }
+
+      for (const endpoint of detail.endpoints.filter(isExternalEndpointDraft)) {
+        await client.query(
+          `
+          INSERT INTO published_external_endpoint_versions (
+            endpoint_version_id, service_id, service_version_id, endpoint_draft_id, title, description, method, public_url,
+            docs_url, auth_notes, request_example, response_example, usage_notes
+          ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, $13
+          )
+          `,
+          [
+            randomUUID(),
+            serviceId,
+            serviceVersionId,
+            endpoint.id,
+            endpoint.title,
+            endpoint.description,
+            endpoint.method,
+            endpoint.publicUrl,
+            endpoint.docsUrl,
+            endpoint.authNotes,
+            JSON.stringify(endpoint.requestExample),
+            JSON.stringify(endpoint.responseExample),
+            endpoint.usageNotes
           ]
         );
       }
@@ -6065,13 +6593,21 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
-    const [serviceResult, endpointsResult] = await Promise.all([
+    const [serviceResult, endpointsResult, externalEndpointsResult] = await Promise.all([
       this.pool.query("SELECT * FROM published_service_versions WHERE version_id = $1", [submittedVersionId]),
       this.pool.query(
         `
         SELECT * FROM published_endpoint_versions
         WHERE service_version_id = $1
         ORDER BY operation ASC
+        `,
+        [submittedVersionId]
+      ),
+      this.pool.query(
+        `
+        SELECT * FROM published_external_endpoint_versions
+        WHERE service_version_id = $1
+        ORDER BY title ASC
         `,
         [submittedVersionId]
       )
@@ -6084,7 +6620,10 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
     return buildSubmittedProviderServiceDetail({
       version: mapPublishedServiceVersionRow(serviceResult.rows[0]),
       account: detail.account,
-      endpoints: endpointsResult.rows.map(mapPublishedEndpointVersionRow),
+      endpoints: [
+        ...endpointsResult.rows.map(mapPublishedEndpointVersionRow),
+        ...externalEndpointsResult.rows.map(mapPublishedExternalEndpointVersionRow)
+      ],
       verification: detail.verification,
       latestReview: detail.latestReview,
       latestPublishedVersionId: detail.latestPublishedVersionId
@@ -6142,7 +6681,12 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
-    const settlementMode = normalizeSettlementMode(input?.settlementMode ?? service.service.settlementMode, service.service.settlementMode);
+    const settlementMode = service.service.serviceType === "marketplace_proxy"
+      ? normalizeSettlementMode(
+        input?.settlementMode ?? service.service.settlementMode,
+        service.service.settlementMode ?? "community_direct"
+      )
+      : null;
 
     await this.pool.query(
       `
@@ -6160,14 +6704,16 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       `,
       [serviceId, submittedVersionId, settlementMode]
     );
-    await this.pool.query(
-      `
-      UPDATE published_endpoint_versions
-      SET settlement_mode = $3, updated_at = NOW()
-      WHERE service_id = $1 AND service_version_id = $2
-      `,
-      [serviceId, submittedVersionId, settlementMode]
-    );
+    if (settlementMode) {
+      await this.pool.query(
+        `
+        UPDATE published_endpoint_versions
+        SET settlement_mode = $3, updated_at = NOW()
+        WHERE service_id = $1 AND service_version_id = $2
+        `,
+        [serviceId, submittedVersionId, settlementMode]
+      );
+    }
     await this.pool.query(
       `
       UPDATE provider_services
@@ -6194,7 +6740,11 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       return null;
     }
 
-    const settlementMode = normalizeSettlementMode(input.settlementMode, service.service.settlementMode);
+    if (service.service.serviceType === "external_registry") {
+      return this.getProviderServiceDetailById(serviceId);
+    }
+
+    const settlementMode = normalizeSettlementMode(input.settlementMode, service.service.settlementMode ?? "community_direct");
     const versionIds = Array.from(
       new Set(
         [
@@ -6453,12 +7003,12 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
     return mapSuggestionRow(result.rows[0]);
   }
 
-  private async assertServiceUniqueness(slug: string, apiNamespace: string, serviceId?: string) {
+  private async assertServiceUniqueness(slug: string, apiNamespace: string | null, serviceId?: string) {
     const result = await this.pool.query(
       `
       SELECT id, slug, api_namespace
       FROM provider_services
-      WHERE (slug = $1 OR api_namespace = $2)
+      WHERE (slug = $1 OR ($2::text IS NOT NULL AND api_namespace = $2))
         AND ($3::text IS NULL OR id <> $3)
       LIMIT 1
       `,
@@ -6473,7 +7023,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       throw new Error(`Service slug already exists: ${slug}`);
     }
 
-    throw new Error(`API namespace already exists: ${apiNamespace}`);
+    throw new Error(`API namespace already exists: ${apiNamespace ?? ""}`);
   }
 
   private async getProviderServiceDetailById(serviceId: string): Promise<ProviderServiceDetailRecord> {
@@ -6489,10 +7039,18 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
     }
     const account = mapProviderAccountRow(accountResult.rows[0]);
 
-    const [endpointsResult, verificationResult, reviewResult] = await Promise.all([
+    const [endpointsResult, externalEndpointsResult, verificationResult, reviewResult] = await Promise.all([
       this.pool.query(
         `
         SELECT * FROM provider_endpoint_drafts
+        WHERE service_id = $1
+        ORDER BY updated_at DESC
+        `,
+        [serviceId]
+      ),
+      this.pool.query(
+        `
+        SELECT * FROM provider_external_endpoint_drafts
         WHERE service_id = $1
         ORDER BY updated_at DESC
         `,
@@ -6521,7 +7079,10 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
     return buildProviderServiceDetail({
       service,
       account,
-      endpoints: endpointsResult.rows.map(mapProviderEndpointDraftRow),
+      endpoints: [
+        ...endpointsResult.rows.map(mapProviderEndpointDraftRow),
+        ...externalEndpointsResult.rows.map(mapProviderExternalEndpointDraftRow)
+      ],
       verification: verificationResult.rowCount ? mapProviderVerificationRow(verificationResult.rows[0]) : null,
       latestReview: reviewResult.rowCount ? mapProviderReviewRow(reviewResult.rows[0]) : null,
       latestPublishedVersionId:
@@ -6670,9 +7231,12 @@ function mapProviderServiceRow(row: Record<string, unknown>): ProviderServiceRec
   return {
     id: row.id as string,
     providerAccountId: row.provider_account_id as string,
-    settlementMode: normalizeSettlementMode(row.settlement_mode as SettlementMode | null | undefined, "community_direct"),
+    serviceType: ((row.service_type as ProviderServiceType | null) ?? "marketplace_proxy"),
+    settlementMode: row.settlement_mode
+      ? normalizeSettlementMode(row.settlement_mode as SettlementMode | null | undefined, "community_direct")
+      : null,
     slug: row.slug as string,
-    apiNamespace: row.api_namespace as string,
+    apiNamespace: (row.api_namespace as string | null) ?? null,
     name: row.name as string,
     tagline: row.tagline as string,
     about: row.about as string,
@@ -6688,9 +7252,10 @@ function mapProviderServiceRow(row: Record<string, unknown>): ProviderServiceRec
   };
 }
 
-function mapProviderEndpointDraftRow(row: Record<string, unknown>): ProviderEndpointDraftRecord {
-  const billing = normalizeRouteBilling(row.price as string, row.billing as ProviderEndpointDraftRecord["billing"]);
+function mapProviderEndpointDraftRow(row: Record<string, unknown>): MarketplaceProviderEndpointDraftRecord {
+  const billing = normalizeRouteBilling(row.price as string, row.billing as MarketplaceProviderEndpointDraftRecord["billing"]);
   return {
+    endpointType: "marketplace_proxy",
     id: row.id as string,
     serviceId: row.service_id as string,
     routeId: row.route_id as string,
@@ -6699,20 +7264,54 @@ function mapProviderEndpointDraftRow(row: Record<string, unknown>): ProviderEndp
     description: row.description as string,
     price: row.price as string,
     billing,
-    mode: row.mode as ProviderEndpointDraftRecord["mode"],
-    requestSchemaJson: row.request_schema_json as ProviderEndpointDraftRecord["requestSchemaJson"],
-    responseSchemaJson: row.response_schema_json as ProviderEndpointDraftRecord["responseSchemaJson"],
+    mode: row.mode as MarketplaceProviderEndpointDraftRecord["mode"],
+    requestSchemaJson: row.request_schema_json as MarketplaceProviderEndpointDraftRecord["requestSchemaJson"],
+    responseSchemaJson: row.response_schema_json as MarketplaceProviderEndpointDraftRecord["responseSchemaJson"],
     requestExample: row.request_example,
     responseExample: row.response_example,
     usageNotes: (row.usage_notes as string | null) ?? null,
-    executorKind: row.executor_kind as ProviderEndpointDraftRecord["executorKind"],
+    executorKind: row.executor_kind as MarketplaceProviderEndpointDraftRecord["executorKind"],
     upstreamBaseUrl: (row.upstream_base_url as string | null) ?? null,
     upstreamPath: (row.upstream_path as string | null) ?? null,
-    upstreamAuthMode: (row.upstream_auth_mode as ProviderEndpointDraftRecord["upstreamAuthMode"]) ?? null,
+    upstreamAuthMode: (row.upstream_auth_mode as MarketplaceProviderEndpointDraftRecord["upstreamAuthMode"]) ?? null,
     upstreamAuthHeaderName: (row.upstream_auth_header_name as string | null) ?? null,
     upstreamSecretRef: (row.upstream_secret_ref as string | null) ?? null,
     hasUpstreamSecret: Boolean(row.upstream_secret_ref),
-    payout: row.payout as ProviderEndpointDraftRecord["payout"],
+    payout: row.payout as MarketplaceProviderEndpointDraftRecord["payout"],
+    createdAt: new Date(row.created_at as string | Date).toISOString(),
+    updatedAt: new Date(row.updated_at as string | Date).toISOString()
+  };
+}
+
+function mapProviderExternalEndpointDraftRow(row: Record<string, unknown>): ExternalProviderEndpointDraftRecord {
+  return {
+    endpointType: "external_registry",
+    id: row.id as string,
+    serviceId: row.service_id as string,
+    routeId: null,
+    operation: null,
+    title: row.title as string,
+    description: row.description as string,
+    price: null,
+    billing: null,
+    mode: null,
+    requestSchemaJson: null,
+    responseSchemaJson: null,
+    method: row.method as ExternalProviderEndpointDraftRecord["method"],
+    publicUrl: row.public_url as string,
+    docsUrl: row.docs_url as string,
+    authNotes: (row.auth_notes as string | null) ?? null,
+    requestExample: row.request_example,
+    responseExample: row.response_example,
+    usageNotes: (row.usage_notes as string | null) ?? null,
+    executorKind: null,
+    upstreamBaseUrl: null,
+    upstreamPath: null,
+    upstreamAuthMode: null,
+    upstreamAuthHeaderName: null,
+    upstreamSecretRef: null,
+    hasUpstreamSecret: false,
+    payout: null,
     createdAt: new Date(row.created_at as string | Date).toISOString(),
     updatedAt: new Date(row.updated_at as string | Date).toISOString()
   };
@@ -6749,9 +7348,12 @@ function mapPublishedServiceVersionRow(row: Record<string, unknown>): PublishedS
     versionId: row.version_id as string,
     serviceId: row.service_id as string,
     providerAccountId: row.provider_account_id as string,
-    settlementMode: normalizeSettlementMode(row.settlement_mode as SettlementMode | null | undefined),
+    serviceType: ((row.service_type as ProviderServiceType | null) ?? "marketplace_proxy"),
+    settlementMode: row.settlement_mode
+      ? normalizeSettlementMode(row.settlement_mode as SettlementMode | null | undefined)
+      : null,
     slug: row.slug as string,
-    apiNamespace: row.api_namespace as string,
+    apiNamespace: (row.api_namespace as string | null) ?? null,
     name: row.name as string,
     ownerName: row.owner_name as string,
     tagline: row.tagline as string,
@@ -6775,6 +7377,7 @@ function mapPublishedServiceVersionRow(row: Record<string, unknown>): PublishedS
 function mapPublishedEndpointVersionRow(row: Record<string, unknown>): PublishedEndpointVersionRecord {
   const billing = normalizeRouteBilling(row.price as string, row.billing as PublishedEndpointVersionRecord["billing"]);
   return {
+    endpointType: "marketplace_proxy",
     endpointVersionId: row.endpoint_version_id as string,
     serviceId: row.service_id as string,
     serviceVersionId: row.service_version_id as string,
@@ -6802,6 +7405,45 @@ function mapPublishedEndpointVersionRow(row: Record<string, unknown>): Published
     upstreamAuthMode: (row.upstream_auth_mode as PublishedEndpointVersionRecord["upstreamAuthMode"]) ?? null,
     upstreamAuthHeaderName: (row.upstream_auth_header_name as string | null) ?? null,
     upstreamSecretRef: (row.upstream_secret_ref as string | null) ?? null,
+    createdAt: new Date(row.created_at as string | Date).toISOString(),
+    updatedAt: new Date(row.updated_at as string | Date).toISOString()
+  };
+}
+
+function mapPublishedExternalEndpointVersionRow(row: Record<string, unknown>): PublishedExternalEndpointVersionRecord {
+  return {
+    endpointType: "external_registry",
+    endpointVersionId: row.endpoint_version_id as string,
+    serviceId: row.service_id as string,
+    serviceVersionId: row.service_version_id as string,
+    endpointDraftId: (row.endpoint_draft_id as string | null) ?? null,
+    routeId: null,
+    provider: null,
+    operation: null,
+    version: null,
+    settlementMode: null,
+    mode: null,
+    network: null,
+    price: null,
+    billing: null,
+    title: row.title as string,
+    description: row.description as string,
+    payout: null,
+    method: row.method as PublishedExternalEndpointVersionRecord["method"],
+    publicUrl: row.public_url as string,
+    docsUrl: row.docs_url as string,
+    authNotes: (row.auth_notes as string | null) ?? null,
+    requestExample: row.request_example,
+    responseExample: row.response_example,
+    usageNotes: (row.usage_notes as string | null) ?? undefined,
+    requestSchemaJson: null,
+    responseSchemaJson: null,
+    executorKind: null,
+    upstreamBaseUrl: null,
+    upstreamPath: null,
+    upstreamAuthMode: null,
+    upstreamAuthHeaderName: null,
+    upstreamSecretRef: null,
     createdAt: new Date(row.created_at as string | Date).toISOString(),
     updatedAt: new Date(row.updated_at as string | Date).toISOString()
   };

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -19,6 +19,9 @@ export type ProviderServiceStatus =
 export type ProviderVerificationStatus = "pending" | "verified" | "failed";
 export type ProviderReviewStatus = "pending_review" | "changes_requested" | "published" | "suspended";
 export type SettlementMode = "community_direct" | "verified_escrow";
+export type ProviderServiceType = "marketplace_proxy" | "external_registry";
+export type ServiceEndpointType = ProviderServiceType;
+export type ExternalEndpointMethod = "GET" | "POST";
 
 export interface RoutePayoutConfig {
   providerAccountId: string;
@@ -92,9 +95,10 @@ export interface MarketplaceRoute {
 export interface ServiceDefinition {
   serviceId: string;
   providerAccountId: string;
-  settlementMode: SettlementMode;
+  serviceType: ProviderServiceType;
+  settlementMode: SettlementMode | null;
   slug: string;
-  apiNamespace: string;
+  apiNamespace: string | null;
   name: string;
   ownerName: string;
   tagline: string;
@@ -119,6 +123,7 @@ export interface PublishedServiceVersionRecord extends ServiceDefinition {
 }
 
 export interface PublishedEndpointVersionRecord extends MarketplaceRoute {
+  endpointType: "marketplace_proxy";
   endpointVersionId: string;
   serviceId: string;
   serviceVersionId: string;
@@ -126,6 +131,47 @@ export interface PublishedEndpointVersionRecord extends MarketplaceRoute {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface PublishedExternalEndpointVersionRecord {
+  endpointType: "external_registry";
+  endpointVersionId: string;
+  serviceId: string;
+  serviceVersionId: string;
+  endpointDraftId: string | null;
+  routeId: null;
+  provider: null;
+  operation: null;
+  version: null;
+  settlementMode: null;
+  mode: null;
+  network: null;
+  price: null;
+  billing: null;
+  title: string;
+  description: string;
+  payout: null;
+  method: ExternalEndpointMethod;
+  publicUrl: string;
+  docsUrl: string;
+  authNotes: string | null;
+  requestExample: unknown;
+  responseExample: unknown;
+  usageNotes?: string;
+  requestSchemaJson: null;
+  responseSchemaJson: null;
+  executorKind: null;
+  upstreamBaseUrl: null;
+  upstreamPath: null;
+  upstreamAuthMode: null;
+  upstreamAuthHeaderName: null;
+  upstreamSecretRef: null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type PublishedServiceEndpointVersionRecord =
+  | PublishedEndpointVersionRecord
+  | PublishedExternalEndpointVersionRecord;
 
 export interface ServiceAnalyticsPoint {
   date: string;
@@ -139,7 +185,8 @@ export interface ServiceAnalytics {
   volume30d: ServiceAnalyticsPoint[];
 }
 
-export interface ServiceSummary {
+export interface MarketplaceServiceSummary {
+  serviceType: "marketplace_proxy";
   slug: string;
   name: string;
   ownerName: string;
@@ -160,7 +207,35 @@ export interface ServiceSummary {
   }>;
 }
 
-export interface ServiceCatalogEndpoint {
+export interface ExternalRegistryServiceSummary {
+  serviceType: "external_registry";
+  slug: string;
+  name: string;
+  ownerName: string;
+  tagline: string;
+  categories: string[];
+  settlementMode: null;
+  settlementLabel: string;
+  settlementDescription: string;
+  priceRange: string;
+  settlementToken: null;
+  totalCalls: null;
+  revenue: null;
+  successRate30d: null;
+  volume30d: Array<{
+    date: string;
+    amount: string;
+  }>;
+  accessModelLabel: string;
+  accessModelDescription: string;
+  endpointCount: number;
+  websiteUrl: string | null;
+}
+
+export type ServiceSummary = MarketplaceServiceSummary | ExternalRegistryServiceSummary;
+
+export interface MarketplaceServiceCatalogEndpoint {
+  endpointType: "marketplace_proxy";
   routeId: string;
   title: string;
   description: string;
@@ -176,13 +251,42 @@ export interface ServiceCatalogEndpoint {
   usageNotes?: string;
 }
 
-export interface ServiceDetail {
-  summary: ServiceSummary;
+export interface ExternalServiceCatalogEndpoint {
+  endpointType: "external_registry";
+  endpointId: string;
+  title: string;
+  description: string;
+  method: ExternalEndpointMethod;
+  publicUrl: string;
+  docsUrl: string;
+  authNotes: string | null;
+  requestExample: unknown;
+  responseExample: unknown;
+  usageNotes?: string;
+}
+
+export type ServiceCatalogEndpoint = MarketplaceServiceCatalogEndpoint | ExternalServiceCatalogEndpoint;
+
+export interface MarketplaceServiceDetail {
+  serviceType: "marketplace_proxy";
+  summary: MarketplaceServiceSummary;
   about: string;
   useThisServicePrompt: string;
   skillUrl: string;
-  endpoints: ServiceCatalogEndpoint[];
+  endpoints: MarketplaceServiceCatalogEndpoint[];
 }
+
+export interface ExternalRegistryServiceDetail {
+  serviceType: "external_registry";
+  summary: ExternalRegistryServiceSummary;
+  about: string;
+  useThisServicePrompt: string;
+  skillUrl: null;
+  websiteUrl: string | null;
+  endpoints: ExternalServiceCatalogEndpoint[];
+}
+
+export type ServiceDetail = MarketplaceServiceDetail | ExternalRegistryServiceDetail;
 
 export interface SuggestionRecord {
   id: string;
@@ -258,9 +362,10 @@ export interface ProviderSecretRecord {
 export interface ProviderServiceRecord {
   id: string;
   providerAccountId: string;
-  settlementMode: SettlementMode;
+  serviceType: ProviderServiceType;
+  settlementMode: SettlementMode | null;
   slug: string;
-  apiNamespace: string;
+  apiNamespace: string | null;
   name: string;
   tagline: string;
   about: string;
@@ -275,7 +380,8 @@ export interface ProviderServiceRecord {
   updatedAt: string;
 }
 
-export interface ProviderEndpointDraftRecord {
+export interface MarketplaceProviderEndpointDraftRecord {
+  endpointType: "marketplace_proxy";
   id: string;
   serviceId: string;
   routeId: string;
@@ -301,6 +407,42 @@ export interface ProviderEndpointDraftRecord {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface ExternalProviderEndpointDraftRecord {
+  endpointType: "external_registry";
+  id: string;
+  serviceId: string;
+  routeId: null;
+  operation: null;
+  title: string;
+  description: string;
+  price: null;
+  billing: null;
+  mode: null;
+  requestSchemaJson: null;
+  responseSchemaJson: null;
+  method: ExternalEndpointMethod;
+  publicUrl: string;
+  docsUrl: string;
+  authNotes: string | null;
+  requestExample: unknown;
+  responseExample: unknown;
+  usageNotes: string | null;
+  executorKind: null;
+  upstreamBaseUrl: null;
+  upstreamPath: null;
+  upstreamAuthMode: null;
+  upstreamAuthHeaderName: null;
+  upstreamSecretRef: null;
+  hasUpstreamSecret: false;
+  payout: null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type ProviderEndpointDraftRecord =
+  | MarketplaceProviderEndpointDraftRecord
+  | ExternalProviderEndpointDraftRecord;
 
 export interface ProviderVerificationRecord {
   id: string;
@@ -341,8 +483,9 @@ export interface UpsertProviderAccountInput {
 }
 
 export interface CreateProviderServiceInput {
+  serviceType: ProviderServiceType;
   slug: string;
-  apiNamespace: string;
+  apiNamespace?: string | null;
   name: string;
   tagline: string;
   about: string;
@@ -350,13 +493,14 @@ export interface CreateProviderServiceInput {
   promptIntro: string;
   setupInstructions: string[];
   websiteUrl?: string | null;
-  payoutWallet: string;
+  payoutWallet?: string | null;
   featured?: boolean;
 }
 
 export interface UpdateProviderServiceInput {
+  serviceType?: ProviderServiceType;
   slug?: string;
-  apiNamespace?: string;
+  apiNamespace?: string | null;
   name?: string;
   tagline?: string;
   about?: string;
@@ -368,7 +512,8 @@ export interface UpdateProviderServiceInput {
   featured?: boolean;
 }
 
-export interface CreateProviderEndpointDraftInput {
+export interface CreateMarketplaceProviderEndpointDraftInput {
+  endpointType: "marketplace_proxy";
   operation: string;
   title: string;
   description: string;
@@ -389,7 +534,25 @@ export interface CreateProviderEndpointDraftInput {
   upstreamSecret?: string | null;
 }
 
-export interface UpdateProviderEndpointDraftInput {
+export interface CreateExternalProviderEndpointDraftInput {
+  endpointType: "external_registry";
+  title: string;
+  description: string;
+  method: ExternalEndpointMethod;
+  publicUrl: string;
+  docsUrl: string;
+  authNotes?: string | null;
+  requestExample: unknown;
+  responseExample: unknown;
+  usageNotes?: string | null;
+}
+
+export type CreateProviderEndpointDraftInput =
+  | CreateMarketplaceProviderEndpointDraftInput
+  | CreateExternalProviderEndpointDraftInput;
+
+export interface UpdateMarketplaceProviderEndpointDraftInput {
+  endpointType: "marketplace_proxy";
   operation?: string;
   title?: string;
   description?: string;
@@ -409,6 +572,23 @@ export interface UpdateProviderEndpointDraftInput {
   upstreamSecret?: string | null;
   clearUpstreamSecret?: boolean;
 }
+
+export interface UpdateExternalProviderEndpointDraftInput {
+  endpointType: "external_registry";
+  title?: string;
+  description?: string;
+  method?: ExternalEndpointMethod;
+  publicUrl?: string;
+  docsUrl?: string;
+  authNotes?: string | null;
+  requestExample?: unknown;
+  responseExample?: unknown;
+  usageNotes?: string | null;
+}
+
+export type UpdateProviderEndpointDraftInput =
+  | UpdateMarketplaceProviderEndpointDraftInput
+  | UpdateExternalProviderEndpointDraftInput;
 
 export interface OpenApiImportRequest {
   documentUrl: string;
@@ -872,7 +1052,7 @@ export interface MarketplaceStore {
   listPublishedServices(): Promise<PublishedServiceVersionRecord[]>;
   getPublishedServiceBySlug(slug: string): Promise<{
     service: PublishedServiceVersionRecord;
-    endpoints: PublishedEndpointVersionRecord[];
+    endpoints: PublishedServiceEndpointVersionRecord[];
   } | null>;
   listPublishedRoutes(): Promise<PublishedEndpointVersionRecord[]>;
   findPublishedRoute(


### PR DESCRIPTION
## Summary
- add the `external_registry` service type alongside `marketplace_proxy`
- publish discovery-only external API metadata without creating executable marketplace routes
- update the provider workflow, public catalog, llms/docs output, and UI for external listings

## Verification
- npm run build
- npm test