### PR TITLE
Fix stale async refund recovery after merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Marketplace-executed routes use one of four billing modes:
 - `fixed_x402`: standard paid route; buyer sends the request, gets `402 Payment Required`, pays with x402, then retries the same request
 - `topup_x402_variable`: buyer supplies an amount in the request body, pays that exact amount with x402, and receives marketplace-managed service credit
 - `prepaid_credit`: buyer first funds service credit, then invokes the route with wallet-session bearer auth instead of paying x402 on every call
-- `free`: buyer invokes the marketplace route directly with no x402 payment
+- `free`: buyer invokes the marketplace route without x402 payment; async free routes still use wallet-session auth for job-bound retrieval
 
 Discovery-only `external_registry` listings do not use marketplace billing. They publish direct provider URLs and the provider defines payment and auth outside the marketplace.
 
@@ -186,13 +186,13 @@ npm run cli -- wallet address
 npm run cli -- invoke mock quick-insight --body '{"query":"alpha"}'
 ```
 
-For prepaid-credit routes, the CLI can mint an API-scoped wallet session automatically when the route responds with auth requirements instead of `402`. You can also create that session explicitly:
+For prepaid-credit routes, and for async free routes that require wallet-session auth, the CLI can mint an API-scoped wallet session automatically when the route responds with auth requirements instead of `402`. You can also create that session explicitly:
 
 ```bash
 npm run cli -- auth api-session <provider> <operation>
 ```
 
-For provider-authored top-up routes, call the route with an amount in the request body. For prepaid-credit routes, fund credit first, then call the prepaid route with the same `invoke` command; the CLI will switch to wallet-session auth when needed.
+For provider-authored top-up routes, call the route with an amount in the request body. For prepaid-credit routes, fund credit first, then call the prepaid route with the same `invoke` command; the CLI will switch to wallet-session auth when needed. Async free routes also use wallet-session auth and return a `jobToken` for `GET /api/jobs/:jobToken`.
 
 Provider-agent workflow:
 
@@ -255,6 +255,7 @@ Required worker environment:
 ```bash
 DATABASE_URL=postgres://...
 MARKETPLACE_TREASURY_PRIVATE_KEY=<fast-ed25519-private-key-hex>
+MARKETPLACE_SECRETS_KEY=change-me-again
 MARKETPLACE_FAST_NETWORK=mainnet
 FAST_RPC_URL=https://api.fast.xyz/proxy
 WORKER_POLL_INTERVAL_MS=5000
@@ -292,20 +293,25 @@ Keep the web, API, and worker on the same network value inside each stack. The f
 
 ### Provider Credit Runtime
 
-Provider runtime keys are used in two cases:
+Provider runtime keys are used in three cases:
 
 - `community_direct` HTTP routes: the marketplace forwards signed buyer identity headers so the provider can trust the requester wallet and `X-MARKETPLACE-REQUEST-ID`
+- `verified_escrow` async HTTP routes: the marketplace signs async execute and poll requests, injects `X-MARKETPLACE-JOB-TOKEN`, and can inject webhook callback auth for provider completion
 - `verified_escrow` prepaid-credit routes: the provider uses the runtime credit APIs to reserve, capture, and release marketplace-held credit
 
 Provider runtime key operations:
 
 - rotate a runtime key from the provider service dashboard or `POST /provider/services/:id/runtime-key`
 - marketplace forwards signed buyer identity headers to the provider upstream when the settlement flow requires them
+- async HTTP providers can complete webhook jobs through `POST /provider/runtime/jobs/:jobToken/callback`
 - provider backends reserve, capture, and release buyer credit through:
   - `POST /provider/runtime/credits/reserve`
   - `POST /provider/runtime/credits/:reservationId/capture`
 - `POST /provider/runtime/credits/:reservationId/release`
+- `POST /provider/runtime/credits/:reservationId/extend`
 - top-up purchases recognize provider revenue at purchase time; later credit consumption does not create a second provider payout
+
+Webhook async providers require an HTTPS `MARKETPLACE_BASE_URL` so the marketplace can inject a callback URL during execute.
 
 ### Scripts
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -21,10 +21,10 @@ Use this skill when a user wants to work with APIs listed on the Fast Marketplac
 - the user wants to sign into `https://marketplace.example.com` with a Fast browser wallet
 - the user wants to pay and execute a marketplace route directly from the website with the Fast browser extension
 - the user needs to call a fixed-price x402 route, a variable top-up route, or a prepaid-credit route with a local Fast wallet
-- the user needs to retrieve an async result from a previously paid job
+- the user needs to retrieve an async result from a previously accepted job
 - the user wants to suggest a missing endpoint or a new source/webservice for providers to build
 - the user wants to create or update a provider profile and manage service drafts
-- the user wants to create or rotate a provider runtime key for a prepaid-credit service
+- the user wants to create or rotate a provider runtime key for an async, prepaid-credit, or community-direct service
 - the user wants to claim provider-visible request intake and route it into a draft service
 - the user wants to verify provider website ownership and submit a service for review
 - the user wants to review, publish, or suspend provider supply from the admin surface
@@ -64,7 +64,7 @@ Before acting, identify:
 
 1. Open the marketplace UI at `https://marketplace.example.com` and locate the relevant service.
 2. Open the service page and identify the route billing type from the published endpoint docs, labels, pricing, and examples.
-3. If the user wants browser execution, use the endpoint's browser execution panel. Fixed-price and top-up routes pay through x402; prepaid-credit routes use the wallet session after the user is signed in.
+3. If the user wants browser execution, use the endpoint's browser execution panel. Fixed-price and top-up routes pay through x402; prepaid-credit routes and async free routes use the wallet session after the user is signed in.
 4. If the user is delegating the task to another agent, copy the service page's "Use this service" block or the canonical skill URL.
 5. For `fixed_x402` routes outside the browser panel, send the first request without payment proof, read the `402 Payment Required` response, pay from the funded wallet, and retry the same request with the payment proof headers.
 6. For `topup_x402_variable` routes, include the requested amount in the request body, expect a `402` quote for that exact amount, pay it, and persist the credited response details.
@@ -104,6 +104,13 @@ The marketplace is Fast-native and wallet-first.
 3. Invoke the `prepaid_credit` route with the bearer token.
 4. If using the CLI, `fast-marketplace invoke` will automatically switch to wallet-session auth when the route requires it.
 
+### Async free
+
+1. Create an API-scoped wallet session through `/auth/challenge` and `/auth/session`.
+2. Invoke the async free route with the bearer token.
+3. If the route returns `202`, persist the `jobToken`.
+4. Create the job-scoped wallet auth session and poll `GET /api/jobs/{jobToken}` until the job completes or fails.
+
 Important constraints:
 
 - paid routes do not use long-lived API keys
@@ -133,10 +140,10 @@ Important constraints:
 
 ## Async retrieval flow
 
-1. If a paid trigger returns `202`, persist the `jobToken`.
+1. If a trigger returns `202`, persist the `jobToken`.
 2. Create the job-scoped wallet auth session through `/auth/challenge` and `/auth/session`.
 3. Poll `GET /api/jobs/{jobToken}` until the job completes or fails.
-4. Use the same wallet that paid for the original trigger.
+4. Use the same wallet that authorized the original trigger.
 
 ## Refund flow
 
@@ -152,24 +159,28 @@ Important constraints:
 3. `provider sync` upserts the provider profile, creates or updates the owned service draft by slug, reconciles endpoint drafts, and creates a runtime key only when a `marketplace_proxy` service does not already have one.
 4. New provider services default to `community_direct`; providers cannot self-assign `verified_escrow` in v1.
 5. For `community_direct`, publish only sync HTTP `fixed_x402` routes and keep the provider runtime key available so the marketplace can forward signed buyer identity headers.
-6. For `verified_escrow`, `fixed_x402`, `topup_x402_variable`, and `prepaid_credit` are allowed only after review promotes the service.
+6. For `verified_escrow`, `fixed_x402`, `topup_x402_variable`, `prepaid_credit`, and async routes are allowed only after review promotes the service.
 7. For `topup_x402_variable` endpoints, set `minAmount` and `maxAmount`; the marketplace owns the top-up crediting flow.
-8. For `prepaid_credit` endpoints, verify marketplace identity headers upstream and use the provider runtime credit APIs to reserve, capture, and release buyer credit.
-9. Run `fast-marketplace provider verify --service <slug-or-id>` to mint a fresh verification challenge and show the exact URL and token the website must serve.
-10. If verification requires touching deploy, DNS, or cloud env outside this repo, ask the user before taking that action. For arbitrary external sites, the agent should hand off the token and wait for confirmation rather than mutating infrastructure on its own.
-11. After the user confirms the verification token is live, continue the same `provider verify` flow so the marketplace performs the ownership check.
-12. Run `fast-marketplace provider submit --service <slug-or-id>` only after verification succeeds; this flow stops at `pending_review`, not admin publish.
-13. If building from marketplace demand, review provider-visible request intake and claim the request you want to build before syncing the draft.
-14. After admin publish, use the public service page and paid proxy routes as the canonical execution surface.
+8. For async HTTP endpoints, require a provider runtime key and implement the marketplace async contract: execute returns `202` with `providerJobId`, poll routes expose `pollPath`, and webhook routes complete through the marketplace callback endpoint.
+9. For `prepaid_credit` endpoints, verify marketplace identity headers upstream and use the provider runtime credit APIs to reserve, capture, release, and when needed extend buyer credit reservations.
+10. Run `fast-marketplace provider verify --service <slug-or-id>` to mint a fresh verification challenge and show the exact URL and token the website must serve.
+11. If verification requires touching deploy, DNS, or cloud env outside this repo, ask the user before taking that action. For arbitrary external sites, the agent should hand off the token and wait for confirmation rather than mutating infrastructure on its own.
+12. After the user confirms the verification token is live, continue the same `provider verify` flow so the marketplace performs the ownership check.
+13. Run `fast-marketplace provider submit --service <slug-or-id>` only after verification succeeds; this flow stops at `pending_review`, not admin publish.
+14. If building from marketplace demand, review provider-visible request intake and claim the request you want to build before syncing the draft.
+15. After admin publish, use the public service page and paid proxy routes as the canonical execution surface.
 
 Important provider constraints:
 
 - provider drafts are scoped to the wallet that owns the provider profile
 - payout wallet validation happens at draft/update time
 - community-direct services need a provider runtime key before publish
+- async `marketplace_proxy` services need a provider runtime key before publish
 - top-up and prepaid-credit routes are Verified/escrow only
 - prepaid-credit services need a provider runtime key before they can debit marketplace-held credit
+- webhook async routes require an HTTPS marketplace base URL so the marketplace can inject a callback URL
 - prepaid-credit upstreams should verify the signed marketplace identity headers before reserving or capturing credit
+- async providers should trust the signed marketplace identity headers and `X-MARKETPLACE-JOB-TOKEN` when correlating work
 - changing the service website host requires re-verification before submission
 - request intake claiming is exclusive once another provider has claimed it
 

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -4177,8 +4177,8 @@ describe("marketplace api", () => {
       .set("PAYMENT-IDENTIFIER", "payment_provider_sync_recovery_1")
       .send({ symbol: "FAST" });
 
-    expect(refunded.status).toBe(409);
-    expect(refunded.body.error).toContain("refund handling has started");
+    expect(refunded.status).toBe(500);
+    expect(refunded.body.error).toContain("not durably recorded");
     expect(refunded.body.refund.status).toBe("sent");
     expect(refunded.body.refund.txHash).toBe("0xmanualrecoveryrefund");
     expect(upstreamExecutions).toBe(1);

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2430,6 +2430,19 @@ async function handleX402Route(input: {
   } catch (error) {
     if (asyncJobToken) {
       await failPendingAsyncJobSafely(input.store, asyncJobToken, error instanceof Error ? error.message : "Route execution failed.");
+      await recordProviderAttemptSafely(input.store, {
+        jobToken: asyncJobToken,
+        routeId: input.route.routeId,
+        requestId,
+        responseStatusCode: 500,
+        phase: "execute",
+        status: "failed",
+        requestPayload: requestBody,
+        responsePayload: {
+          error: error instanceof Error ? error.message : "Route execution failed."
+        },
+        errorMessage: error instanceof Error ? error.message : "Route execution failed."
+      });
     }
     const failedResponse = await buildRejectedSyncResponse({
       executeResult: {
@@ -2467,6 +2480,21 @@ async function handleX402Route(input: {
   }
 
   if (executeResult.kind === "sync") {
+    if (asyncJobToken) {
+      await recordProviderAttemptSafely(input.store, {
+        jobToken: asyncJobToken,
+        routeId: input.route.routeId,
+        requestId,
+        responseStatusCode: executeResult.statusCode,
+        phase: "execute",
+        status: executeResult.statusCode >= 200 && executeResult.statusCode < 400 ? "succeeded" : "failed",
+        requestPayload: requestBody,
+        responsePayload: executeResult.body,
+        errorMessage: executeResult.statusCode >= 200 && executeResult.statusCode < 400
+          ? undefined
+          : `Async route failed with status ${executeResult.statusCode} before acceptance.`
+      });
+    }
     if (asyncJobToken) {
       await failPendingAsyncJobSafely(
         input.store,

--- a/apps/worker/src/worker.test.ts
+++ b/apps/worker/src/worker.test.ts
@@ -616,6 +616,267 @@ describe("marketplace worker", () => {
     }));
   });
 
+  it("refunds stale pre-accept async failures instead of replaying them as accepted jobs", async () => {
+    const networkConfig = resolveMarketplaceNetworkConfig({
+      deploymentNetwork: "testnet"
+    });
+    const store = new InMemoryMarketplaceStore(networkConfig);
+    const asyncRoute = buildMarketplaceRoutes(networkConfig).find((route) => route.routeId === "mock.async-report.v1");
+
+    if (!asyncRoute) {
+      throw new Error("Missing async seeded route.");
+    }
+
+    const buyerWallet = "fast1buyerpreacceptfailure000000000000000000000000000000000000000";
+    const paymentId = "stale_payment_preaccept_failure_1";
+    const jobToken = "job_stale_preaccept_failure_1";
+
+    await store.claimPaymentExecution({
+      paymentId,
+      normalizedRequestHash: "stale-preaccept-failure-hash-1",
+      buyerWallet,
+      routeId: asyncRoute.routeId,
+      routeVersion: asyncRoute.version,
+      pendingRecoveryAction: "refund",
+      quotedPrice: "150000",
+      payoutSplit: buildEscrowSplit({
+        providerAccountId: "mock",
+        providerWallet: "fast1providerrefund000000000000000000000000000000000000000000",
+        marketplaceBps: 5000,
+        marketplaceAmount: "75000",
+        providerBps: 5000,
+        providerAmount: "75000"
+      }),
+      paymentPayload: "payload-preaccept-failure-1",
+      facilitatorResponse: { isValid: true },
+      responseKind: "job",
+      requestId: "request-preaccept-failure-1",
+      jobToken,
+      responseBody: { status: "processing" },
+      responseHeaders: {}
+    });
+
+    await store.savePendingAsyncJob({
+      jobToken,
+      paymentId,
+      buyerWallet,
+      route: {
+        ...asyncRoute,
+        executorKind: "http",
+        asyncConfig: {
+          strategy: "poll",
+          timeoutMs: 60_000,
+          pollPath: "/api/poll"
+        }
+      },
+      quotedPrice: "150000",
+      payoutSplit: buildEscrowSplit({
+        providerAccountId: "mock",
+        providerWallet: "fast1providerrefund000000000000000000000000000000000000000000",
+        marketplaceBps: 5000,
+        marketplaceAmount: "75000",
+        providerBps: 5000,
+        providerAmount: "75000"
+      }),
+      serviceId: "service_preaccept_failure_1",
+      requestId: "request-preaccept-failure-1",
+      requestBody: { topic: "pre-accept failure" },
+      nextPollAt: null,
+      timeoutAt: null
+    });
+
+    await store.failJob(jobToken, "Async route failed before acceptance.");
+
+    const idempotencyByPaymentId = (store as unknown as {
+      idempotencyByPaymentId: Map<string, {
+        updatedAt: string;
+      }>;
+    }).idempotencyByPaymentId;
+    const pending = idempotencyByPaymentId.get(paymentId);
+    if (!pending) {
+      throw new Error("Missing pending pre-accept payment record.");
+    }
+
+    idempotencyByPaymentId.set(paymentId, {
+      ...pending,
+      updatedAt: new Date(Date.now() - PAYMENT_EXECUTION_RECOVERY_MS - 1_000).toISOString()
+    });
+
+    let refundCalls = 0;
+
+    await runMarketplaceWorkerCycle({
+      store,
+      secretsKey: "test-secrets-key",
+      refundService: {
+        async issueRefund() {
+          refundCalls += 1;
+          return { txHash: "0xpreaccept-refund" };
+        }
+      }
+    });
+
+    const payment = await store.getIdempotencyByPaymentId(paymentId);
+    const refund = await store.getRefundByJobToken(jobToken);
+    const job = await store.getJob(jobToken);
+
+    expect(refundCalls).toBe(1);
+    expect(payment?.executionStatus).toBe("pending");
+    expect(payment?.responseKind).toBe("job");
+    expect(refund?.status).toBe("sent");
+    expect(job?.status).toBe("failed");
+    expect(job?.providerJobId).toBeNull();
+
+    await runMarketplaceWorkerCycle({
+      store,
+      secretsKey: "test-secrets-key",
+      refundService: {
+        async issueRefund() {
+          refundCalls += 1;
+          return { txHash: "0xunexpected-second-refund" };
+        }
+      }
+    });
+
+    expect(refundCalls).toBe(1);
+    expect((await store.getIdempotencyByPaymentId(paymentId))?.executionStatus).toBe("pending");
+  });
+
+  it("attaches stale-payment refunds to async jobs and excludes refunded jobs from payout recovery", async () => {
+    const networkConfig = resolveMarketplaceNetworkConfig({
+      deploymentNetwork: "testnet"
+    });
+    const store = new InMemoryMarketplaceStore(networkConfig);
+    const asyncRoute = buildMarketplaceRoutes(networkConfig).find((route) => route.routeId === "mock.async-report.v1");
+
+    if (!asyncRoute) {
+      throw new Error("Missing async seeded route.");
+    }
+
+    const buyerWallet = "fast1buyerrefundfence0000000000000000000000000000000000000000000";
+    const paymentId = "stale_payment_refund_fence_1";
+    const jobToken = "job_stale_refund_fence_1";
+
+    await store.claimPaymentExecution({
+      paymentId,
+      normalizedRequestHash: "stale-refund-fence-hash-1",
+      buyerWallet,
+      routeId: asyncRoute.routeId,
+      routeVersion: asyncRoute.version,
+      pendingRecoveryAction: "refund",
+      quotedPrice: "150000",
+      payoutSplit: buildEscrowSplit({
+        providerAccountId: "mock",
+        providerWallet: "fast1providerfence00000000000000000000000000000000000000000000",
+        marketplaceBps: 5000,
+        marketplaceAmount: "75000",
+        providerBps: 5000,
+        providerAmount: "75000"
+      }),
+      paymentPayload: "payload-refund-fence-1",
+      facilitatorResponse: { isValid: true },
+      responseKind: "job",
+      requestId: "request-refund-fence-1",
+      jobToken,
+      responseBody: { status: "processing" },
+      responseHeaders: {}
+    });
+
+    await store.savePendingAsyncJob({
+      jobToken,
+      paymentId,
+      buyerWallet,
+      route: {
+        ...asyncRoute,
+        executorKind: "http",
+        asyncConfig: {
+          strategy: "webhook",
+          timeoutMs: 60_000,
+          pollPath: null
+        }
+      },
+      quotedPrice: "150000",
+      payoutSplit: buildEscrowSplit({
+        providerAccountId: "mock",
+        providerWallet: "fast1providerfence00000000000000000000000000000000000000000000",
+        marketplaceBps: 5000,
+        marketplaceAmount: "75000",
+        providerBps: 5000,
+        providerAmount: "75000"
+      }),
+      serviceId: "service_refund_fence_1",
+      requestId: "request-refund-fence-1",
+      requestBody: { topic: "refund fence" },
+      nextPollAt: new Date(Date.now() + 60_000).toISOString(),
+      timeoutAt: null
+    });
+
+    const existingRefund = await store.createRefund({
+      paymentId,
+      wallet: buyerWallet,
+      amount: "150000"
+    });
+    await store.markRefundSent(existingRefund.id, "0xexisting-refund");
+
+    const idempotencyByPaymentId = (store as unknown as {
+      idempotencyByPaymentId: Map<string, {
+        updatedAt: string;
+      }>;
+    }).idempotencyByPaymentId;
+    const pending = idempotencyByPaymentId.get(paymentId);
+    if (!pending) {
+      throw new Error("Missing pending refund-fence payment record.");
+    }
+
+    idempotencyByPaymentId.set(paymentId, {
+      ...pending,
+      updatedAt: new Date(Date.now() - PAYMENT_EXECUTION_RECOVERY_MS - 1_000).toISOString()
+    });
+
+    let refundCalls = 0;
+
+    await runMarketplaceWorkerCycle({
+      store,
+      secretsKey: "test-secrets-key",
+      refundService: {
+        async issueRefund() {
+          refundCalls += 1;
+          return { txHash: "0xunexpected-refund" };
+        }
+      }
+    });
+
+    const attachedRefund = await store.getRefundByJobToken(jobToken);
+    const failedJob = await store.getJob(jobToken);
+
+    expect(refundCalls).toBe(0);
+    expect(attachedRefund?.id).toBe(existingRefund.id);
+    expect(attachedRefund?.status).toBe("sent");
+    expect(failedJob?.status).toBe("failed");
+    expect(failedJob?.refundStatus).toBe("sent");
+
+    await store.completeJob(jobToken, { late: true });
+
+    const payouts: Array<{ wallet: string; amount: string }> = [];
+
+    await runMarketplaceWorkerCycle({
+      store,
+      secretsKey: "test-secrets-key",
+      refundService: {
+        async issueRefund() {
+          return { txHash: "0xrefund" };
+        }
+      },
+      payoutService: {
+        async issuePayout({ wallet, amount }) {
+          payouts.push({ wallet, amount });
+          return { txHash: "0xpayout" };
+        }
+      }
+    });
+
+    expect(payouts).toEqual([]);
+  });
+
   it("refunds stale webhook placeholders when the provider never accepted the job", async () => {
     const networkConfig = resolveMarketplaceNetworkConfig({
       deploymentNetwork: "testnet"

--- a/apps/worker/src/worker.test.ts
+++ b/apps/worker/src/worker.test.ts
@@ -483,6 +483,117 @@ describe("marketplace worker", () => {
     expect((await store.getRefundByPaymentId("stale_payment_refund_1"))?.txHash).toBe("0xstale-refund");
   });
 
+  it("finalizes already-refunded stale payments so they do not starve later recovery work", async () => {
+    const store = new InMemoryMarketplaceStore();
+    const buyerWallet = "fast1buyerstalequeue000000000000000000000000000000000000000000000000";
+
+    await store.claimPaymentExecution({
+      paymentId: "stale_payment_already_refunded_1",
+      normalizedRequestHash: "stale-queue-hash-1",
+      buyerWallet,
+      routeId: "mock.quick-insight.v1",
+      routeVersion: "v1",
+      pendingRecoveryAction: "refund",
+      quotedPrice: "125000",
+      payoutSplit: buildEscrowSplit({
+        providerAccountId: "mock",
+        providerWallet: null,
+        marketplaceBps: 10000,
+        marketplaceAmount: "125000",
+        providerBps: 0,
+        providerAmount: "0"
+      }),
+      paymentPayload: "payload-stale-queue-1",
+      facilitatorResponse: { isValid: true },
+      responseKind: "sync",
+      requestId: "request-stale-queue-1",
+      responseHeaders: {}
+    });
+
+    const existingRefund = await store.createRefund({
+      paymentId: "stale_payment_already_refunded_1",
+      wallet: buyerWallet,
+      amount: "125000"
+    });
+    await store.markRefundSent(existingRefund.id, "0xexisting-refund");
+
+    await store.claimPaymentExecution({
+      paymentId: "stale_payment_waiting_behind_refund_1",
+      normalizedRequestHash: "stale-queue-hash-2",
+      buyerWallet,
+      routeId: "mock.quick-insight.v1",
+      routeVersion: "v1",
+      pendingRecoveryAction: "refund",
+      quotedPrice: "125000",
+      payoutSplit: buildEscrowSplit({
+        providerAccountId: "mock",
+        providerWallet: null,
+        marketplaceBps: 10000,
+        marketplaceAmount: "125000",
+        providerBps: 0,
+        providerAmount: "0"
+      }),
+      paymentPayload: "payload-stale-queue-2",
+      facilitatorResponse: { isValid: true },
+      responseKind: "sync",
+      requestId: "request-stale-queue-2",
+      responseHeaders: {}
+    });
+
+    const idempotencyByPaymentId = (store as unknown as {
+      idempotencyByPaymentId: Map<string, {
+        updatedAt: string;
+      }>;
+    }).idempotencyByPaymentId;
+
+    for (const [paymentId, offsetMs] of [
+      ["stale_payment_already_refunded_1", 2_000],
+      ["stale_payment_waiting_behind_refund_1", 1_000]
+    ] as const) {
+      const pending = idempotencyByPaymentId.get(paymentId);
+      if (!pending) {
+        throw new Error(`Missing stale payment record: ${paymentId}`);
+      }
+
+      idempotencyByPaymentId.set(paymentId, {
+        ...pending,
+        updatedAt: new Date(Date.now() - PAYMENT_EXECUTION_RECOVERY_MS - offsetMs).toISOString()
+      });
+    }
+
+    const refunds: Array<{ wallet: string; amount: string }> = [];
+
+    await runMarketplaceWorkerCycle({
+      store,
+      secretsKey: "test-secrets-key",
+      limit: 1,
+      refundService: {
+        async issueRefund({ wallet, amount }) {
+          refunds.push({ wallet, amount });
+          return { txHash: "0xnew-refund" };
+        }
+      }
+    });
+
+    expect((await store.getIdempotencyByPaymentId("stale_payment_already_refunded_1"))?.executionStatus).toBe("completed");
+    expect(refunds).toEqual([]);
+
+    await runMarketplaceWorkerCycle({
+      store,
+      secretsKey: "test-secrets-key",
+      limit: 1,
+      refundService: {
+        async issueRefund({ wallet, amount }) {
+          refunds.push({ wallet, amount });
+          return { txHash: "0xnew-refund" };
+        }
+      }
+    });
+
+    expect((await store.getRefundByPaymentId("stale_payment_waiting_behind_refund_1"))?.txHash).toBe("0xnew-refund");
+    expect(refunds).toEqual([{ wallet: buyerWallet, amount: "125000" }]);
+  });
+
   it("recovers stale accepted async poll payments from placeholder jobs without issuing a refund", async () => {
     const networkConfig = resolveMarketplaceNetworkConfig({
       deploymentNetwork: "testnet"
@@ -686,6 +797,20 @@ describe("marketplace worker", () => {
     });
 
     await store.failJob(jobToken, "Async route failed before acceptance.");
+    await store.recordProviderAttempt({
+      jobToken,
+      routeId: asyncRoute.routeId,
+      requestId: "request-preaccept-failure-1",
+      responseStatusCode: 502,
+      phase: "execute",
+      status: "failed",
+      requestPayload: { topic: "pre-accept failure" },
+      responsePayload: {
+        error: "upstream rejected",
+        details: "provider rejected request"
+      },
+      errorMessage: "Async route failed with status 502 before acceptance."
+    });
 
     const idempotencyByPaymentId = (store as unknown as {
       idempotencyByPaymentId: Map<string, {
@@ -720,8 +845,21 @@ describe("marketplace worker", () => {
     const job = await store.getJob(jobToken);
 
     expect(refundCalls).toBe(1);
-    expect(payment?.executionStatus).toBe("pending");
-    expect(payment?.responseKind).toBe("job");
+    expect(payment?.executionStatus).toBe("completed");
+    expect(payment?.responseKind).toBe("sync");
+    expect(payment?.responseStatusCode).toBe(502);
+    expect(payment?.responseBody).toEqual({
+      error: "Upstream request failed. Payment was refunded.",
+      upstreamStatus: 502,
+      upstreamBody: {
+        error: "upstream rejected",
+        details: "provider rejected request"
+      },
+      refund: {
+        status: "sent",
+        txHash: "0xpreaccept-refund"
+      }
+    });
     expect(refund?.status).toBe("sent");
     expect(job?.status).toBe("failed");
     expect(job?.providerJobId).toBeNull();
@@ -738,7 +876,7 @@ describe("marketplace worker", () => {
     });
 
     expect(refundCalls).toBe(1);
-    expect((await store.getIdempotencyByPaymentId(paymentId))?.executionStatus).toBe("pending");
+    expect((await store.getIdempotencyByPaymentId(paymentId))?.executionStatus).toBe("completed");
   });
 
   it("attaches stale-payment refunds to async jobs and excludes refunded jobs from payout recovery", async () => {

--- a/apps/worker/src/worker.test.ts
+++ b/apps/worker/src/worker.test.ts
@@ -879,6 +879,118 @@ describe("marketplace worker", () => {
     expect((await store.getIdempotencyByPaymentId(paymentId))?.executionStatus).toBe("completed");
   });
 
+  it("does not refund a stale async payment when the job completes during refund fencing", async () => {
+    class CompletionDuringFenceStore extends InMemoryMarketplaceStore {
+      override async failJob(jobToken: string, error: string) {
+        await super.completeJob(jobToken, { ok: true, source: "late-completion" });
+        return super.failJob(jobToken, error);
+      }
+    }
+
+    const networkConfig = resolveMarketplaceNetworkConfig({
+      deploymentNetwork: "testnet"
+    });
+    const store = new CompletionDuringFenceStore(networkConfig);
+    const asyncRoute = buildMarketplaceRoutes(networkConfig).find((route) => route.routeId === "mock.async-report.v1");
+
+    if (!asyncRoute) {
+      throw new Error("Missing async seeded route.");
+    }
+
+    const paymentId = "stale_payment_race_completion_1";
+    const jobToken = "job_stale_race_completion_1";
+    const buyerWallet = "fast1buyerracecomplete00000000000000000000000000000000000000000";
+
+    await store.claimPaymentExecution({
+      paymentId,
+      normalizedRequestHash: "stale-race-completion-hash-1",
+      buyerWallet,
+      routeId: asyncRoute.routeId,
+      routeVersion: asyncRoute.version,
+      pendingRecoveryAction: "refund",
+      quotedPrice: "150000",
+      payoutSplit: buildEscrowSplit({
+        providerAccountId: "mock",
+        providerWallet: "fast1providerracecomplete000000000000000000000000000000000000",
+        marketplaceBps: 5000,
+        marketplaceAmount: "75000",
+        providerBps: 5000,
+        providerAmount: "75000"
+      }),
+      paymentPayload: "payload-race-completion-1",
+      facilitatorResponse: { isValid: true },
+      responseKind: "job",
+      requestId: "request-race-completion-1",
+      jobToken,
+      responseBody: { status: "processing" },
+      responseHeaders: {}
+    });
+
+    await store.savePendingAsyncJob({
+      jobToken,
+      paymentId,
+      buyerWallet,
+      route: {
+        ...asyncRoute,
+        executorKind: "http",
+        asyncConfig: {
+          strategy: "poll",
+          timeoutMs: 60_000,
+          pollPath: "/api/poll"
+        }
+      },
+      quotedPrice: "150000",
+      payoutSplit: buildEscrowSplit({
+        providerAccountId: "mock",
+        providerWallet: "fast1providerracecomplete000000000000000000000000000000000000",
+        marketplaceBps: 5000,
+        marketplaceAmount: "75000",
+        providerBps: 5000,
+        providerAmount: "75000"
+      }),
+      serviceId: "service_race_completion_1",
+      requestId: "request-race-completion-1",
+      requestBody: { topic: "late completion" },
+      nextPollAt: null,
+      timeoutAt: null
+    });
+
+    const idempotencyByPaymentId = (store as unknown as {
+      idempotencyByPaymentId: Map<string, { updatedAt: string }>;
+    }).idempotencyByPaymentId;
+    const pending = idempotencyByPaymentId.get(paymentId);
+    if (!pending) {
+      throw new Error("Missing pending payment record.");
+    }
+
+    idempotencyByPaymentId.set(paymentId, {
+      ...pending,
+      updatedAt: new Date(Date.now() - PAYMENT_EXECUTION_RECOVERY_MS - 1_000).toISOString()
+    });
+
+    let refundCalls = 0;
+    await runMarketplaceWorkerCycle({
+      store,
+      secretsKey: "test-secrets-key",
+      refundService: {
+        async issueRefund() {
+          refundCalls += 1;
+          return { txHash: "0xunexpected-race-refund" };
+        }
+      }
+    });
+
+    const payment = await store.getIdempotencyByPaymentId(paymentId);
+    const refund = await store.getRefundByPaymentId(paymentId);
+    const job = await store.getJob(jobToken);
+
+    expect(refundCalls).toBe(0);
+    expect(refund).toBeNull();
+    expect(job?.status).toBe("completed");
+    expect(payment?.executionStatus).toBe("completed");
+    expect(payment?.responseKind).toBe("job");
+  });
+
   it("attaches stale-payment refunds to async jobs and excludes refunded jobs from payout recovery", async () => {
     const networkConfig = resolveMarketplaceNetworkConfig({
       deploymentNetwork: "testnet"
@@ -1259,6 +1371,80 @@ describe("marketplace worker", () => {
     expect(job?.providerJobId).toBeNull();
     expect(job?.nextPollAt).not.toBeNull();
     expect(refundCalls).toBe(0);
+  });
+
+  it("fails stale wallet-session async placeholders that never reach acceptance", async () => {
+    const networkConfig = resolveMarketplaceNetworkConfig({
+      deploymentNetwork: "testnet"
+    });
+    const store = new InMemoryMarketplaceStore(networkConfig);
+    const asyncRoute = buildMarketplaceRoutes(networkConfig).find((route) => route.routeId === "mock.async-report.v1");
+
+    if (!asyncRoute) {
+      throw new Error("Missing async seeded route.");
+    }
+
+    await store.savePendingAsyncJob({
+      jobToken: "job_wallet_placeholder_stale_1",
+      paymentId: "wallet_access_stale_1",
+      buyerWallet: "fast1buyerwalletstale000000000000000000000000000000000000000000",
+      route: {
+        ...asyncRoute,
+        billing: { type: "free" },
+        price: "Free",
+        executorKind: "http",
+        asyncConfig: {
+          strategy: "poll",
+          timeoutMs: 60_000,
+          pollPath: "/api/poll"
+        }
+      },
+      quotedPrice: "0",
+      payoutSplit: buildEscrowSplit({
+        providerAccountId: "mock",
+        providerWallet: null,
+        marketplaceBps: 10000,
+        marketplaceAmount: "0",
+        providerBps: 0,
+        providerAmount: "0"
+      }),
+      serviceId: "service_wallet_placeholder_stale_1",
+      requestId: "request_wallet_placeholder_stale_1",
+      requestBody: { topic: "wallet placeholder" },
+      nextPollAt: new Date(Date.now() - 1_000).toISOString(),
+      timeoutAt: null
+    });
+
+    const jobsByToken = (store as unknown as {
+      jobsByToken: Map<string, { createdAt: string; updatedAt: string }>;
+    }).jobsByToken;
+    const existing = jobsByToken.get("job_wallet_placeholder_stale_1");
+    if (!existing) {
+      throw new Error("Missing wallet placeholder job.");
+    }
+    jobsByToken.set("job_wallet_placeholder_stale_1", {
+      ...existing,
+      createdAt: new Date(Date.now() - PAYMENT_EXECUTION_RECOVERY_MS - 1_000).toISOString(),
+      updatedAt: new Date(Date.now() - PAYMENT_EXECUTION_RECOVERY_MS - 1_000).toISOString()
+    });
+
+    let refundCalls = 0;
+    await runMarketplaceWorkerCycle({
+      store,
+      secretsKey: "test-secrets-key",
+      refundService: {
+        async issueRefund() {
+          refundCalls += 1;
+          return { txHash: "0xwallet-placeholder-refund" };
+        }
+      }
+    });
+
+    const job = await store.getJob("job_wallet_placeholder_stale_1");
+    expect(job?.status).toBe("failed");
+    expect(job?.errorMessage).toContain("never accepted upstream");
+    expect(refundCalls).toBe(0);
+    expect(await store.getRefundByJobToken("job_wallet_placeholder_stale_1")).toBeNull();
   });
 
   it("prioritizes accepted due poll jobs ahead of older pre-accept placeholders", async () => {

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -14,6 +14,7 @@ import {
   type MarketplaceStore,
   type PollResult,
   type PayoutService,
+  type ProviderAttemptRecord,
   type ProviderRegistry,
   type RefundService,
   type UpstreamAuthMode
@@ -221,15 +222,16 @@ export async function runMarketplaceWorkerCycle(options: MarketplaceWorkerOption
 
 async function recoverAcceptedAsyncPlaceholder(
   store: MarketplaceStore,
-  job: JobRecord
+  job: JobRecord,
+  attempt?: ProviderAttemptRecord | null
 ): Promise<JobRecord | null> {
-  const attempt = await store.getLatestSuccessfulProviderExecuteAttempt(job.jobToken);
-  const accepted = parseAcceptedAsyncExecuteAttempt(attempt?.responsePayload);
+  const resolvedAttempt = attempt ?? await store.getLatestSuccessfulProviderExecuteAttempt(job.jobToken);
+  const accepted = parseAcceptedAsyncExecuteAttempt(resolvedAttempt?.responsePayload);
   if (!accepted) {
     return null;
   }
 
-  const acceptedAt = parseAttemptCreatedAt(attempt?.createdAt);
+  const acceptedAt = parseAttemptCreatedAt(resolvedAttempt?.createdAt);
   const nextPollAt = job.routeSnapshot.asyncConfig?.strategy === "poll"
     ? computeNextPollAt(accepted.pollAfterMs, acceptedAt)
     : null;
@@ -522,9 +524,13 @@ function buildRecoveredAsyncJobResponse(job: JobRecord, now: Date = new Date()):
   return response;
 }
 
-function canRecoverPendingJobExecution(job: JobRecord): boolean {
-  return job.status !== "pending"
-    || Boolean(job.providerJobId);
+function canRecoverPendingJobExecution(
+  job: JobRecord,
+  acceptedExecuteAttempt: ProviderAttemptRecord | null
+): boolean {
+  return job.status === "completed"
+    || Boolean(job.providerJobId)
+    || Boolean(parseAcceptedAsyncExecuteAttempt(acceptedExecuteAttempt?.responsePayload));
 }
 
 async function recoverStalePendingPayments(input: {
@@ -540,9 +546,19 @@ async function recoverStalePendingPayments(input: {
       continue;
     }
 
+    let job: JobRecord | null = null;
+    let acceptedExecuteAttempt: ProviderAttemptRecord | null = null;
     if (payment.responseKind === "job" && payment.jobToken) {
-      const job = await input.store.getJob(payment.jobToken);
-      if (job && canRecoverPendingJobExecution(job)) {
+      job = await input.store.getJob(payment.jobToken);
+      if (job && !job.providerJobId) {
+        acceptedExecuteAttempt = await input.store.getLatestSuccessfulProviderExecuteAttempt(job.jobToken);
+        const repairedJob = await recoverAcceptedAsyncPlaceholder(input.store, job, acceptedExecuteAttempt);
+        if (repairedJob) {
+          job = repairedJob;
+        }
+      }
+
+      if (job && canRecoverPendingJobExecution(job, acceptedExecuteAttempt)) {
         await input.store.completePendingJobExecution({
           paymentId: payment.paymentId,
           jobToken: job.jobToken,
@@ -553,16 +569,20 @@ async function recoverStalePendingPayments(input: {
       }
     }
 
-    const existingRefund = await input.store.getRefundByPaymentId(payment.paymentId);
-    if (existingRefund?.status === "sent") {
-      continue;
-    }
-
-    const refund = existingRefund ?? await input.store.createRefund({
+    const refund = await input.store.createRefund({
+      jobToken: payment.jobToken ?? undefined,
       paymentId: payment.paymentId,
       wallet: payment.buyerWallet,
       amount: payment.quotedPrice
     });
+
+    if (job) {
+      await fenceRefundedAsyncJob(input.store, payment.paymentId, job);
+    }
+
+    if (refund.status === "sent") {
+      continue;
+    }
 
     try {
       const receipt = await input.refundService.issueRefund({
@@ -576,6 +596,21 @@ async function recoverStalePendingPayments(input: {
       await input.store.markRefundFailed(refund.id, message);
     }
   }
+}
+
+async function fenceRefundedAsyncJob(
+  store: MarketplaceStore,
+  paymentId: string,
+  job: JobRecord
+) {
+  if (job.status !== "pending") {
+    return job;
+  }
+
+  return store.failJob(
+    job.jobToken,
+    `Automatic recovery refund started for unresolved paid request ${paymentId}.`
+  );
 }
 
 async function backfillProviderPayouts(input: {

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -45,6 +45,25 @@ export async function runMarketplaceWorkerCycle(options: MarketplaceWorkerOption
     if (!currentJob.providerJobId) {
       const repairedJob = await recoverAcceptedAsyncPlaceholder(options.store, currentJob);
       if (!repairedJob) {
+        if (isExpiredUnacceptedPlaceholder(currentJob, nowMs)) {
+          await options.store.recordProviderAttempt({
+            jobToken: currentJob.jobToken,
+            routeId: currentJob.routeId,
+            requestId: currentJob.requestId,
+            phase: "poll",
+            status: "failed",
+            requestPayload: currentJob.requestBody,
+            errorMessage: `Async job was never accepted upstream: ${currentJob.jobToken}`
+          });
+          await expireAsyncPrepaidReservation(options.store, currentJob);
+          await resolveAsyncJobFailure({
+            store: options.store,
+            refundService: options.refundService,
+            job: currentJob,
+            error: `Async job was never accepted upstream for ${currentJob.routeId}.`
+          });
+          continue;
+        }
         await backoffUnacceptedPlaceholder(options.store, currentJob);
         continue;
       }
@@ -260,6 +279,11 @@ async function backoffUnacceptedPlaceholder(store: MarketplaceStore, job: JobRec
     jobToken: job.jobToken,
     nextPollAt: computeNextPollAt()
   });
+}
+
+function isExpiredUnacceptedPlaceholder(job: JobRecord, nowMs: number): boolean {
+  const createdAtMs = Date.parse(job.createdAt);
+  return !Number.isNaN(createdAtMs) && createdAtMs <= nowMs - PAYMENT_EXECUTION_RECOVERY_MS;
 }
 
 function parseAttemptCreatedAt(createdAt: string | undefined): Date {
@@ -575,16 +599,25 @@ async function recoverStalePendingPayments(input: {
       }
     }
 
+    if (job) {
+      job = await fenceRefundedAsyncJob(input.store, payment.paymentId, job);
+      if (canRecoverPendingJobExecution(job, acceptedExecuteAttempt)) {
+        await input.store.completePendingJobExecution({
+          paymentId: payment.paymentId,
+          jobToken: job.jobToken,
+          responseBody: buildRecoveredAsyncJobResponse(job),
+          responseHeaders: payment.responseHeaders
+        });
+        continue;
+      }
+    }
+
     const refund = await input.store.createRefund({
       jobToken: payment.jobToken ?? undefined,
       paymentId: payment.paymentId,
       wallet: payment.buyerWallet,
       amount: payment.quotedPrice
     });
-
-    if (job) {
-      await fenceRefundedAsyncJob(input.store, payment.paymentId, job);
-    }
 
     if (refund.status === "sent" || refund.status === "failed") {
       await finalizeRecoveredRefundedPayment(input.store, payment, refund, latestExecuteAttempt);
@@ -612,10 +645,6 @@ async function fenceRefundedAsyncJob(
   paymentId: string,
   job: JobRecord
 ) {
-  if (job.status !== "pending") {
-    return job;
-  }
-
   return store.failJob(
     job.jobToken,
     `Automatic recovery refund started for unresolved paid request ${paymentId}.`

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -10,12 +10,14 @@ import {
   isPrepaidCreditBilling,
   resolveAsyncJobFailure,
   type AsyncExecuteResult,
+  type IdempotencyRecord,
   type JobRecord,
   type MarketplaceStore,
   type PollResult,
   type PayoutService,
   type ProviderAttemptRecord,
   type ProviderRegistry,
+  type RefundRecord,
   type RefundService,
   type UpstreamAuthMode
 } from "@marketplace/shared";
@@ -548,10 +550,14 @@ async function recoverStalePendingPayments(input: {
 
     let job: JobRecord | null = null;
     let acceptedExecuteAttempt: ProviderAttemptRecord | null = null;
+    let latestExecuteAttempt: ProviderAttemptRecord | null = null;
     if (payment.responseKind === "job" && payment.jobToken) {
       job = await input.store.getJob(payment.jobToken);
+      latestExecuteAttempt = await input.store.getLatestProviderExecuteAttempt(payment.jobToken);
       if (job && !job.providerJobId) {
-        acceptedExecuteAttempt = await input.store.getLatestSuccessfulProviderExecuteAttempt(job.jobToken);
+        acceptedExecuteAttempt = latestExecuteAttempt?.status === "succeeded"
+          ? latestExecuteAttempt
+          : await input.store.getLatestSuccessfulProviderExecuteAttempt(job.jobToken);
         const repairedJob = await recoverAcceptedAsyncPlaceholder(input.store, job, acceptedExecuteAttempt);
         if (repairedJob) {
           job = repairedJob;
@@ -580,7 +586,8 @@ async function recoverStalePendingPayments(input: {
       await fenceRefundedAsyncJob(input.store, payment.paymentId, job);
     }
 
-    if (refund.status === "sent") {
+    if (refund.status === "sent" || refund.status === "failed") {
+      await finalizeRecoveredRefundedPayment(input.store, payment, refund, latestExecuteAttempt);
       continue;
     }
 
@@ -590,10 +597,12 @@ async function recoverStalePendingPayments(input: {
         amount: payment.quotedPrice,
         reason: `Automatic recovery refund for unresolved paid request ${payment.paymentId}.`
       });
-      await input.store.markRefundSent(refund.id, receipt.txHash);
+      const sentRefund = await input.store.markRefundSent(refund.id, receipt.txHash);
+      await finalizeRecoveredRefundedPayment(input.store, payment, sentRefund, latestExecuteAttempt);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown refund failure.";
-      await input.store.markRefundFailed(refund.id, message);
+      const failedRefund = await input.store.markRefundFailed(refund.id, message);
+      await finalizeRecoveredRefundedPayment(input.store, payment, failedRefund, latestExecuteAttempt);
     }
   }
 }
@@ -611,6 +620,110 @@ async function fenceRefundedAsyncJob(
     job.jobToken,
     `Automatic recovery refund started for unresolved paid request ${paymentId}.`
   );
+}
+
+async function finalizeRecoveredRefundedPayment(
+  store: MarketplaceStore,
+  payment: IdempotencyRecord,
+  refund: RefundRecord,
+  executeAttempt: ProviderAttemptRecord | null
+) {
+  const failure = buildRecoveredRefundFailureResponse(refund, executeAttempt);
+  await store.saveSyncIdempotency({
+    paymentId: payment.paymentId,
+    normalizedRequestHash: payment.normalizedRequestHash,
+    buyerWallet: payment.buyerWallet,
+    routeId: payment.routeId,
+    routeVersion: payment.routeVersion,
+    quotedPrice: payment.quotedPrice,
+    payoutSplit: payment.payoutSplit,
+    paymentPayload: payment.paymentPayload,
+    facilitatorResponse: payment.facilitatorResponse,
+    statusCode: failure.statusCode,
+    body: failure.body,
+    headers: failure.headers,
+    requestId: payment.requestId ?? undefined
+  });
+}
+
+function buildRecoveredRefundFailureResponse(
+  refund: RefundRecord,
+  executeAttempt: ProviderAttemptRecord | null
+): {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+} {
+  const hasFailedExecuteAttempt = executeAttempt?.status === "failed";
+  const upstreamStatus = executeAttempt?.responseStatusCode ?? 500;
+  const upstreamBody = executeAttempt?.responsePayload
+    ?? (executeAttempt?.errorMessage ? { error: executeAttempt.errorMessage } : { error: "Upstream request failed." });
+
+  if (!hasFailedExecuteAttempt) {
+    if (refund.status === "sent") {
+      return {
+        statusCode: 500,
+        headers: {
+          "content-type": "application/json"
+        },
+        body: {
+          error: "Request outcome was not durably recorded. Payment was refunded.",
+          refund: {
+            status: refund.status,
+            txHash: refund.txHash
+          }
+        }
+      };
+    }
+
+    return {
+      statusCode: 500,
+      headers: {
+        "content-type": "application/json"
+      },
+      body: {
+        error: "Request outcome was not durably recorded and the automatic refund did not complete.",
+        refund: {
+          status: refund.status,
+          error: refund.errorMessage
+        }
+      }
+    };
+  }
+
+  if (refund.status === "sent") {
+    return {
+      statusCode: upstreamStatus,
+      headers: {
+        "content-type": "application/json"
+      },
+      body: {
+        error: "Upstream request failed. Payment was refunded.",
+        upstreamStatus,
+        upstreamBody,
+        refund: {
+          status: refund.status,
+          txHash: refund.txHash
+        }
+      }
+    };
+  }
+
+  return {
+    statusCode: upstreamStatus,
+    headers: {
+      "content-type": "application/json"
+    },
+    body: {
+      error: "Upstream request failed and the automatic refund did not complete.",
+      upstreamStatus,
+      upstreamBody,
+      refund: {
+        status: refund.status,
+        error: refund.errorMessage
+      }
+    }
+  };
 }
 
 async function backfillProviderPayouts(input: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,12 @@
         "@marketplace/shared": "*"
       }
     },
+    "apps/apify-service": {
+      "name": "@marketplace/apify-service",
+      "dependencies": {
+        "express": "^4.21.2"
+      }
+    },
     "apps/facilitator": {
       "name": "@marketplace/facilitator"
     },
@@ -1348,6 +1354,10 @@
     },
     "node_modules/@marketplace/api": {
       "resolved": "apps/api",
+      "link": true
+    },
+    "node_modules/@marketplace/apify-service": {
+      "resolved": "apps/apify-service",
       "link": true
     },
     "node_modules/@marketplace/cli": {

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -733,7 +733,7 @@ describe("shared marketplace helpers", () => {
     expect((await store.listProviderRequests("fast1providerwallet000000000000000000000000000000000000000000000000")).length).toBe(0);
   });
 
-  it("deduplicates refunds by payment id in the in-memory store", async () => {
+  it("deduplicates refunds by payment id and attaches the job token in the in-memory store", async () => {
     const store = new InMemoryMarketplaceStore();
 
     const first = await store.createRefund({
@@ -751,7 +751,55 @@ describe("shared marketplace helpers", () => {
 
     expect(second.id).toBe(first.id);
     expect(second.paymentId).toBe(first.paymentId);
-    expect(second.jobToken).toBeNull();
+    expect(second.jobToken).toBe("job_refund_1");
+  });
+
+  it("does not backfill provider payouts for refunded completed jobs", async () => {
+    const store = new InMemoryMarketplaceStore(TESTNET_NETWORK_CONFIG);
+    const asyncRoute = TESTNET_MARKETPLACE_ROUTES.find((route) => route.routeId === "mock.async-report.v1");
+
+    if (!asyncRoute) {
+      throw new Error("Missing async seeded route.");
+    }
+
+    await store.saveAsyncAcceptance({
+      paymentId: "payment_refunded_completed_job_1",
+      normalizedRequestHash: "hash-refunded-completed-job-1",
+      buyerWallet: "fast1buyerrefundedcompleted000000000000000000000000000000000000000",
+      route: asyncRoute,
+      quotedPrice: "150000",
+      payoutSplit: buildEscrowSplit({
+        providerAccountId: "mock",
+        providerWallet: "fast1providerrefundedcompleted0000000000000000000000000000000000000",
+        marketplaceBps: 5000,
+        marketplaceAmount: "75000",
+        providerBps: 5000,
+        providerAmount: "75000"
+      }),
+      paymentPayload: "payload-refunded-completed-job-1",
+      facilitatorResponse: { isValid: true },
+      jobToken: "job_refunded_completed_1",
+      requestId: "request_refunded_completed_1",
+      providerJobId: "provider_refunded_completed_1",
+      requestBody: { topic: "refunded completed" },
+      providerState: { step: "done" },
+      responseBody: {
+        jobToken: "job_refunded_completed_1",
+        status: "pending"
+      },
+      responseHeaders: {}
+    });
+
+    await store.completeJob("job_refunded_completed_1", { ok: true });
+    const refund = await store.createRefund({
+      jobToken: "job_refunded_completed_1",
+      paymentId: "payment_refunded_completed_job_1",
+      wallet: "fast1buyerrefundedcompleted000000000000000000000000000000000000000",
+      amount: "150000"
+    });
+    await store.markRefundSent(refund.id, "0xrefunded-completed");
+
+    expect(await store.listRecoverableProviderPayouts(10)).toEqual([]);
   });
 
   it("resets async job timeout metadata when acceptance is persisted after a placeholder", async () => {

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -921,6 +921,81 @@ describe("shared marketplace helpers", () => {
     expect(job?.timeoutAt).toBe("2026-03-20T00:10:00.000Z");
   });
 
+  it("does not overwrite terminal async jobs when duplicate terminal updates race", async () => {
+    const store = new InMemoryMarketplaceStore(TESTNET_NETWORK_CONFIG);
+    const asyncRoute = TESTNET_MARKETPLACE_ROUTES.find((route) => route.routeId === "mock.async-report.v1");
+
+    if (!asyncRoute) {
+      throw new Error("Missing async seeded route.");
+    }
+
+    await store.saveAsyncAcceptance({
+      paymentId: "payment_terminal_sticky_1",
+      normalizedRequestHash: "hash_terminal_sticky_1",
+      buyerWallet: "fast1buyerterminalsticky0000000000000000000000000000000000000000",
+      route: asyncRoute,
+      quotedPrice: "150000",
+      payoutSplit: buildEscrowSplit({
+        providerAccountId: "mock",
+        providerWallet: null,
+        marketplaceBps: 10000,
+        marketplaceAmount: "150000",
+        providerBps: 0,
+        providerAmount: "0"
+      }),
+      paymentPayload: "payload-terminal-sticky-1",
+      facilitatorResponse: { isValid: true },
+      jobToken: "job_terminal_sticky_1",
+      requestId: "request_terminal_sticky_1",
+      providerJobId: "provider_terminal_sticky_1",
+      requestBody: { topic: "terminal sticky" },
+      responseBody: {
+        jobToken: "job_terminal_sticky_1",
+        status: "pending"
+      },
+      responseHeaders: {}
+    });
+
+    await store.completeJob("job_terminal_sticky_1", { ok: true });
+    const stillCompleted = await store.failJob("job_terminal_sticky_1", "late failure should not overwrite");
+    expect(stillCompleted.status).toBe("completed");
+    expect(stillCompleted.resultBody).toEqual({ ok: true });
+    expect(stillCompleted.errorMessage).toBeNull();
+
+    await store.saveAsyncAcceptance({
+      paymentId: "payment_terminal_sticky_2",
+      normalizedRequestHash: "hash_terminal_sticky_2",
+      buyerWallet: "fast1buyerterminalsticky200000000000000000000000000000000000000",
+      route: asyncRoute,
+      quotedPrice: "150000",
+      payoutSplit: buildEscrowSplit({
+        providerAccountId: "mock",
+        providerWallet: null,
+        marketplaceBps: 10000,
+        marketplaceAmount: "150000",
+        providerBps: 0,
+        providerAmount: "0"
+      }),
+      paymentPayload: "payload-terminal-sticky-2",
+      facilitatorResponse: { isValid: true },
+      jobToken: "job_terminal_sticky_2",
+      requestId: "request_terminal_sticky_2",
+      providerJobId: "provider_terminal_sticky_2",
+      requestBody: { topic: "terminal sticky" },
+      responseBody: {
+        jobToken: "job_terminal_sticky_2",
+        status: "pending"
+      },
+      responseHeaders: {}
+    });
+
+    await store.failJob("job_terminal_sticky_2", "permanent failure");
+    const stillFailed = await store.completeJob("job_terminal_sticky_2", { ok: true });
+    expect(stillFailed.status).toBe("failed");
+    expect(stillFailed.errorMessage).toBe("permanent failure");
+    expect(stillFailed.resultBody).toBeNull();
+  });
+
   it("tracks prepaid credit balances across topup, reserve, capture, release, and expiry", async () => {
     const store = new InMemoryMarketplaceStore();
     const serviceId = "service_credit_1";

--- a/packages/shared/src/store.ts
+++ b/packages/shared/src/store.ts
@@ -1159,6 +1159,33 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
     const existing = this.refundsByPaymentId.get(input.paymentId)
       ?? (input.jobToken ? this.refundsByJobToken.get(input.jobToken) : undefined);
     if (existing) {
+      if (input.jobToken && existing.jobToken && existing.jobToken !== input.jobToken) {
+        throw new Error("Refund paymentId and jobToken reference different jobs.");
+      }
+
+      if (input.jobToken && !existing.jobToken) {
+        const updated: RefundRecord = {
+          ...existing,
+          jobToken: input.jobToken,
+          updatedAt: timestamp()
+        };
+        this.refundsById.set(updated.id, updated);
+        this.refundsByPaymentId.set(updated.paymentId, updated);
+        this.refundsByJobToken.set(input.jobToken, updated);
+
+        const job = this.jobsByToken.get(input.jobToken);
+        if (job) {
+          this.jobsByToken.set(input.jobToken, {
+            ...job,
+            refundStatus: updated.status,
+            refundId: updated.id,
+            updatedAt: timestamp()
+          });
+        }
+
+        return clone(updated);
+      }
+
       return clone(existing);
     }
 
@@ -1355,6 +1382,7 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
 
       if (
         job.status !== "completed"
+        || job.refundStatus !== "not_required"
         || !job.payoutSplit.usesTreasurySettlement
         || !job.payoutSplit.providerWallet
         || BigInt(job.payoutSplit.providerAmount) <= 0n
@@ -5147,7 +5175,35 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       [input.paymentId, jobToken]
     );
     if (existingResult.rowCount) {
-      return mapRefundRow(existingResult.rows[0]);
+      const existing = mapRefundRow(existingResult.rows[0]);
+      if (jobToken && existing.jobToken && existing.jobToken !== jobToken) {
+        throw new Error("Refund paymentId and jobToken reference different jobs.");
+      }
+
+      if (jobToken && !existing.jobToken) {
+        const result = await this.pool.query(
+          `
+          UPDATE refunds
+          SET job_token = $2, updated_at = NOW()
+          WHERE id = $1
+            AND job_token IS NULL
+          RETURNING *
+          `,
+          [existing.id, jobToken]
+        );
+        const updated = mapRefundRow(result.rows[0] ?? existingResult.rows[0]);
+        await this.pool.query(
+          `
+          UPDATE jobs
+          SET refund_status = $2, refund_id = $3, updated_at = NOW()
+          WHERE job_token = $1
+          `,
+          [jobToken, updated.status, updated.id]
+        );
+        return updated;
+      }
+
+      return existing;
     }
 
     const result = await this.pool.query(
@@ -5314,6 +5370,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         payout_split->>'providerAmount' AS amount
       FROM jobs
       WHERE status = 'completed'
+        AND refund_status = 'not_required'
         AND COALESCE((payout_split->>'usesTreasurySettlement')::boolean, TRUE)
         AND COALESCE(payout_split->>'providerWallet', '') <> ''
         AND (payout_split->>'providerAmount')::numeric > 0

--- a/packages/shared/src/store.ts
+++ b/packages/shared/src/store.ts
@@ -1046,6 +1046,10 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
       throw new Error(`Job not found: ${jobToken}`);
     }
 
+    if (existing.status !== "pending") {
+      return clone(existing);
+    }
+
     const updated: JobRecord = {
       ...existing,
       status: "completed",
@@ -1063,6 +1067,10 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
     const existing = this.jobsByToken.get(jobToken);
     if (!existing) {
       throw new Error(`Job not found: ${jobToken}`);
+    }
+
+    if (existing.status !== "pending") {
+      return clone(existing);
     }
 
     const updated: JobRecord = {
@@ -5055,10 +5063,18 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
   async completeJob(jobToken: string, body: unknown): Promise<JobRecord> {
     const result = await this.pool.query(
       `
-      UPDATE jobs
-      SET status = 'completed', result_body = $2::jsonb, error_message = NULL, next_poll_at = NULL, updated_at = NOW()
+      WITH updated AS (
+        UPDATE jobs
+        SET status = 'completed', result_body = $2::jsonb, error_message = NULL, next_poll_at = NULL, updated_at = NOW()
+        WHERE job_token = $1
+          AND status = 'pending'
+        RETURNING *
+      )
+      SELECT * FROM updated
+      UNION ALL
+      SELECT * FROM jobs
       WHERE job_token = $1
-      RETURNING *
+        AND NOT EXISTS (SELECT 1 FROM updated)
       `,
       [jobToken, JSON.stringify(body)]
     );
@@ -5069,10 +5085,18 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
   async failJob(jobToken: string, error: string): Promise<JobRecord> {
     const result = await this.pool.query(
       `
-      UPDATE jobs
-      SET status = 'failed', error_message = $2, next_poll_at = NULL, updated_at = NOW()
+      WITH updated AS (
+        UPDATE jobs
+        SET status = 'failed', error_message = $2, next_poll_at = NULL, updated_at = NOW()
+        WHERE job_token = $1
+          AND status = 'pending'
+        RETURNING *
+      )
+      SELECT * FROM updated
+      UNION ALL
+      SELECT * FROM jobs
       WHERE job_token = $1
-      RETURNING *
+        AND NOT EXISTS (SELECT 1 FROM updated)
       `,
       [jobToken, error]
     );

--- a/packages/shared/src/store.ts
+++ b/packages/shared/src/store.ts
@@ -1150,6 +1150,18 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
     );
   }
 
+  async getLatestProviderExecuteAttempt(jobToken: string): Promise<ProviderAttemptRecord | null> {
+    return clone(
+      [...this.attempts]
+        .filter((attempt) =>
+          attempt.jobToken === jobToken
+          && attempt.phase === "execute"
+        )
+        .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0]
+        ?? null
+    );
+  }
+
   async createRefund(input: {
     jobToken?: string | null;
     paymentId: string;
@@ -5147,6 +5159,22 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       WHERE job_token = $1
         AND phase = 'execute'
         AND status = 'succeeded'
+      ORDER BY created_at DESC
+      LIMIT 1
+      `,
+      [jobToken]
+    );
+
+    return result.rowCount ? mapAttemptRow(result.rows[0]) : null;
+  }
+
+  async getLatestProviderExecuteAttempt(jobToken: string): Promise<ProviderAttemptRecord | null> {
+    const result = await this.pool.query(
+      `
+      SELECT *
+      FROM provider_attempts
+      WHERE job_token = $1
+        AND phase = 'execute'
       ORDER BY created_at DESC
       LIMIT 1
       `,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1033,6 +1033,7 @@ export interface MarketplaceStore {
     responsePayload?: unknown;
     errorMessage?: string;
   }): Promise<ProviderAttemptRecord>;
+  getLatestProviderExecuteAttempt(jobToken: string): Promise<ProviderAttemptRecord | null>;
   getLatestSuccessfulProviderExecuteAttempt(jobToken: string): Promise<ProviderAttemptRecord | null>;
   createRefund(input: {
     jobToken?: string | null;


### PR DESCRIPTION
## Summary
- fix stale-payment recovery so only actually accepted async executions are replayed as job responses
- bind stale-payment refunds to async job tokens, fail refunded placeholders, and prevent refunded jobs from re-entering payout recovery
- add regressions for pre-accept async failures, refund fencing, refund attachment, and refunded-job payout exclusion

## Verification
- npm run build
- npm test

## Context
Follow-up to merged PR #11. GitHub does not allow reopening a merged PR, so this uses the same branch for the post-merge fixes.