### PR TITLE
Implement discovery-first marketplace CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Fast-native data marketplace using [`@fastxyz/sdk`](https://www.npmjs.com/packag
 - `apps/facilitator`: x402 facilitator service used for payment verification
 - `apps/tavily-service`: optional standalone Tavily-backed provider example that can be onboarded through the website like any other provider service. See [`apps/tavily-service/README.md`](./apps/tavily-service/README.md)
 - `packages/shared`: source of truth for shared contracts, route registry, catalog/docs generation, auth, billing, payout logic, and store behavior
-- `packages/cli`: buyer and provider CLI for wallet setup, x402 calls, provider draft sync/verification/submission, prepaid-credit flows, API sessions, and job retrieval
+- `packages/cli`: buyer and provider CLI for discovery-first marketplace search/show/use flows, wallet setup, provider draft sync/verification/submission, and job retrieval
 
 ## Billing Model
 
@@ -182,19 +182,16 @@ This service is not wired into `apps/api`. To use it, create a `marketplace_prox
 
 ```bash
 npm run cli -- wallet init
-npm run cli -- wallet address
-npm run cli -- invoke mock quick-insight --body '{"query":"alpha"}'
+npm run cli -- search "quick insight"
+npm run cli -- show mock-research-signals
+npm run cli -- show mock.quick-insight
+npm run cli -- use mock.quick-insight --input '{"query":"alpha"}'
+npm run cli -- job get <jobToken>
 ```
 
-The CLI currently uses `@fastxyz/x402-client@^0.1.2` and calls `x402Pay` for payable routes.
+The buyer CLI is discovery-first. `search` and `show` only consume machine-readable catalog APIs, and `use` fetches route detail first before executing through the existing x402 or wallet-session flow. Payable routes still use `@fastxyz/x402-client@^0.1.2` under the hood.
 
-For prepaid-credit routes, and for async free routes that require wallet-session auth, the CLI can mint an API-scoped wallet session automatically when the route responds with auth requirements instead of `402`. You can also create that session explicitly:
-
-```bash
-npm run cli -- auth api-session <provider> <operation>
-```
-
-For provider-authored top-up routes, call the route with an amount in the request body. For prepaid-credit routes, fund credit first, then call the prepaid route with the same `invoke` command; the CLI will switch to wallet-session auth when needed. Async free routes also use wallet-session auth and return a `jobToken` for `GET /api/jobs/:jobToken`.
+For provider-authored top-up routes, pass the amount in `--input`. For prepaid-credit routes, fund credit first and then call the prepaid route with `use`; the CLI will mint a route-scoped wallet session automatically when the route requires bearer auth. Async free routes also use wallet-session auth and return a `jobToken` for `job get`.
 
 Async retrieval uses a second wallet challenge flow scoped to the `jobToken`. Poll `GET /api/jobs/:jobToken` with `Authorization: Bearer <accessToken>` from the same wallet that paid for or authorized the original trigger. The default poll interval is `5000` ms.
 

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -186,7 +186,7 @@ describe("marketplace api", () => {
       summary: {
         slug: "mock-research-signals"
       },
-      routeRefs: ["mock.quick-insight", "mock.async-report"]
+      routeRefs: ["mock.quick-insight"]
     });
   });
 

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -153,9 +153,12 @@ describe("marketplace api", () => {
     const detailResponse = await request(app).get("/catalog/services/mock-research-signals");
     expect(detailResponse.status).toBe(200);
     expect(detailResponse.body.summary.endpointCount).toBe(2);
+    expect(detailResponse.body.summary.settlementToken).toBe("testUSDC");
     expect(detailResponse.body.skillUrl).toBe("https://marketplace.example.com/skill.md");
     expect(detailResponse.body.useThisServicePrompt).toContain("https://marketplace.example.com/skill.md");
+    expect(detailResponse.body.useThisServicePrompt).toContain("testUSDC");
     expect(detailResponse.body.endpoints[0]?.authRequirement?.type).toBe("x402");
+    expect(detailResponse.body.endpoints[0]?.tokenSymbol).toBe("testUSDC");
   });
 
   it("returns mixed catalog search results with stable machine-readable filters", async () => {
@@ -176,6 +179,7 @@ describe("marketplace api", () => {
       kind: "route",
       summary: {
         ref: "mock.quick-insight",
+        tokenSymbol: "testUSDC",
         authRequirement: {
           type: "x402"
         }
@@ -203,11 +207,13 @@ describe("marketplace api", () => {
       ref: "mock.quick-insight",
       routeId: "mock.quick-insight.v1",
       billingType: "fixed_x402",
+      tokenSymbol: "testUSDC",
       authRequirement: {
         type: "x402"
       }
     });
     expect(response.body.serviceSummary.slug).toBe("mock-research-signals");
+    expect(response.body.serviceSummary.settlementToken).toBe("testUSDC");
   });
 
   it("returns 404 for unknown route detail", async () => {

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -155,6 +155,69 @@ describe("marketplace api", () => {
     expect(detailResponse.body.summary.endpointCount).toBe(2);
     expect(detailResponse.body.skillUrl).toBe("https://marketplace.example.com/skill.md");
     expect(detailResponse.body.useThisServicePrompt).toContain("https://marketplace.example.com/skill.md");
+    expect(detailResponse.body.endpoints[0]?.authRequirement?.type).toBe("x402");
+  });
+
+  it("returns mixed catalog search results with stable machine-readable filters", async () => {
+    const { app } = await createTestApp({
+      deploymentNetwork: "testnet"
+    });
+
+    const response = await request(app)
+      .get("/catalog/search")
+      .query({
+        q: "quick insight",
+        settlementMode: "verified_escrow",
+        limit: 5
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.results[0]).toMatchObject({
+      kind: "route",
+      summary: {
+        ref: "mock.quick-insight",
+        authRequirement: {
+          type: "x402"
+        }
+      }
+    });
+    expect(response.body.results[1]).toMatchObject({
+      kind: "service",
+      summary: {
+        slug: "mock-research-signals"
+      },
+      routeRefs: ["mock.quick-insight", "mock.async-report"]
+    });
+  });
+
+  it("returns route detail for one executable marketplace route", async () => {
+    const { app } = await createTestApp({
+      deploymentNetwork: "testnet"
+    });
+
+    const response = await request(app).get("/catalog/routes/mock/quick-insight");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      kind: "route",
+      ref: "mock.quick-insight",
+      routeId: "mock.quick-insight.v1",
+      billingType: "fixed_x402",
+      authRequirement: {
+        type: "x402"
+      }
+    });
+    expect(response.body.serviceSummary.slug).toBe("mock-research-signals");
+  });
+
+  it("returns 404 for unknown route detail", async () => {
+    const { app } = await createTestApp({
+      deploymentNetwork: "testnet"
+    });
+
+    const response = await request(app).get("/catalog/routes/missing/route");
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe("Route not found.");
   });
 
   it("accepts public suggestions and requires an admin token for internal review", async () => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,6 +14,7 @@ import {
   MARKETPLACE_JOB_TOKEN_HEADER,
   buildLlmsTxt,
   buildMarketplaceCatalog,
+  buildMarketplaceRouteDetail,
   buildOpenApiDocument,
   buildPaymentRequiredHeaders,
   buildPaymentRequiredResponse,
@@ -22,6 +23,7 @@ import {
   buildPayoutSplit,
   buildServiceDetail,
   buildServiceSummary,
+  buildCatalogSearchResults,
   computeNextPollAt,
   computeTimeoutAt,
   createChallenge,
@@ -138,6 +140,14 @@ const suggestionCreateSchema = z
   });
 
 const suggestionStatusSchema = z.enum(["submitted", "reviewing", "accepted", "rejected", "shipped"]);
+const catalogSearchQuerySchema = z.object({
+  q: z.string().min(1).optional(),
+  category: z.string().min(1).optional(),
+  billingType: z.enum(["fixed_x402", "topup_x402_variable", "prepaid_credit", "free"]).optional(),
+  mode: z.enum(["sync", "async"]).optional(),
+  settlementMode: z.enum(["community_direct", "verified_escrow"]).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional()
+});
 
 const suggestionUpdateSchema = z.object({
   status: suggestionStatusSchema.optional(),
@@ -429,6 +439,39 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
     return res.json({ services });
   });
 
+  app.get("/catalog/search", async (req, res) => {
+    const parsed = catalogSearchQuerySchema.safeParse({
+      q: typeof req.query.q === "string" ? req.query.q : undefined,
+      category: typeof req.query.category === "string" ? req.query.category : undefined,
+      billingType: typeof req.query.billingType === "string" ? req.query.billingType : undefined,
+      mode: typeof req.query.mode === "string" ? req.query.mode : undefined,
+      settlementMode: typeof req.query.settlementMode === "string" ? req.query.settlementMode : undefined,
+      limit: req.query.limit
+    });
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: "Search query validation failed.",
+        issues: parsed.error.issues
+      });
+    }
+
+    const catalog = await loadPublishedCatalog(options.store);
+    const services = await Promise.all(
+      catalog.services.map(async (serviceDetail) => ({
+        ...serviceDetail,
+        analytics: await options.store.getServiceAnalytics(serviceDetail.service.routeIds)
+      }))
+    );
+
+    return res.json({
+      results: buildCatalogSearchResults({
+        services,
+        apiBaseUrl: baseUrl,
+        filters: parsed.data
+      })
+    });
+  });
+
   app.get("/catalog/services/:slug", async (req, res) => {
     const published = await options.store.getPublishedServiceBySlug(req.params.slug);
     if (!published) {
@@ -444,6 +487,35 @@ export function createMarketplaceApi(options: MarketplaceApiOptions): Express {
     });
 
     return res.json(detail);
+  });
+
+  app.get("/catalog/routes/:provider/:operation", async (req, res) => {
+    const route = await options.store.findPublishedRoute(
+      req.params.provider,
+      req.params.operation,
+      networkConfig.paymentNetwork
+    );
+    if (!route) {
+      return res.status(404).json({ error: "Route not found." });
+    }
+
+    const catalog = await loadPublishedCatalog(options.store);
+    const published = catalog.services.find((serviceDetail) =>
+      serviceDetail.endpoints.some((endpoint) => endpoint.endpointType === "marketplace_proxy" && endpoint.routeId === route.routeId)
+    );
+    if (!published) {
+      return res.status(404).json({ error: "Service not found for route." });
+    }
+
+    return res.json(
+      buildMarketplaceRouteDetail({
+        route,
+        service: published.service,
+        serviceEndpoints: published.endpoints,
+        analytics: await options.store.getServiceAnalytics(published.service.routeIds),
+        apiBaseUrl: baseUrl
+      })
+    );
   });
 
   app.post("/catalog/suggestions", async (req, res) => {

--- a/packages/cli/bin/fast-marketplace.mjs
+++ b/packages/cli/bin/fast-marketplace.mjs
@@ -1,4 +1,0 @@
-#!/usr/bin/env -S node --import tsx
-import { runCli } from "../src/index.ts";
-
-await runCli(process.argv);

--- a/packages/cli/bin/fast-marketplace.mjs
+++ b/packages/cli/bin/fast-marketplace.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S node --import tsx
+import { runCli } from "../src/index.ts";
+
+await runCli(process.argv);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,14 +1,33 @@
 {
   "name": "@marketplace/cli",
   "private": true,
+  "version": "0.0.0",
   "type": "module",
+  "main": "./dist/index.js",
   "bin": {
-    "fast-marketplace": "./bin/fast-marketplace.mjs"
+    "fast-marketplace": "./dist/index.js"
   },
   "dependencies": {
-    "@marketplace/shared": "*"
+    "@fastxyz/sdk": "^0.2.5",
+    "@fastxyz/x402-client": "^0.1.2",
+    "@noble/ed25519": "^2.3.0",
+    "@noble/hashes": "^1.8.0",
+    "ajv": "^8.18.0",
+    "commander": "^13.1.0",
+    "dotenv": "^17.3.1",
+    "zod": "^3.24.4"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --config tsup.config.ts",
+    "prepack": "npm run build"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./dist/index.js"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,9 @@
   "name": "@marketplace/cli",
   "private": true,
   "type": "module",
+  "bin": {
+    "fast-marketplace": "./bin/fast-marketplace.mjs"
+  },
   "dependencies": {
     "@marketplace/shared": "*"
   },

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,8 +1,12 @@
 import { readFile } from "node:fs/promises";
+import { mkdtemp, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
-import { createProgram } from "./index.js";
+import { createProgram, shouldRunCli } from "./index.js";
 
 describe("marketplace cli command surface", () => {
   it("registers the discovery-first buyer commands", () => {
@@ -46,5 +50,14 @@ describe("marketplace cli command surface", () => {
     expect(packageJson.bin?.["fast-marketplace"]).toBe("./dist/index.js");
     expect(packageJson.exports?.["."]).toBe("./dist/index.js");
     expect(packageJson.scripts?.prepack).toBe("npm run build");
+  });
+
+  it("treats a symlinked bin path as the CLI entrypoint", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "marketplace-cli-entry-"));
+    const targetPath = new URL("./index.ts", import.meta.url);
+    const symlinkPath = join(tempDir, "fast-marketplace");
+    await symlink(fileURLToPath(targetPath), symlinkPath);
+
+    expect(shouldRunCli(["node", symlinkPath], targetPath.href)).toBe(true);
   });
 });

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -60,4 +60,27 @@ describe("marketplace cli command surface", () => {
 
     expect(shouldRunCli(["node", symlinkPath], targetPath.href)).toBe(true);
   });
+
+  it("lets non-init commands fall back to the saved network config", () => {
+    const program = createProgram({
+      fetchImpl: fetch,
+      confirm: async () => true,
+      now: () => new Date(),
+      print: () => {},
+      error: () => {}
+    });
+
+    const walletInit = program.commands.find((command) => command.name() === "wallet")
+      ?.commands.find((command) => command.name() === "init");
+    const walletBalance = program.commands.find((command) => command.name() === "wallet")
+      ?.commands.find((command) => command.name() === "balance");
+    const useCommand = program.commands.find((command) => command.name() === "use");
+    const jobGet = program.commands.find((command) => command.name() === "job")
+      ?.commands.find((command) => command.name() === "get");
+
+    expect(walletInit?.options.find((option) => option.long === "--network")?.defaultValue).toBe("mainnet");
+    expect(walletBalance?.options.find((option) => option.long === "--network")?.defaultValue).toBeUndefined();
+    expect(useCommand?.options.find((option) => option.long === "--network")?.defaultValue).toBeUndefined();
+    expect(jobGet?.options.find((option) => option.long === "--network")?.defaultValue).toBeUndefined();
+  });
 });

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+
 import { describe, expect, it } from "vitest";
 
 import { createProgram } from "./index.js";
@@ -28,5 +30,21 @@ describe("marketplace cli command surface", () => {
     const names = program.commands.map((command) => command.name());
     expect(names).not.toContain("invoke");
     expect(names).not.toContain("auth");
+  });
+
+  it("ships a package bin that points at built runtime output", async () => {
+    const packageJson = JSON.parse(
+      await readFile(new URL("../package.json", import.meta.url), "utf8")
+    ) as {
+      version?: string;
+      bin?: Record<string, string>;
+      exports?: Record<string, string>;
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.version).toBeTruthy();
+    expect(packageJson.bin?.["fast-marketplace"]).toBe("./dist/index.js");
+    expect(packageJson.exports?.["."]).toBe("./dist/index.js");
+    expect(packageJson.scripts?.prepack).toBe("npm run build");
   });
 });

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { createProgram } from "./index.js";
+
+describe("marketplace cli command surface", () => {
+  it("registers the discovery-first buyer commands", () => {
+    const program = createProgram({
+      fetchImpl: fetch,
+      confirm: async () => true,
+      now: () => new Date(),
+      print: () => {},
+      error: () => {}
+    });
+
+    const names = program.commands.map((command) => command.name());
+    expect(names).toEqual(expect.arrayContaining(["search", "show", "use", "wallet", "config", "job", "provider"]));
+  });
+
+  it("does not register legacy buyer commands", () => {
+    const program = createProgram({
+      fetchImpl: fetch,
+      confirm: async () => true,
+      now: () => new Date(),
+      print: () => {},
+      error: () => {}
+    });
+
+    const names = program.commands.map((command) => command.name());
+    expect(names).not.toContain("invoke");
+    expect(names).not.toContain("auth");
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
+import { realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 import { Command } from "commander";
 
@@ -284,6 +286,19 @@ export async function runCli(argv = process.argv, deps: CliDependencies = defaul
   }
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+export function shouldRunCli(argv = process.argv, moduleUrl = import.meta.url): boolean {
+  const invokedPath = argv[1];
+  if (!invokedPath) {
+    return false;
+  }
+
+  try {
+    return realpathSync(invokedPath) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return moduleUrl === pathToFileURL(invokedPath).href;
+  }
+}
+
+if (shouldRunCli(process.argv, import.meta.url)) {
   await runCli(process.argv);
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -95,7 +95,7 @@ export function createProgram(deps: CliDependencies = defaultCliDependencies()):
     .command("load")
     .option("--keyfile <path>")
     .option("--config <path>")
-    .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
+    .option("--network <network>", "Fast network (mainnet or testnet)")
     .action(async (options) => {
       const result = await walletAddress({
         keyfilePath: options.keyfile,
@@ -109,7 +109,7 @@ export function createProgram(deps: CliDependencies = defaultCliDependencies()):
     .command("address")
     .option("--keyfile <path>")
     .option("--config <path>")
-    .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
+    .option("--network <network>", "Fast network (mainnet or testnet)")
     .action(async (options) => {
       const result = await walletAddress({
         keyfilePath: options.keyfile,
@@ -123,7 +123,7 @@ export function createProgram(deps: CliDependencies = defaultCliDependencies()):
     .command("balance")
     .option("--keyfile <path>")
     .option("--config <path>")
-    .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
+    .option("--network <network>", "Fast network (mainnet or testnet)")
     .option("--token <symbol>", "Token symbol override")
     .action(async (options) => {
       const result = await walletBalance({
@@ -160,7 +160,7 @@ export function createProgram(deps: CliDependencies = defaultCliDependencies()):
     .argument("<ref>")
     .requiredOption("--input <json>")
     .option("--api-url <url>", "Marketplace API URL", "http://localhost:3000")
-    .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
+    .option("--network <network>", "Fast network (mainnet or testnet)")
     .option("--keyfile <path>")
     .option("--config <path>")
     .option("--approve-expensive", "Auto-approve expensive routes", false)
@@ -188,7 +188,7 @@ export function createProgram(deps: CliDependencies = defaultCliDependencies()):
     .command("get")
     .argument("<jobToken>")
     .option("--api-url <url>", "Marketplace API URL", "http://localhost:3000")
-    .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
+    .option("--network <network>", "Fast network (mainnet or testnet)")
     .option("--keyfile <path>")
     .option("--config <path>")
     .action(async (jobToken, options) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+
 import { Command } from "commander";
 
 import {
-  createApiSession,
   defaultCliDependencies,
   fetchJobResult,
   initializeWallet,
-  invokePaidRoute,
+  searchMarketplace,
   setSpendControls,
+  showMarketplaceItem,
+  useMarketplaceRoute,
   walletAddress,
-  walletBalance
+  walletBalance,
+  type CliDependencies
 } from "./lib.js";
 import {
   submitProviderService,
@@ -17,239 +21,269 @@ import {
   verifyProviderService
 } from "./provider.js";
 
-const program = new Command();
-const deps = defaultCliDependencies();
+function parseJsonOption(value: string, label: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new Error(`${label} must be valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
 
-program.name("fast-marketplace");
+export function createProgram(deps: CliDependencies = defaultCliDependencies()): Command {
+  const program = new Command();
+  program.name("fast-marketplace");
 
-const authProgram = program.command("auth");
+  program
+    .command("search")
+    .argument("[query]")
+    .option("--api-url <url>", "Marketplace API URL", "http://localhost:3000")
+    .option("--category <name>")
+    .option("--billing-type <type>")
+    .option("--mode <mode>")
+    .option("--settlement-mode <mode>")
+    .option("--limit <number>")
+    .action(async (query, options) => {
+      const result = await searchMarketplace(
+        {
+          apiUrl: options.apiUrl,
+          q: query,
+          category: options.category,
+          billingType: options.billingType,
+          mode: options.mode,
+          settlementMode: options.settlementMode,
+          limit: options.limit ? Number(options.limit) : undefined
+        },
+        deps
+      );
+      deps.print(JSON.stringify(result, null, 2));
+    });
 
-authProgram
-  .command("api-session")
-  .argument("<provider>")
-  .argument("<operation>")
-  .option("--api-url <url>", "Marketplace API URL", "http://localhost:3000")
-  .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
-  .option("--keyfile <path>")
-  .option("--config <path>")
-  .action(async (provider, operation, options) => {
-    const result = await createApiSession(
-      {
-        apiUrl: options.apiUrl,
-        provider,
-        operation,
+  program
+    .command("show")
+    .argument("<ref>")
+    .option("--api-url <url>", "Marketplace API URL", "http://localhost:3000")
+    .action(async (ref, options) => {
+      const result = await showMarketplaceItem(
+        {
+          apiUrl: options.apiUrl,
+          ref
+        },
+        deps
+      );
+      deps.print(JSON.stringify(result, null, 2));
+    });
+
+  const walletProgram = program.command("wallet");
+
+  walletProgram
+    .command("init")
+    .option("--keyfile <path>")
+    .option("--config <path>")
+    .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
+    .action(async (options) => {
+      const result = await initializeWallet({
         keyfilePath: options.keyfile,
         configPath: options.config,
         network: options.network
-      },
-      deps
-    );
-    deps.print(JSON.stringify(result, null, 2));
-  });
-
-const walletProgram = program.command("wallet");
-
-walletProgram
-  .command("init")
-  .option("--keyfile <path>")
-  .option("--config <path>")
-  .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
-  .action(async (options) => {
-    const result = await initializeWallet({
-      keyfilePath: options.keyfile,
-      configPath: options.config,
-      network: options.network
+      });
+      deps.print(JSON.stringify(result, null, 2));
     });
-    deps.print(JSON.stringify(result, null, 2));
-  });
 
-walletProgram
-  .command("load")
-  .option("--keyfile <path>")
-  .option("--config <path>")
-  .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
-  .action(async (options) => {
-    const result = await walletAddress({
-      keyfilePath: options.keyfile,
-      configPath: options.config,
-      network: options.network
-    });
-    deps.print(JSON.stringify(result, null, 2));
-  });
-
-walletProgram
-  .command("address")
-  .option("--keyfile <path>")
-  .option("--config <path>")
-  .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
-  .action(async (options) => {
-    const result = await walletAddress({
-      keyfilePath: options.keyfile,
-      configPath: options.config,
-      network: options.network
-    });
-    deps.print(JSON.stringify(result, null, 2));
-  });
-
-walletProgram
-  .command("balance")
-  .option("--keyfile <path>")
-  .option("--config <path>")
-  .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
-  .option("--token <symbol>", "Token symbol override")
-  .action(async (options) => {
-    const result = await walletBalance({
-      keyfilePath: options.keyfile,
-      configPath: options.config,
-      network: options.network,
-      token: options.token
-    });
-    deps.print(JSON.stringify(result, null, 2));
-  });
-
-program
-  .command("config")
-  .description("Manage local CLI configuration")
-  .command("spend")
-  .option("--config <path>")
-  .option("--max-per-call <amount>")
-  .option("--daily-cap <amount>")
-  .option("--allowlist <items>")
-  .option("--manual-approval-above <amount>")
-  .action(async (options) => {
-    const result = await setSpendControls({
-      configPath: options.config,
-      maxPerCall: options.maxPerCall,
-      dailyCap: options.dailyCap,
-      allowlist: options.allowlist ? String(options.allowlist).split(",").map((item) => item.trim()) : undefined,
-      manualApprovalAbove: options.manualApprovalAbove
-    });
-    deps.print(JSON.stringify(result, null, 2));
-  });
-
-program
-  .command("invoke")
-  .argument("<provider>")
-  .argument("<operation>")
-  .requiredOption("--body <json>")
-  .option("--api-url <url>", "Marketplace API URL", "http://localhost:3000")
-  .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
-  .option("--keyfile <path>")
-  .option("--config <path>")
-  .option("--approve-expensive", "Auto-approve expensive routes", false)
-  .option("--verbose", "Print x402 client logs", false)
-  .action(async (provider, operation, options) => {
-    const result = await invokePaidRoute(
-      {
-        apiUrl: options.apiUrl,
-        provider,
-        operation,
-        body: JSON.parse(options.body),
-        keyfilePath: options.keyfile,
-        configPath: options.config,
-        network: options.network,
-        autoApproveExpensive: Boolean(options.approveExpensive),
-        verbose: Boolean(options.verbose)
-      },
-      deps
-    );
-    deps.print(JSON.stringify(result, null, 2));
-  });
-
-const jobProgram = program.command("job");
-
-jobProgram
-  .command("get")
-  .argument("<jobToken>")
-  .option("--api-url <url>", "Marketplace API URL", "http://localhost:3000")
-  .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
-  .option("--keyfile <path>")
-  .option("--config <path>")
-  .action(async (jobToken, options) => {
-    const result = await fetchJobResult(
-      {
-        apiUrl: options.apiUrl,
-        jobToken,
+  walletProgram
+    .command("load")
+    .option("--keyfile <path>")
+    .option("--config <path>")
+    .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
+    .action(async (options) => {
+      const result = await walletAddress({
         keyfilePath: options.keyfile,
         configPath: options.config,
         network: options.network
-      },
-      deps
-    );
-    deps.print(JSON.stringify(result, null, 2));
-  });
+      });
+      deps.print(JSON.stringify(result, null, 2));
+    });
 
-const providerProgram = program.command("provider");
+  walletProgram
+    .command("address")
+    .option("--keyfile <path>")
+    .option("--config <path>")
+    .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
+    .action(async (options) => {
+      const result = await walletAddress({
+        keyfilePath: options.keyfile,
+        configPath: options.config,
+        network: options.network
+      });
+      deps.print(JSON.stringify(result, null, 2));
+    });
 
-providerProgram
-  .command("sync")
-  .requiredOption("--spec <path>")
-  .option("--api-url <url>", "Marketplace API URL")
-  .option("--network <network>", "Fast network (mainnet or testnet)")
-  .option("--keyfile <path>")
-  .option("--config <path>")
-  .action(async (options) => {
-    const result = await syncProviderSpec(
-      {
-        specPath: options.spec,
-        apiUrl: options.apiUrl,
+  walletProgram
+    .command("balance")
+    .option("--keyfile <path>")
+    .option("--config <path>")
+    .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
+    .option("--token <symbol>", "Token symbol override")
+    .action(async (options) => {
+      const result = await walletBalance({
         keyfilePath: options.keyfile,
         configPath: options.config,
         network: options.network,
-        rpcUrl: undefined
-      },
-      deps
-    );
-    deps.print(JSON.stringify(result, null, 2));
-  });
+        token: options.token
+      });
+      deps.print(JSON.stringify(result, null, 2));
+    });
 
-providerProgram
-  .command("verify")
-  .requiredOption("--service <slug-or-id>")
-  .option("--api-url <url>", "Marketplace API URL")
-  .option("--network <network>", "Fast network (mainnet or testnet)")
-  .option("--keyfile <path>")
-  .option("--config <path>")
-  .action(async (options) => {
-    const result = await verifyProviderService(
-      {
-        serviceRef: options.service,
-        apiUrl: options.apiUrl,
-        keyfilePath: options.keyfile,
+  program
+    .command("config")
+    .description("Manage local CLI configuration")
+    .command("spend")
+    .option("--config <path>")
+    .option("--max-per-call <amount>")
+    .option("--daily-cap <amount>")
+    .option("--allowlist <items>")
+    .option("--manual-approval-above <amount>")
+    .action(async (options) => {
+      const result = await setSpendControls({
         configPath: options.config,
-        network: options.network,
-        rpcUrl: undefined
-      },
-      deps
-    );
-    deps.print(JSON.stringify(result, null, 2));
-  });
+        maxPerCall: options.maxPerCall,
+        dailyCap: options.dailyCap,
+        allowlist: options.allowlist ? String(options.allowlist).split(",").map((item) => item.trim()) : undefined,
+        manualApprovalAbove: options.manualApprovalAbove
+      });
+      deps.print(JSON.stringify(result, null, 2));
+    });
 
-providerProgram
-  .command("submit")
-  .requiredOption("--service <slug-or-id>")
-  .option("--api-url <url>", "Marketplace API URL")
-  .option("--network <network>", "Fast network (mainnet or testnet)")
-  .option("--keyfile <path>")
-  .option("--config <path>")
-  .action(async (options) => {
-    const result = await submitProviderService(
-      {
-        serviceRef: options.service,
-        apiUrl: options.apiUrl,
-        keyfilePath: options.keyfile,
-        configPath: options.config,
-        network: options.network,
-        rpcUrl: undefined
-      },
-      deps
-    );
-    deps.print(JSON.stringify(result, null, 2));
-  });
+  program
+    .command("use")
+    .argument("<ref>")
+    .requiredOption("--input <json>")
+    .option("--api-url <url>", "Marketplace API URL", "http://localhost:3000")
+    .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
+    .option("--keyfile <path>")
+    .option("--config <path>")
+    .option("--approve-expensive", "Auto-approve expensive routes", false)
+    .option("--verbose", "Print x402 client logs", false)
+    .action(async (ref, options) => {
+      const result = await useMarketplaceRoute(
+        {
+          apiUrl: options.apiUrl,
+          ref,
+          body: parseJsonOption(options.input, "--input"),
+          keyfilePath: options.keyfile,
+          configPath: options.config,
+          network: options.network,
+          autoApproveExpensive: Boolean(options.approveExpensive),
+          verbose: Boolean(options.verbose)
+        },
+        deps
+      );
+      deps.print(JSON.stringify(result, null, 2));
+    });
 
-try {
-  await program.parseAsync(process.argv);
-} catch (error) {
-  deps.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+  const jobProgram = program.command("job");
+
+  jobProgram
+    .command("get")
+    .argument("<jobToken>")
+    .option("--api-url <url>", "Marketplace API URL", "http://localhost:3000")
+    .option("--network <network>", "Fast network (mainnet or testnet)", "mainnet")
+    .option("--keyfile <path>")
+    .option("--config <path>")
+    .action(async (jobToken, options) => {
+      const result = await fetchJobResult(
+        {
+          apiUrl: options.apiUrl,
+          jobToken,
+          keyfilePath: options.keyfile,
+          configPath: options.config,
+          network: options.network
+        },
+        deps
+      );
+      deps.print(JSON.stringify(result, null, 2));
+    });
+
+  const providerProgram = program.command("provider");
+
+  providerProgram
+    .command("sync")
+    .requiredOption("--spec <path>")
+    .option("--api-url <url>", "Marketplace API URL")
+    .option("--network <network>", "Fast network (mainnet or testnet)")
+    .option("--keyfile <path>")
+    .option("--config <path>")
+    .action(async (options) => {
+      const result = await syncProviderSpec(
+        {
+          specPath: options.spec,
+          apiUrl: options.apiUrl,
+          keyfilePath: options.keyfile,
+          configPath: options.config,
+          network: options.network,
+          rpcUrl: undefined
+        },
+        deps
+      );
+      deps.print(JSON.stringify(result, null, 2));
+    });
+
+  providerProgram
+    .command("verify")
+    .requiredOption("--service <slug-or-id>")
+    .option("--api-url <url>", "Marketplace API URL")
+    .option("--network <network>", "Fast network (mainnet or testnet)")
+    .option("--keyfile <path>")
+    .option("--config <path>")
+    .action(async (options) => {
+      const result = await verifyProviderService(
+        {
+          serviceRef: options.service,
+          apiUrl: options.apiUrl,
+          keyfilePath: options.keyfile,
+          configPath: options.config,
+          network: options.network,
+          rpcUrl: undefined
+        },
+        deps
+      );
+      deps.print(JSON.stringify(result, null, 2));
+    });
+
+  providerProgram
+    .command("submit")
+    .requiredOption("--service <slug-or-id>")
+    .option("--api-url <url>", "Marketplace API URL")
+    .option("--network <network>", "Fast network (mainnet or testnet)")
+    .option("--keyfile <path>")
+    .option("--config <path>")
+    .action(async (options) => {
+      const result = await submitProviderService(
+        {
+          serviceRef: options.service,
+          apiUrl: options.apiUrl,
+          keyfilePath: options.keyfile,
+          configPath: options.config,
+          network: options.network,
+          rpcUrl: undefined
+        },
+        deps
+      );
+      deps.print(JSON.stringify(result, null, 2));
+    });
+
+  return program;
+}
+
+export async function runCli(argv = process.argv, deps: CliDependencies = defaultCliDependencies()) {
+  const program = createProgram(deps);
+  try {
+    await program.parseAsync(argv);
+  } catch (error) {
+    deps.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await runCli(process.argv);
 }

--- a/packages/cli/src/lib.test.ts
+++ b/packages/cli/src/lib.test.ts
@@ -548,6 +548,68 @@ describe("marketplace cli", () => {
     });
   });
 
+  it("executes a free sync route without requiring local wallet setup", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url.endsWith("/catalog/routes/public/free-search")) {
+        return jsonResponse(200, buildRouteDetail({
+          ref: "public.free-search",
+          routeId: "public.free-search.v1",
+          provider: "public",
+          operation: "free-search",
+          price: "Free",
+          billingType: "free",
+          authRequirement: {
+            type: "none",
+            description: "No payment or session token is required."
+          },
+          path: "/api/public/free-search",
+          proxyUrl: `${API_URL}/api/public/free-search`,
+          requestExample: { query: "alpha" }
+        }));
+      }
+
+      if (url.endsWith("/api/public/free-search")) {
+        const headers = new Headers(init?.headers);
+        expect(headers.get("authorization")).toBeNull();
+        expect(headers.get("x-payment")).toBeNull();
+        return jsonResponse(200, {
+          ok: true,
+          query: "alpha"
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const result = await useMarketplaceRoute(
+      {
+        apiUrl: API_URL,
+        ref: "public.free-search",
+        body: { query: "alpha" }
+      },
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        confirm: async () => true,
+        now: () => new Date(),
+        print: () => {},
+        error: () => {}
+      }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      ref: "public.free-search",
+      statusCode: 200,
+      authFlow: "none",
+      body: {
+        ok: true,
+        query: "alpha"
+      }
+    });
+  });
+
   it("executes a prepaid-credit route with wallet-session auth", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "marketplace-cli-use-prepaid-"));
     const keyfilePath = join(tempDir, "wallet.json");

--- a/packages/cli/src/lib.test.ts
+++ b/packages/cli/src/lib.test.ts
@@ -5,12 +5,13 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import {
-  createApiSession,
   fetchJobResult,
   initializeWallet,
-  invokePaidRoute,
   readCliConfig,
+  searchMarketplace,
   setSpendControls,
+  showMarketplaceItem,
+  useMarketplaceRoute,
   walletAddress
 } from "./lib.js";
 
@@ -25,14 +26,117 @@ function jsonResponse(status: number, body: unknown, headers?: Record<string, st
 }
 
 const FAST_MAINNET_USDC_ASSET_ID = "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130";
+const API_URL = "http://localhost:3000";
 
-describe("marketplace cli", () => {
-  const mockCatalogResponse = jsonResponse(200, {
-    routes: [
+function buildServiceSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    serviceType: "marketplace_proxy",
+    slug: "mock-research-signals",
+    name: "Mock Research Signals",
+    ownerName: "Marketplace",
+    tagline: "Mock route set for signal lookups.",
+    categories: ["Research"],
+    settlementMode: "verified_escrow",
+    settlementLabel: "Verified escrow",
+    settlementDescription: "Marketplace holds funds and handles refunds.",
+    priceRange: "$0.05 USDC",
+    settlementToken: "USDC",
+    endpointCount: 1,
+    totalCalls: 0,
+    revenue: "0",
+    successRate30d: 0,
+    volume30d: [],
+    ...overrides
+  };
+}
+
+function buildRouteDetail(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "route",
+    ref: "mock.quick-insight",
+    routeId: "mock.quick-insight.v1",
+    provider: "mock",
+    operation: "quick-insight",
+    serviceSlug: "mock-research-signals",
+    serviceName: "Mock Research Signals",
+    ownerName: "Marketplace",
+    categories: ["Research"],
+    title: "Quick Insight",
+    description: "Run a quick signal lookup.",
+    price: "$0.05",
+    billingType: "fixed_x402",
+    tokenSymbol: "USDC",
+    mode: "sync",
+    method: "POST",
+    path: "/api/mock/quick-insight",
+    proxyUrl: `${API_URL}/api/mock/quick-insight`,
+    settlementMode: "verified_escrow",
+    settlementLabel: "Verified escrow",
+    settlementDescription: "Marketplace holds funds and handles refunds.",
+    authRequirement: {
+      type: "x402",
+      description: "Requires x402 payment headers and Fast wallet authorization.",
+      paymentProtocol: "x402",
+      paymentHeaders: {
+        required: "payment-required",
+        signature: "payment-signature",
+        response: "payment-response",
+        paymentIdentifier: "payment-identifier"
+      }
+    },
+    requestSchemaJson: {
+      type: "object",
+      properties: {
+        query: { type: "string" }
+      },
+      required: ["query"],
+      additionalProperties: false
+    },
+    responseSchemaJson: {
+      type: "object",
+      additionalProperties: true
+    },
+    requestExample: { query: "alpha" },
+    responseExample: { ok: true },
+    usageNotes: "Use for quick research lookups.",
+    asyncConfig: null,
+    serviceSummary: buildServiceSummary(),
+    ...overrides
+  };
+}
+
+function buildServiceDetail(overrides: Record<string, unknown> = {}) {
+  return {
+    serviceType: "marketplace_proxy",
+    summary: buildServiceSummary(),
+    about: "Mock service detail.",
+    useThisServicePrompt: "Use the mock service.",
+    skillUrl: "https://marketplace.example.com/skill.md",
+    endpoints: [
       {
-        provider: "mock",
-        operation: "quick-insight",
+        endpointType: "marketplace_proxy",
+        routeId: "mock.quick-insight.v1",
+        ref: "mock.quick-insight",
+        title: "Quick Insight",
+        description: "Run a quick signal lookup.",
+        price: "$0.05",
+        billingType: "fixed_x402",
+        tokenSymbol: "USDC",
+        mode: "sync",
         method: "POST",
+        path: "/api/mock/quick-insight",
+        proxyUrl: `${API_URL}/api/mock/quick-insight`,
+        authRequirement: {
+          type: "x402",
+          description: "Requires x402 payment headers and Fast wallet authorization.",
+          paymentProtocol: "x402",
+          paymentHeaders: {
+            required: "payment-required",
+            signature: "payment-signature",
+            response: "payment-response",
+            paymentIdentifier: "payment-identifier"
+          }
+        },
         requestSchemaJson: {
           type: "object",
           properties: {
@@ -40,38 +144,20 @@ describe("marketplace cli", () => {
           },
           required: ["query"],
           additionalProperties: false
-        }
-      },
-      {
-        provider: "orders",
-        operation: "place-order",
-        method: "POST",
-        requestSchemaJson: {
+        },
+        responseSchemaJson: {
           type: "object",
-          properties: {
-            item: { type: "string" }
-          },
-          required: ["item"],
-          additionalProperties: false
-        }
-      },
-      {
-        provider: "weather",
-        operation: "lookup",
-        method: "GET",
-        requestSchemaJson: {
-          type: "object",
-          properties: {
-            city: { type: "string" },
-            day: { type: "integer" }
-          },
-          required: ["city", "day"],
-          additionalProperties: false
-        }
+          additionalProperties: true
+        },
+        requestExample: { query: "alpha" },
+        responseExample: { ok: true }
       }
-    ]
-  });
+    ],
+    ...overrides
+  };
+}
 
+describe("marketplace cli", () => {
   it("initializes and loads a local wallet keyfile", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "marketplace-cli-wallet-"));
     const keyfilePath = join(tempDir, "wallet.json");
@@ -85,7 +171,97 @@ describe("marketplace cli", () => {
     expect(config.defaultNetwork).toBe("testnet");
   });
 
-  it("blocks invocation when local spend controls would be exceeded", async () => {
+  it("searches the machine-readable catalog", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      expect(url).toContain("/catalog/search?q=shopping&mode=sync");
+      return jsonResponse(200, {
+        results: [
+          {
+            kind: "route",
+            summary: {
+              ref: "amazon.search",
+              routeId: "amazon.search.v1"
+            }
+          },
+          {
+            kind: "service",
+            summary: {
+              slug: "amazon-shop-proxy"
+            },
+            executableByMarketplace: true,
+            routeRefs: ["amazon.search"]
+          }
+        ]
+      });
+    });
+
+    const result = await searchMarketplace(
+      {
+        apiUrl: API_URL,
+        q: "shopping",
+        mode: "sync"
+      },
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        confirm: async () => true,
+        now: () => new Date(),
+        print: () => {},
+        error: () => {}
+      }
+    );
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toMatchObject({
+      kind: "route"
+    });
+  });
+
+  it("shows either a service slug or a route ref", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/catalog/services/mock-research-signals")) {
+        return jsonResponse(200, buildServiceDetail());
+      }
+      if (url.endsWith("/catalog/routes/mock/quick-insight")) {
+        return jsonResponse(200, buildRouteDetail());
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const deps = {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      confirm: async () => true,
+      now: () => new Date(),
+      print: () => {},
+      error: () => {}
+    };
+
+    const service = await showMarketplaceItem(
+      {
+        apiUrl: API_URL,
+        ref: "mock-research-signals"
+      },
+      deps
+    );
+    const route = await showMarketplaceItem(
+      {
+        apiUrl: API_URL,
+        ref: "mock.quick-insight"
+      },
+      deps
+    );
+
+    expect(service).toMatchObject({
+      serviceType: "marketplace_proxy"
+    });
+    expect(route).toMatchObject({
+      kind: "route",
+      ref: "mock.quick-insight"
+    });
+  });
+
+  it("blocks x402 execution when local spend controls would be exceeded", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "marketplace-cli-spend-"));
     const keyfilePath = join(tempDir, "wallet.json");
     const configPath = join(tempDir, "config.json");
@@ -95,27 +271,29 @@ describe("marketplace cli", () => {
       maxPerCall: "0.01"
     });
 
-    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
-      if (url.endsWith("/.well-known/marketplace.json")) {
-        return mockCatalogResponse;
+      if (url.endsWith("/catalog/routes/mock/quick-insight")) {
+        return jsonResponse(200, buildRouteDetail());
       }
-
-      return jsonResponse(402, {
-        accepts: [
-          {
-            maxAmountRequired: "0.05"
-          }
-        ]
-      });
+      if (url.endsWith("/api/mock/quick-insight")) {
+        expect(new Headers(init?.headers).get("payment-identifier")).toBeTruthy();
+        return jsonResponse(402, {
+          accepts: [
+            {
+              maxAmountRequired: "0.05"
+            }
+          ]
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
     });
 
     await expect(
-      invokePaidRoute(
+      useMarketplaceRoute(
         {
-          apiUrl: "http://localhost:3000",
-          provider: "mock",
-          operation: "quick-insight",
+          apiUrl: API_URL,
+          ref: "mock.quick-insight",
           body: { query: "alpha" },
           keyfilePath,
           configPath
@@ -131,8 +309,8 @@ describe("marketplace cli", () => {
     ).rejects.toThrow(/max per call/i);
   });
 
-  it("invokes a paid route with x402-client compatibility", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "marketplace-cli-invoke-"));
+  it("executes a paid POST route through x402", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "marketplace-cli-use-post-"));
     const keyfilePath = join(tempDir, "wallet.json");
     const configPath = join(tempDir, "config.json");
     await initializeWallet({ keyfilePath, configPath });
@@ -140,11 +318,11 @@ describe("marketplace cli", () => {
     const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
 
-      if (url.endsWith("/.well-known/marketplace.json")) {
-        return mockCatalogResponse;
+      if (url.endsWith("/catalog/routes/mock/quick-insight")) {
+        return jsonResponse(200, buildRouteDetail());
       }
 
-      if (url.includes("/api/mock/quick-insight")) {
+      if (url.endsWith("/api/mock/quick-insight")) {
         const headers = new Headers(init?.headers);
         if (!headers.get("X-PAYMENT")) {
           return jsonResponse(402, {
@@ -155,17 +333,13 @@ describe("marketplace cli", () => {
                 network: "fast-mainnet",
                 maxAmountRequired: "0.05",
                 payTo: "fast19cjwajufyuqv883ydlvrp8xrhxejuvfe40pxq5dsrv675zgh89sqg9txs8",
-                asset: "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130"
+                asset: FAST_MAINNET_USDC_ASSET_ID
               }
             ]
           });
         }
 
-        return jsonResponse(
-          200,
-          { ok: true, route: "mock.quick-insight" },
-          { "payment-response": "encoded" }
-        );
+        return jsonResponse(200, { ok: true, route: "mock.quick-insight" }, { "payment-response": "encoded" });
       }
 
       const body = JSON.parse(String(init?.body ?? "{}")) as {
@@ -216,11 +390,10 @@ describe("marketplace cli", () => {
       throw new Error(`Unexpected fetch: ${url}`);
     });
 
-    const result = await invokePaidRoute(
+    const result = await useMarketplaceRoute(
       {
-        apiUrl: "http://localhost:3000",
-        provider: "mock",
-        operation: "quick-insight",
+        apiUrl: API_URL,
+        ref: "mock.quick-insight",
         body: { query: "alpha" },
         keyfilePath,
         configPath
@@ -234,16 +407,19 @@ describe("marketplace cli", () => {
       }
     );
 
-    expect("success" in result && result.success).toBe(true);
-    expect(result.statusCode).toBe(200);
-    expect(fetchImpl).toHaveBeenCalled();
+    expect(result).toMatchObject({
+      ref: "mock.quick-insight",
+      statusCode: 200,
+      authFlow: "x402",
+      jobToken: null
+    });
 
     const config = await readCliConfig(configPath);
     expect(config.spendLedger?.spentRaw).toBe("50000");
   });
 
-  it("invokes a paid GET route with canonical query params", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "marketplace-cli-invoke-get-"));
+  it("executes a paid GET route with canonical query params", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "marketplace-cli-use-get-"));
     const keyfilePath = join(tempDir, "wallet.json");
     const configPath = join(tempDir, "config.json");
     await initializeWallet({ keyfilePath, configPath });
@@ -251,15 +427,33 @@ describe("marketplace cli", () => {
     const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
 
-      if (url.endsWith("/.well-known/marketplace.json")) {
-        return mockCatalogResponse;
+      if (url.endsWith("/catalog/routes/weather/lookup")) {
+        return jsonResponse(200, buildRouteDetail({
+          ref: "weather.lookup",
+          routeId: "weather.lookup.v1",
+          provider: "weather",
+          operation: "lookup",
+          title: "Weather Lookup",
+          method: "GET",
+          path: "/api/weather/lookup",
+          proxyUrl: `${API_URL}/api/weather/lookup`,
+          requestSchemaJson: {
+            type: "object",
+            properties: {
+              city: { type: "string" },
+              day: { type: "integer" }
+            },
+            required: ["city", "day"],
+            additionalProperties: false
+          },
+          requestExample: { city: "Paris", day: 1 }
+        }));
       }
 
-      if (url.includes("/api/weather/lookup?city=Paris&day=1")) {
-        const headers = new Headers(init?.headers);
+      if (url.endsWith("/api/weather/lookup?city=Paris&day=1")) {
         expect(init?.method).toBe("GET");
         expect(init?.body).toBeUndefined();
-
+        const headers = new Headers(init?.headers);
         if (!headers.get("X-PAYMENT")) {
           return jsonResponse(402, {
             x402Version: 1,
@@ -269,16 +463,13 @@ describe("marketplace cli", () => {
                 network: "fast-mainnet",
                 maxAmountRequired: "0.05",
                 payTo: "fast19cjwajufyuqv883ydlvrp8xrhxejuvfe40pxq5dsrv675zgh89sqg9txs8",
-                asset: "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130"
+                asset: FAST_MAINNET_USDC_ASSET_ID
               }
             ]
           });
         }
 
-        return jsonResponse(200, {
-          city: "Paris",
-          forecast: "sunny"
-        });
+        return jsonResponse(200, { city: "Paris", forecast: "sunny" });
       }
 
       const body = JSON.parse(String(init?.body ?? "{}")) as {
@@ -329,11 +520,10 @@ describe("marketplace cli", () => {
       throw new Error(`Unexpected fetch: ${url}`);
     });
 
-    const result = await invokePaidRoute(
+    const result = await useMarketplaceRoute(
       {
-        apiUrl: "http://localhost:3000",
-        provider: "weather",
-        operation: "lookup",
+        apiUrl: API_URL,
+        ref: "weather.lookup",
         body: { day: 1, city: "Paris" },
         keyfilePath,
         configPath
@@ -347,81 +537,19 @@ describe("marketplace cli", () => {
       }
     );
 
-    expect("success" in result && result.success).toBe(true);
-    expect(result.statusCode).toBe(200);
-    expect(result.body).toEqual({
-      city: "Paris",
-      forecast: "sunny"
+    expect(result).toMatchObject({
+      ref: "weather.lookup",
+      statusCode: 200,
+      authFlow: "x402",
+      body: {
+        city: "Paris",
+        forecast: "sunny"
+      }
     });
   });
 
-  it("retrieves a job through the wallet-challenge flow", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "marketplace-cli-job-"));
-    const keyfilePath = join(tempDir, "wallet.json");
-    const configPath = join(tempDir, "config.json");
-    const initialized = await initializeWallet({ keyfilePath, configPath });
-
-    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
-      const url = typeof input === "string" ? input : input.toString();
-
-      if (url.endsWith("/auth/challenge")) {
-        return jsonResponse(200, {
-          wallet: initialized.address,
-          resourceType: "job",
-          resourceId: "job_123",
-          nonce: "nonce-1",
-          expiresAt: new Date(Date.now() + 60_000).toISOString(),
-          message: [
-            "Fast Marketplace Access",
-            `Wallet: ${initialized.address}`,
-            "Resource: job/job_123",
-            "Nonce: nonce-1",
-            `Expires: ${new Date(Date.now() + 60_000).toISOString()}`
-          ].join("\n")
-        });
-      }
-
-      if (url.endsWith("/auth/session")) {
-        return jsonResponse(200, {
-          accessToken: "token-1"
-        });
-      }
-
-      if (url.endsWith("/api/jobs/job_123")) {
-        return jsonResponse(200, {
-          jobToken: "job_123",
-          status: "completed"
-        });
-      }
-
-      throw new Error(`Unexpected URL ${url}`);
-    });
-
-    const result = await fetchJobResult(
-      {
-        apiUrl: "http://localhost:3000",
-        jobToken: "job_123",
-        keyfilePath,
-        configPath
-      },
-      {
-        fetchImpl: fetchImpl as unknown as typeof fetch,
-        confirm: async () => true,
-        now: () => new Date(),
-        print: () => {},
-        error: () => {}
-      }
-    );
-
-    expect(result.statusCode).toBe(200);
-    expect(result.body).toEqual({
-      jobToken: "job_123",
-      status: "completed"
-    });
-  });
-
-  it("creates an API-scoped session and invokes a prepaid-credit route without x402", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "marketplace-cli-api-session-"));
+  it("executes a prepaid-credit route with wallet-session auth", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "marketplace-cli-use-prepaid-"));
     const keyfilePath = join(tempDir, "wallet.json");
     const configPath = join(tempDir, "config.json");
     const initialized = await initializeWallet({ keyfilePath, configPath });
@@ -429,12 +557,34 @@ describe("marketplace cli", () => {
     const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
 
-      if (url.endsWith("/.well-known/marketplace.json")) {
-        return mockCatalogResponse;
-      }
-
-      if (url.endsWith("/api/orders/place-order") && !new Headers(init?.headers).get("authorization")) {
-        return jsonResponse(401, { error: "Missing bearer token." });
+      if (url.endsWith("/catalog/routes/orders/place-order")) {
+        return jsonResponse(200, buildRouteDetail({
+          ref: "orders.place-order",
+          routeId: "orders.place-order.v1",
+          provider: "orders",
+          operation: "place-order",
+          price: "Prepaid credit",
+          billingType: "prepaid_credit",
+          authRequirement: {
+            type: "wallet_session",
+            description: "Requires a wallet-bound bearer token scoped to the route.",
+            authorizationScheme: "Bearer",
+            challengeEndpoint: "/auth/challenge",
+            sessionEndpoint: "/auth/session",
+            resourceType: "api"
+          },
+          path: "/api/orders/place-order",
+          proxyUrl: `${API_URL}/api/orders/place-order`,
+          requestSchemaJson: {
+            type: "object",
+            properties: {
+              item: { type: "string" }
+            },
+            required: ["item"],
+            additionalProperties: false
+          },
+          requestExample: { item: "notebook" }
+        }));
       }
 
       if (url.endsWith("/auth/challenge")) {
@@ -467,33 +617,13 @@ describe("marketplace cli", () => {
         });
       }
 
-      throw new Error(`Unexpected URL ${url}`);
+      throw new Error(`Unexpected fetch: ${url}`);
     });
 
-    const session = await createApiSession(
+    const result = await useMarketplaceRoute(
       {
-        apiUrl: "http://localhost:3000",
-        provider: "orders",
-        operation: "place-order",
-        keyfilePath,
-        configPath
-      },
-      {
-        fetchImpl: fetchImpl as unknown as typeof fetch,
-        confirm: async () => true,
-        now: () => new Date(),
-        print: () => {},
-        error: () => {}
-      }
-    );
-
-    expect(session.accessToken).toBe("api-token-1");
-
-    const result = await invokePaidRoute(
-      {
-        apiUrl: "http://localhost:3000",
-        provider: "orders",
-        operation: "place-order",
+        apiUrl: API_URL,
+        ref: "orders.place-order",
         body: { item: "notebook" },
         keyfilePath,
         configPath
@@ -507,8 +637,128 @@ describe("marketplace cli", () => {
       }
     );
 
-    expect(result.statusCode).toBe(200);
-    expect(result.body).toEqual({ orderId: "ord_123" });
-    expect(result.note).toContain("wallet-session");
+    expect(result).toMatchObject({
+      ref: "orders.place-order",
+      statusCode: 200,
+      authFlow: "wallet_session",
+      body: { orderId: "ord_123" }
+    });
+  });
+
+  it("returns a job token for async wallet-session routes and retrieves jobs", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "marketplace-cli-use-async-"));
+    const keyfilePath = join(tempDir, "wallet.json");
+    const configPath = join(tempDir, "config.json");
+    const initialized = await initializeWallet({ keyfilePath, configPath });
+
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url.endsWith("/catalog/routes/signals/async-search")) {
+        return jsonResponse(200, buildRouteDetail({
+          ref: "signals.async-search",
+          routeId: "signals.async-search.v1",
+          provider: "signals",
+          operation: "async-search",
+          price: "Free",
+          billingType: "free",
+          mode: "async",
+          authRequirement: {
+            type: "wallet_session",
+            description: "Requires a wallet-bound bearer token scoped to the route.",
+            authorizationScheme: "Bearer",
+            challengeEndpoint: "/auth/challenge",
+            sessionEndpoint: "/auth/session",
+            resourceType: "api"
+          },
+          path: "/api/signals/async-search",
+          proxyUrl: `${API_URL}/api/signals/async-search`
+        }));
+      }
+
+      if (url.endsWith("/auth/challenge")) {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { resourceType: string; resourceId: string };
+        return jsonResponse(200, {
+          wallet: initialized.address,
+          resourceType: body.resourceType,
+          resourceId: body.resourceId,
+          nonce: "nonce-async",
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+          message: [
+            "Fast Marketplace Access",
+            `Wallet: ${initialized.address}`,
+            `Resource: ${body.resourceType}/${body.resourceId}`,
+            "Nonce: nonce-async",
+            `Expires: ${new Date(Date.now() + 60_000).toISOString()}`
+          ].join("\n")
+        });
+      }
+
+      if (url.endsWith("/auth/session")) {
+        return jsonResponse(200, {
+          accessToken: "token-async"
+        });
+      }
+
+      if (url.endsWith("/api/signals/async-search")) {
+        expect(new Headers(init?.headers).get("authorization")).toBe("Bearer token-async");
+        return jsonResponse(202, {
+          jobToken: "job_123",
+          status: "pending"
+        });
+      }
+
+      if (url.endsWith("/api/jobs/job_123")) {
+        expect(new Headers(init?.headers).get("authorization")).toBe("Bearer token-async");
+        return jsonResponse(200, {
+          jobToken: "job_123",
+          status: "completed"
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const deps = {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      confirm: async () => true,
+      now: () => new Date(),
+      print: () => {},
+      error: () => {}
+    };
+
+    const useResult = await useMarketplaceRoute(
+      {
+        apiUrl: API_URL,
+        ref: "signals.async-search",
+        body: { query: "fast" },
+        keyfilePath,
+        configPath
+      },
+      deps
+    );
+    const jobResult = await fetchJobResult(
+      {
+        apiUrl: API_URL,
+        jobToken: "job_123",
+        keyfilePath,
+        configPath
+      },
+      deps
+    );
+
+    expect(useResult).toMatchObject({
+      ref: "signals.async-search",
+      statusCode: 202,
+      authFlow: "wallet_session",
+      jobToken: "job_123"
+    });
+    expect(jobResult).toMatchObject({
+      statusCode: 200,
+      body: {
+        jobToken: "job_123",
+        status: "completed"
+      }
+    });
   });
 });

--- a/packages/cli/src/lib.ts
+++ b/packages/cli/src/lib.ts
@@ -367,9 +367,6 @@ export async function invokePaidRoute(
   },
   deps: CliDependencies = defaultCliDependencies()
 ): Promise<UseRouteResult> {
-  const loaded = await loadWallet(input);
-  const config = await readCliConfig(input.configPath);
-  const network = resolveCliNetwork(input.network, config.defaultNetwork, input.rpcUrl);
   const route = await resolvePublishedRoute(input.apiUrl, input.provider, input.operation, deps);
   const requestTarget = buildInvocationTarget({
     apiUrl: input.apiUrl,
@@ -413,6 +410,9 @@ export async function invokePaidRoute(
     return buildUseRouteResult(route.ref, response.status, await safeJson(response), "none");
   }
 
+  const config = await readCliConfig(input.configPath);
+  const network = resolveCliNetwork(input.network, config.defaultNetwork, input.rpcUrl);
+  const loaded = await loadWallet(input);
   const paymentId = createOpaqueToken("payment");
   const headers = buildClientHeaders(config, paymentId);
   const preflight = await deps.fetchImpl(requestTarget.url, buildInvocationInit(route.method, headers, requestTarget.body));

--- a/packages/cli/src/lib.ts
+++ b/packages/cli/src/lib.ts
@@ -9,15 +9,21 @@ import { FastProvider, FastWallet, encodeFastAddress } from "@fastxyz/sdk";
 import { x402Pay } from "@fastxyz/x402-client";
 import {
   PAYMENT_IDENTIFIER_HEADER,
+  buildRouteRef,
   createOpaqueToken,
   decimalToRawString,
   normalizeFastWalletAddress,
   rawToDecimalString,
   resolveMarketplaceNetworkConfig,
   serializeQueryInput,
+  validateJsonSchema,
+  type CatalogSearchFilters,
+  type CatalogSearchResult,
   type HttpMethod,
   type JsonSchema,
-  type MarketplaceDeploymentNetwork
+  type MarketplaceRouteDetail,
+  type MarketplaceDeploymentNetwork,
+  type ServiceDetail
 } from "@marketplace/shared";
 
 export interface CliConfig {
@@ -65,10 +71,21 @@ export interface CliDependencies {
 }
 
 interface PublishedRouteCatalogEntry {
+  ref: string;
+  routeId: string;
   provider: string;
   operation: string;
   method: HttpMethod;
   requestSchemaJson: JsonSchema;
+  authRequirement: MarketplaceRouteDetail["authRequirement"];
+}
+
+export interface UseRouteResult {
+  ref: string;
+  statusCode: number;
+  body: unknown;
+  authFlow: "x402" | "wallet_session" | "none";
+  jobToken: string | null;
 }
 
 const DEFAULT_CONFIG_PATH = "~/.fast-marketplace/config.json";
@@ -266,6 +283,75 @@ export async function walletBalance(input: {
   return loaded.wallet.balance(input.token ?? network.tokenSymbol);
 }
 
+export async function searchMarketplace(
+  input: {
+    apiUrl: string;
+    q?: string;
+    category?: string;
+    billingType?: CatalogSearchFilters["billingType"];
+    mode?: CatalogSearchFilters["mode"];
+    settlementMode?: CatalogSearchFilters["settlementMode"];
+    limit?: number;
+  },
+  deps: CliDependencies = defaultCliDependencies()
+): Promise<{ results: CatalogSearchResult[] }> {
+  return fetchMarketplaceJson<{ results: CatalogSearchResult[] }>(
+    deps,
+    buildSearchRequestUrl(input.apiUrl, input)
+  );
+}
+
+export async function showMarketplaceItem(
+  input: {
+    apiUrl: string;
+    ref: string;
+  },
+  deps: CliDependencies = defaultCliDependencies()
+): Promise<ServiceDetail | MarketplaceRouteDetail> {
+  const routeRef = parseRouteRef(input.ref);
+  if (routeRef) {
+    return fetchRouteDetail(input.apiUrl, routeRef.provider, routeRef.operation, deps);
+  }
+
+  return fetchServiceDetail(input.apiUrl, input.ref, deps);
+}
+
+export async function useMarketplaceRoute(
+  input: {
+    apiUrl: string;
+    ref: string;
+    body: unknown;
+    keyfilePath?: string;
+    configPath?: string;
+    network?: MarketplaceDeploymentNetwork;
+    rpcUrl?: string;
+    autoApproveExpensive?: boolean;
+    verbose?: boolean;
+  },
+  deps: CliDependencies = defaultCliDependencies()
+): Promise<UseRouteResult> {
+  const routeRef = parseRouteRef(input.ref);
+  if (!routeRef) {
+    throw new Error(`Route ref must use provider.operation: ${input.ref}`);
+  }
+
+  return invokePaidRoute(
+    {
+      apiUrl: input.apiUrl,
+      provider: routeRef.provider,
+      operation: routeRef.operation,
+      body: input.body,
+      keyfilePath: input.keyfilePath,
+      configPath: input.configPath,
+      network: input.network,
+      rpcUrl: input.rpcUrl,
+      autoApproveExpensive: input.autoApproveExpensive,
+      verbose: input.verbose
+    },
+    deps
+  );
+}
+
 export async function invokePaidRoute(
   input: {
     apiUrl: string;
@@ -280,12 +366,10 @@ export async function invokePaidRoute(
     verbose?: boolean;
   },
   deps: CliDependencies = defaultCliDependencies()
-) {
+): Promise<UseRouteResult> {
   const loaded = await loadWallet(input);
   const config = await readCliConfig(input.configPath);
   const network = resolveCliNetwork(input.network, config.defaultNetwork, input.rpcUrl);
-  const routeKey = `${input.provider}.${input.operation}`;
-  const paymentId = createOpaqueToken("payment");
   const route = await resolvePublishedRoute(input.apiUrl, input.provider, input.operation, deps);
   const requestTarget = buildInvocationTarget({
     apiUrl: input.apiUrl,
@@ -295,17 +379,13 @@ export async function invokePaidRoute(
     requestSchemaJson: route.requestSchemaJson,
     body: input.body
   });
-  const headers = buildClientHeaders(config, paymentId);
 
-  const preflight = await deps.fetchImpl(requestTarget.url, buildInvocationInit(route.method, headers, requestTarget.body));
-
-  if (preflight.status === 401 || preflight.status === 403) {
-    const routeId = `${input.provider}.${input.operation}.v1`;
+  if (route.authRequirement.type === "wallet_session") {
     const session = await createScopedSession(
       {
         apiUrl: input.apiUrl,
         resourceType: "api",
-        resourceId: routeId,
+        resourceId: route.routeId,
         keyfilePath: input.keyfilePath,
         configPath: input.configPath,
         network: input.network,
@@ -321,25 +401,28 @@ export async function invokePaidRoute(
       }, requestTarget.body)
     );
 
-    return {
-      statusCode: response.status,
-      body: await safeJson(response),
-      note: "Request used wallet-session auth."
-    };
+    return buildUseRouteResult(route.ref, response.status, await safeJson(response), "wallet_session");
   }
 
+  if (route.authRequirement.type === "none") {
+    const response = await deps.fetchImpl(
+      requestTarget.url,
+      buildInvocationInit(route.method, {}, requestTarget.body)
+    );
+
+    return buildUseRouteResult(route.ref, response.status, await safeJson(response), "none");
+  }
+
+  const paymentId = createOpaqueToken("payment");
+  const headers = buildClientHeaders(config, paymentId);
+  const preflight = await deps.fetchImpl(requestTarget.url, buildInvocationInit(route.method, headers, requestTarget.body));
   if (preflight.status !== 402) {
-    return {
-      statusCode: preflight.status,
-      body: await safeJson(preflight),
-      note: "Request did not require payment."
-    };
+    return buildUseRouteResult(route.ref, preflight.status, await safeJson(preflight), "x402");
   }
 
   const paymentRequired = await preflight.json() as {
     accepts?: Array<{ maxAmountRequired: string }>;
   };
-
   const maxAmountRequired = paymentRequired.accepts?.[0]?.maxAmountRequired;
   if (!maxAmountRequired) {
     throw new Error("Marketplace did not return a usable payment requirement.");
@@ -347,7 +430,7 @@ export async function invokePaidRoute(
   const amountRaw = decimalToRawString(maxAmountRequired, 6);
 
   await enforceSpendControls({
-    routeKey,
+    routeKey: route.ref,
     amountRaw,
     tokenSymbol: network.tokenSymbol,
     config,
@@ -358,7 +441,11 @@ export async function invokePaidRoute(
   const previousFetch = globalThis.fetch;
   globalThis.fetch = async (...args) => normalizeMarketplacePaymentRequirement(await deps.fetchImpl(...args));
 
-  let result;
+  let result: {
+    success: boolean;
+    statusCode: number;
+    body: unknown;
+  };
   try {
     result = await x402Pay({
       url: requestTarget.url,
@@ -369,7 +456,11 @@ export async function invokePaidRoute(
       },
       wallet: loaded.paymentWallet,
       verbose: input.verbose
-    });
+    }) as {
+      success: boolean;
+      statusCode: number;
+      body: unknown;
+    };
   } finally {
     globalThis.fetch = previousFetch;
   }
@@ -378,7 +469,7 @@ export async function invokePaidRoute(
     await recordSpend(config, amountRaw, input.configPath, deps.now());
   }
 
-  return result;
+  return buildUseRouteResult(route.ref, result.statusCode, result.body, "x402");
 }
 
 async function resolvePublishedRoute(
@@ -387,29 +478,19 @@ async function resolvePublishedRoute(
   operation: string,
   deps: CliDependencies
 ): Promise<PublishedRouteCatalogEntry> {
-  const response = await deps.fetchImpl(`${apiUrl.replace(/\/$/, "")}/.well-known/marketplace.json`);
-  if (!response.ok) {
-    throw new Error(`Marketplace catalog request failed with status ${response.status}`);
-  }
-
-  const body = await safeJson(response) as {
-    routes?: Array<{
-      provider?: string;
-      operation?: string;
-      method?: string;
-      requestSchemaJson?: JsonSchema;
-    }>;
-  };
-  const route = body.routes?.find((candidate) => candidate.provider === provider && candidate.operation === operation);
-  if (!route || (route.method !== "GET" && route.method !== "POST") || !route.requestSchemaJson) {
+  const route = await fetchRouteDetail(apiUrl, provider, operation, deps);
+  if (route.method !== "GET" && route.method !== "POST") {
     throw new Error(`Published route metadata not found for ${provider}.${operation}.`);
   }
 
   return {
-    provider,
-    operation,
+    ref: route.ref,
+    routeId: route.routeId,
+    provider: route.provider,
+    operation: route.operation,
     method: route.method,
-    requestSchemaJson: route.requestSchemaJson
+    requestSchemaJson: route.requestSchemaJson,
+    authRequirement: route.authRequirement
   };
 }
 
@@ -431,6 +512,12 @@ function buildInvocationTarget(input: {
       })}`
     };
   }
+
+  validateJsonSchema({
+    schema: input.requestSchemaJson,
+    value: input.body,
+    label: `${buildRouteRef({ provider: input.provider, operation: input.operation })} POST input`
+  });
 
   return {
     url: baseUrl,
@@ -457,6 +544,110 @@ function buildInvocationInit(
       ...headers
     },
     body
+  };
+}
+
+function buildSearchRequestUrl(
+  apiUrl: string,
+  filters: {
+    q?: string;
+    category?: string;
+    billingType?: CatalogSearchFilters["billingType"];
+    mode?: CatalogSearchFilters["mode"];
+    settlementMode?: CatalogSearchFilters["settlementMode"];
+    limit?: number;
+  }
+): string {
+  const params = new URLSearchParams();
+  if (filters.q) {
+    params.set("q", filters.q);
+  }
+  if (filters.category) {
+    params.set("category", filters.category);
+  }
+  if (filters.billingType) {
+    params.set("billingType", filters.billingType);
+  }
+  if (filters.mode) {
+    params.set("mode", filters.mode);
+  }
+  if (filters.settlementMode) {
+    params.set("settlementMode", filters.settlementMode);
+  }
+  if (typeof filters.limit === "number") {
+    params.set("limit", String(filters.limit));
+  }
+
+  const baseUrl = `${apiUrl.replace(/\/$/, "")}/catalog/search`;
+  const query = params.toString();
+  return query ? `${baseUrl}?${query}` : baseUrl;
+}
+
+function parseRouteRef(ref: string): { provider: string; operation: string } | null {
+  const [provider, operation, extra] = ref.split(".");
+  if (!provider || !operation || extra) {
+    return null;
+  }
+
+  return { provider, operation };
+}
+
+async function fetchMarketplaceJson<T>(deps: CliDependencies, url: string): Promise<T> {
+  const response = await deps.fetchImpl(url);
+  if (!response.ok) {
+    const body = await safeJson(response);
+    const message = typeof body === "string"
+      ? body
+      : typeof body === "object" && body && "error" in body && typeof body.error === "string"
+        ? body.error
+        : `Marketplace request failed with status ${response.status}`;
+    throw new Error(message);
+  }
+
+  return await response.json() as T;
+}
+
+async function fetchServiceDetail(apiUrl: string, slug: string, deps: CliDependencies): Promise<ServiceDetail> {
+  return fetchMarketplaceJson<ServiceDetail>(
+    deps,
+    `${apiUrl.replace(/\/$/, "")}/catalog/services/${encodeURIComponent(slug)}`
+  );
+}
+
+async function fetchRouteDetail(
+  apiUrl: string,
+  provider: string,
+  operation: string,
+  deps: CliDependencies
+): Promise<MarketplaceRouteDetail> {
+  return fetchMarketplaceJson<MarketplaceRouteDetail>(
+    deps,
+    `${apiUrl.replace(/\/$/, "")}/catalog/routes/${encodeURIComponent(provider)}/${encodeURIComponent(operation)}`
+  );
+}
+
+function extractJobToken(body: unknown): string | null {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  return typeof (body as { jobToken?: unknown }).jobToken === "string"
+    ? (body as { jobToken: string }).jobToken
+    : null;
+}
+
+function buildUseRouteResult(
+  ref: string,
+  statusCode: number,
+  body: unknown,
+  authFlow: UseRouteResult["authFlow"]
+): UseRouteResult {
+  return {
+    ref,
+    statusCode,
+    body,
+    authFlow,
+    jobToken: extractJobToken(body)
   };
 }
 
@@ -508,11 +699,12 @@ export async function createApiSession(
   },
   deps: CliDependencies = defaultCliDependencies()
 ) {
+  const route = await fetchRouteDetail(input.apiUrl, input.provider, input.operation, deps);
   return createScopedSession(
     {
       apiUrl: input.apiUrl,
       resourceType: "api",
-      resourceId: `${input.provider}.${input.operation}.v1`,
+      resourceId: route.routeId,
       keyfilePath: input.keyfilePath,
       configPath: input.configPath,
       network: input.network,

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  outDir: "dist",
+  format: ["esm"],
+  platform: "node",
+  target: "node20",
+  sourcemap: true,
+  splitting: false,
+  clean: true,
+  dts: false,
+  noExternal: [/^@marketplace\//]
+});

--- a/packages/shared/src/catalog.ts
+++ b/packages/shared/src/catalog.ts
@@ -615,7 +615,6 @@ export function buildCatalogSearchResults(input: {
       continue;
     }
 
-    const matchingRouteRefs = filteredRoutes.map((route) => buildRouteRef(route));
     const serviceScore = scoreTextMatch(queryTokens, [
       serviceDetail.service.slug,
       serviceDetail.service.name,
@@ -625,23 +624,32 @@ export function buildCatalogSearchResults(input: {
       serviceDetail.service.promptIntro,
       ...serviceDetail.service.categories
     ]);
-    const routeScores = filteredRoutes.map((route) =>
-      scoreTextMatch(queryTokens, [
-        buildRouteRef(route),
-        route.routeId,
-        route.provider,
-        route.operation,
-        route.title,
-        route.description,
-        route.usageNotes,
-        serviceDetail.service.slug,
-        serviceDetail.service.name,
-        serviceDetail.service.ownerName,
-        ...serviceDetail.service.categories
-      ])
-    );
-    const maxRouteScore = routeScores.reduce((highest, score) => Math.max(highest, score), -1);
-
+    const scoredRoutes = filteredRoutes.map((route) => {
+      const ref = buildRouteRef(route);
+      return {
+        route,
+        ref,
+        score: scoreTextMatch(queryTokens, [
+          ref,
+          route.routeId,
+          route.provider,
+          route.operation,
+          route.title,
+          route.description,
+          route.usageNotes,
+          serviceDetail.service.slug,
+          serviceDetail.service.name,
+          serviceDetail.service.ownerName,
+          ...serviceDetail.service.categories
+        ])
+      };
+    });
+    const maxRouteScore = scoredRoutes.reduce((highest, candidate) => Math.max(highest, candidate.score), -1);
+    const matchingRouteRefs = (queryTokens.length === 0
+      ? scoredRoutes
+      : scoredRoutes.filter((candidate) => candidate.score >= 0))
+      .map((candidate) => candidate.ref)
+      .sort((left, right) => left.localeCompare(right));
     if (queryTokens.length === 0 || serviceScore >= 0 || maxRouteScore >= 0) {
       results.push({
         score: Math.max(serviceScore, maxRouteScore > 0 ? maxRouteScore - 1 : maxRouteScore),
@@ -652,21 +660,7 @@ export function buildCatalogSearchResults(input: {
       });
     }
 
-    for (const route of filteredRoutes) {
-      const routeScore = scoreTextMatch(queryTokens, [
-        buildRouteRef(route),
-        route.routeId,
-        route.provider,
-        route.operation,
-        route.title,
-        route.description,
-        route.usageNotes,
-        serviceDetail.service.slug,
-        serviceDetail.service.name,
-        serviceDetail.service.ownerName,
-        ...serviceCategories
-      ]);
-
+    for (const { route, score: routeScore } of scoredRoutes) {
       if (queryTokens.length > 0 && routeScore < 0) {
         continue;
       }

--- a/packages/shared/src/catalog.ts
+++ b/packages/shared/src/catalog.ts
@@ -15,7 +15,7 @@ import {
   PAYMENT_RESPONSE_HEADER,
   PAYMENT_SIGNATURE_HEADER
 } from "./constants.js";
-import { getDefaultMarketplaceNetworkConfig } from "./network.js";
+import { getDefaultMarketplaceNetworkConfig, getMarketplaceTokenSymbol } from "./network.js";
 import { serializeQueryInput } from "./request-input.js";
 import { settlementModeDescription, settlementModeLabel } from "./settlement.js";
 import type {
@@ -57,7 +57,7 @@ function roundToSingleDecimal(value: number): number {
   return Math.round(value * 10) / 10;
 }
 
-function formatPriceLabelFromRaw(rawAmount: string, tokenSymbol = getDefaultMarketplaceNetworkConfig().tokenSymbol): string {
+function formatPriceLabelFromRaw(rawAmount: string, tokenSymbol: MarketplaceServiceCatalogEndpoint["tokenSymbol"]): string {
   return `$${rawToDecimalString(rawAmount, 6)} ${tokenSymbol}`;
 }
 
@@ -202,8 +202,16 @@ export function formatRevenueLabel(rawAmount: string): string {
   return rawToDecimalString(rawAmount, 6);
 }
 
+function getRouteTokenSymbol(route: Pick<MarketplaceRoute, "network">): MarketplaceServiceCatalogEndpoint["tokenSymbol"] {
+  return getMarketplaceTokenSymbol(route.network);
+}
+
+function getRoutesTokenSymbol(routes: Array<Pick<MarketplaceRoute, "network">>): MarketplaceServiceCatalogEndpoint["tokenSymbol"] {
+  return routes[0] ? getRouteTokenSymbol(routes[0]) : getDefaultMarketplaceNetworkConfig().tokenSymbol;
+}
+
 export function buildPriceRange(routes: MarketplaceRoute[]): string {
-  const tokenSymbol = getDefaultMarketplaceNetworkConfig().tokenSymbol;
+  const tokenSymbol = getRoutesTokenSymbol(routes);
   const fixedRoutes = routes
     .filter(isFixedX402Billing)
     .map((route) => quotedPriceRaw(route))
@@ -246,7 +254,7 @@ export function buildMarketplaceServiceEndpoint(
   apiBaseUrl: string
 ): MarketplaceServiceCatalogEndpoint {
   const path = `/api/${route.provider}/${route.operation}`;
-  const tokenSymbol = getDefaultMarketplaceNetworkConfig().tokenSymbol;
+  const tokenSymbol = getRouteTokenSymbol(route);
 
   return {
     endpointType: "marketplace_proxy",
@@ -477,6 +485,7 @@ export function buildServiceSummary(input: {
 
   const routes = input.endpoints.filter(isMarketplaceEndpoint);
   const settlementMode = input.service.settlementMode ?? "verified_escrow";
+  const settlementToken = getRoutesTokenSymbol(routes);
 
   const summary: MarketplaceServiceSummary = {
     serviceType: "marketplace_proxy",
@@ -489,7 +498,7 @@ export function buildServiceSummary(input: {
     settlementLabel: settlementModeLabel(settlementMode),
     settlementDescription: settlementModeDescription(settlementMode),
     priceRange: buildPriceRange(routes),
-    settlementToken: getDefaultMarketplaceNetworkConfig().tokenSymbol,
+    settlementToken,
     endpointCount: routes.length,
     totalCalls: input.analytics.totalCalls,
     revenue: formatRevenueLabel(input.analytics.revenueRaw),

--- a/packages/shared/src/catalog.ts
+++ b/packages/shared/src/catalog.ts
@@ -1,26 +1,57 @@
 import { rawToDecimalString } from "./amounts.js";
-import { isFixedX402Billing, isFreeBilling, isPrepaidCreditBilling, isTopupX402Billing, quotedPriceRaw, routePriceLabel } from "./billing.js";
+import {
+  isFixedX402Billing,
+  isFreeBilling,
+  isPrepaidCreditBilling,
+  isTopupX402Billing,
+  quotedPriceRaw,
+  requiresWalletSession,
+  requiresX402Payment,
+  routePriceLabel
+} from "./billing.js";
+import {
+  PAYMENT_IDENTIFIER_HEADER,
+  PAYMENT_REQUIRED_HEADER,
+  PAYMENT_RESPONSE_HEADER,
+  PAYMENT_SIGNATURE_HEADER
+} from "./constants.js";
 import { getDefaultMarketplaceNetworkConfig } from "./network.js";
 import { serializeQueryInput } from "./request-input.js";
 import { settlementModeDescription, settlementModeLabel } from "./settlement.js";
 import type {
+  CatalogSearchFilters,
+  CatalogSearchResult,
   ExternalRegistryServiceSummary,
   ExternalServiceCatalogEndpoint,
   MarketplaceRoute,
+  MarketplaceRouteAuthRequirement,
+  MarketplaceRouteDetail,
+  MarketplaceRouteSearchSummary,
   MarketplaceServiceCatalogEndpoint,
   MarketplaceServiceSummary,
   PublishedExternalEndpointVersionRecord,
   PublishedEndpointVersionRecord,
   PublishedServiceEndpointVersionRecord,
+  RouteSearchResult,
   ServiceAnalytics,
   ServiceDefinition,
   ServiceDetail,
+  ServiceSearchResult,
   ServiceSummary
 } from "./types.js";
 
 function joinUrl(baseUrl: string, path: string): string {
   return `${baseUrl.replace(/\/$/, "")}${path.startsWith("/") ? path : `/${path}`}`;
 }
+
+type PublishedCatalogService = {
+  service: ServiceDefinition;
+  endpoints: PublishedServiceEndpointVersionRecord[];
+};
+
+type PublishedCatalogServiceWithAnalytics = PublishedCatalogService & {
+  analytics: ServiceAnalytics;
+};
 
 function roundToSingleDecimal(value: number): number {
   return Math.round(value * 10) / 10;
@@ -44,6 +75,127 @@ function isExternalEndpoint(
   endpoint: PublishedServiceEndpointVersionRecord
 ): endpoint is PublishedExternalEndpointVersionRecord {
   return endpoint.endpointType === "external_registry";
+}
+
+function normalizeSearchText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function tokenizeSearchQuery(query?: string): string[] {
+  const normalized = normalizeSearchText(query ?? "");
+  return normalized ? normalized.split(/\s+/).filter(Boolean) : [];
+}
+
+function scoreTextMatch(tokens: string[], fields: Array<string | null | undefined>): number {
+  if (tokens.length === 0) {
+    return 0;
+  }
+
+  const normalizedFields = fields
+    .map((field) => normalizeSearchText(field ?? ""))
+    .filter((field) => field.length > 0);
+  if (normalizedFields.length === 0) {
+    return -1;
+  }
+
+  let matchedTokens = 0;
+  let score = 0;
+  for (const token of tokens) {
+    let tokenScore = 0;
+    for (const field of normalizedFields) {
+      const words = field.split(/\s+/);
+      if (field === token) {
+        tokenScore = Math.max(tokenScore, 12);
+        continue;
+      }
+      if (words.includes(token)) {
+        tokenScore = Math.max(tokenScore, 8);
+        continue;
+      }
+      if (field.includes(token)) {
+        tokenScore = Math.max(tokenScore, 4);
+      }
+    }
+
+    if (tokenScore > 0) {
+      matchedTokens += 1;
+      score += tokenScore;
+    }
+  }
+
+  return matchedTokens > 0 ? score : -1;
+}
+
+function matchesCategory(categories: string[], category?: string): boolean {
+  if (!category) {
+    return true;
+  }
+
+  const normalizedCategory = normalizeSearchText(category);
+  return categories.some((candidate) => normalizeSearchText(candidate) === normalizedCategory);
+}
+
+function compareSearchResultIdentity(left: CatalogSearchResult, right: CatalogSearchResult): number {
+  const leftIdentity = left.kind === "route" ? left.summary.ref : left.summary.slug;
+  const rightIdentity = right.kind === "route" ? right.summary.ref : right.summary.slug;
+  return leftIdentity.localeCompare(rightIdentity);
+}
+
+function buildServiceSearchResult(input: {
+  summary: ServiceSummary;
+  routeRefs: string[];
+}): ServiceSearchResult {
+  return {
+    kind: "service",
+    summary: input.summary,
+    executableByMarketplace: input.summary.serviceType === "marketplace_proxy",
+    routeRefs: input.routeRefs
+  };
+}
+
+function buildRouteSearchResult(input: {
+  summary: MarketplaceRouteSearchSummary;
+}): RouteSearchResult {
+  return {
+    kind: "route",
+    summary: input.summary
+  };
+}
+
+export function buildRouteRef(input: Pick<MarketplaceRoute, "provider" | "operation">): string {
+  return `${input.provider}.${input.operation}`;
+}
+
+export function buildRouteAuthRequirement(route: MarketplaceRoute): MarketplaceRouteAuthRequirement {
+  if (requiresX402Payment(route)) {
+    return {
+      type: "x402",
+      description: "Requires x402 payment headers and Fast wallet authorization.",
+      paymentProtocol: "x402",
+      paymentHeaders: {
+        required: PAYMENT_REQUIRED_HEADER,
+        signature: PAYMENT_SIGNATURE_HEADER,
+        response: PAYMENT_RESPONSE_HEADER,
+        paymentIdentifier: PAYMENT_IDENTIFIER_HEADER
+      }
+    };
+  }
+
+  if (requiresWalletSession(route)) {
+    return {
+      type: "wallet_session",
+      description: "Requires a wallet-bound bearer token scoped to the route.",
+      authorizationScheme: "Bearer",
+      challengeEndpoint: "/auth/challenge",
+      sessionEndpoint: "/auth/session",
+      resourceType: "api"
+    };
+  }
+
+  return {
+    type: "none",
+    description: "No payment headers or bearer token required."
+  };
 }
 
 export function formatRevenueLabel(rawAmount: string): string {
@@ -99,6 +251,7 @@ export function buildMarketplaceServiceEndpoint(
   return {
     endpointType: "marketplace_proxy",
     routeId: route.routeId,
+    ref: buildRouteRef(route),
     title: route.title,
     description: route.description,
     price: routePriceLabel(route),
@@ -108,11 +261,46 @@ export function buildMarketplaceServiceEndpoint(
     method: route.method,
     path,
     proxyUrl: joinUrl(apiBaseUrl, path),
+    authRequirement: buildRouteAuthRequirement(route),
     requestSchemaJson: route.requestSchemaJson,
     responseSchemaJson: route.responseSchemaJson,
     requestExample: route.requestExample,
     responseExample: route.responseExample,
     usageNotes: route.usageNotes
+  };
+}
+
+export function buildMarketplaceRouteSearchSummary(input: {
+  route: MarketplaceRoute;
+  service: ServiceDefinition;
+  apiBaseUrl: string;
+}): MarketplaceRouteSearchSummary {
+  const endpoint = buildMarketplaceServiceEndpoint(input.route, input.apiBaseUrl);
+  const settlementMode = input.route.settlementMode;
+
+  return {
+    ref: buildRouteRef(input.route),
+    routeId: input.route.routeId,
+    provider: input.route.provider,
+    operation: input.route.operation,
+    serviceSlug: input.service.slug,
+    serviceName: input.service.name,
+    ownerName: input.service.ownerName,
+    categories: input.service.categories,
+    title: input.route.title,
+    description: input.route.description,
+    price: endpoint.price,
+    billingType: endpoint.billingType,
+    tokenSymbol: endpoint.tokenSymbol,
+    mode: endpoint.mode,
+    method: endpoint.method,
+    path: endpoint.path,
+    proxyUrl: endpoint.proxyUrl,
+    settlementMode,
+    settlementLabel: settlementModeLabel(settlementMode),
+    settlementDescription: settlementModeDescription(settlementMode),
+    authRequirement: endpoint.authRequirement ?? buildRouteAuthRequirement(input.route),
+    usageNotes: endpoint.usageNotes
   };
 }
 
@@ -313,6 +501,202 @@ export function buildServiceSummary(input: {
   };
 
   return summary;
+}
+
+export function buildMarketplaceRouteDetail(input: {
+  route: PublishedEndpointVersionRecord;
+  service: ServiceDefinition;
+  serviceEndpoints: PublishedServiceEndpointVersionRecord[];
+  analytics: ServiceAnalytics;
+  apiBaseUrl: string;
+}): MarketplaceRouteDetail {
+  const endpoint = buildMarketplaceServiceEndpoint(input.route, input.apiBaseUrl);
+  const serviceSummary = buildServiceSummary({
+    service: input.service,
+    endpoints: input.serviceEndpoints,
+    analytics: input.analytics
+  });
+  if (serviceSummary.serviceType !== "marketplace_proxy") {
+    throw new Error("Expected a marketplace proxy service summary.");
+  }
+
+  return {
+    kind: "route",
+    ref: buildRouteRef(input.route),
+    routeId: input.route.routeId,
+    provider: input.route.provider,
+    operation: input.route.operation,
+    serviceSlug: input.service.slug,
+    serviceName: input.service.name,
+    ownerName: input.service.ownerName,
+    categories: input.service.categories,
+    title: input.route.title,
+    description: input.route.description,
+    price: endpoint.price,
+    billingType: endpoint.billingType,
+    tokenSymbol: endpoint.tokenSymbol,
+    mode: endpoint.mode,
+    method: endpoint.method,
+    path: endpoint.path,
+    proxyUrl: endpoint.proxyUrl,
+    settlementMode: input.route.settlementMode,
+    settlementLabel: settlementModeLabel(input.route.settlementMode),
+    settlementDescription: settlementModeDescription(input.route.settlementMode),
+    authRequirement: endpoint.authRequirement ?? buildRouteAuthRequirement(input.route),
+    requestSchemaJson: endpoint.requestSchemaJson,
+    responseSchemaJson: endpoint.responseSchemaJson,
+    requestExample: endpoint.requestExample,
+    responseExample: endpoint.responseExample,
+    usageNotes: endpoint.usageNotes,
+    asyncConfig: input.route.asyncConfig ?? null,
+    serviceSummary
+  };
+}
+
+export function buildCatalogSearchResults(input: {
+  services: PublishedCatalogServiceWithAnalytics[];
+  apiBaseUrl: string;
+  filters?: CatalogSearchFilters;
+}): CatalogSearchResult[] {
+  const filters = input.filters ?? {};
+  const queryTokens = tokenizeSearchQuery(filters.q);
+  const results: Array<{ score: number; result: CatalogSearchResult }> = [];
+
+  for (const serviceDetail of input.services) {
+    const summary = buildServiceSummary({
+      service: serviceDetail.service,
+      endpoints: serviceDetail.endpoints,
+      analytics: serviceDetail.analytics
+    });
+    const serviceCategories = serviceDetail.service.categories;
+    if (!matchesCategory(serviceCategories, filters.category)) {
+      continue;
+    }
+
+    const marketplaceRoutes = serviceDetail.endpoints.filter(isMarketplaceEndpoint);
+    const filteredRoutes = marketplaceRoutes.filter((route) => {
+      if (filters.billingType && route.billing.type !== filters.billingType) {
+        return false;
+      }
+      if (filters.mode && route.mode !== filters.mode) {
+        return false;
+      }
+      if (filters.settlementMode && route.settlementMode !== filters.settlementMode) {
+        return false;
+      }
+      return true;
+    });
+
+    if (
+      (filters.billingType || filters.mode)
+      && serviceDetail.service.serviceType !== "marketplace_proxy"
+    ) {
+      continue;
+    }
+
+    if (
+      filters.settlementMode
+      && serviceDetail.service.serviceType === "marketplace_proxy"
+      && (serviceDetail.service.settlementMode ?? "verified_escrow") !== filters.settlementMode
+      && filteredRoutes.length === 0
+    ) {
+      continue;
+    }
+
+    if (serviceDetail.service.serviceType === "external_registry" && filters.settlementMode) {
+      continue;
+    }
+
+    if (
+      serviceDetail.service.serviceType === "marketplace_proxy"
+      && (filters.billingType || filters.mode || filters.settlementMode)
+      && filteredRoutes.length === 0
+    ) {
+      continue;
+    }
+
+    const matchingRouteRefs = filteredRoutes.map((route) => buildRouteRef(route));
+    const serviceScore = scoreTextMatch(queryTokens, [
+      serviceDetail.service.slug,
+      serviceDetail.service.name,
+      serviceDetail.service.ownerName,
+      serviceDetail.service.tagline,
+      serviceDetail.service.about,
+      serviceDetail.service.promptIntro,
+      ...serviceDetail.service.categories
+    ]);
+    const routeScores = filteredRoutes.map((route) =>
+      scoreTextMatch(queryTokens, [
+        buildRouteRef(route),
+        route.routeId,
+        route.provider,
+        route.operation,
+        route.title,
+        route.description,
+        route.usageNotes,
+        serviceDetail.service.slug,
+        serviceDetail.service.name,
+        serviceDetail.service.ownerName,
+        ...serviceDetail.service.categories
+      ])
+    );
+    const maxRouteScore = routeScores.reduce((highest, score) => Math.max(highest, score), -1);
+
+    if (queryTokens.length === 0 || serviceScore >= 0 || maxRouteScore >= 0) {
+      results.push({
+        score: Math.max(serviceScore, maxRouteScore > 0 ? maxRouteScore - 1 : maxRouteScore),
+        result: buildServiceSearchResult({
+          summary,
+          routeRefs: serviceDetail.service.serviceType === "marketplace_proxy" ? matchingRouteRefs : []
+        })
+      });
+    }
+
+    for (const route of filteredRoutes) {
+      const routeScore = scoreTextMatch(queryTokens, [
+        buildRouteRef(route),
+        route.routeId,
+        route.provider,
+        route.operation,
+        route.title,
+        route.description,
+        route.usageNotes,
+        serviceDetail.service.slug,
+        serviceDetail.service.name,
+        serviceDetail.service.ownerName,
+        ...serviceCategories
+      ]);
+
+      if (queryTokens.length > 0 && routeScore < 0) {
+        continue;
+      }
+
+      results.push({
+        score: routeScore,
+        result: buildRouteSearchResult({
+          summary: buildMarketplaceRouteSearchSummary({
+            route,
+            service: serviceDetail.service,
+            apiBaseUrl: input.apiBaseUrl
+          })
+        })
+      });
+    }
+  }
+
+  const sorted = results
+    .sort((left, right) => {
+      if (right.score !== left.score) {
+        return right.score - left.score;
+      }
+      if (left.result.kind !== right.result.kind) {
+        return left.result.kind === "route" ? -1 : 1;
+      }
+      return compareSearchResultIdentity(left.result, right.result);
+    })
+    .map((entry) => entry.result);
+
+  return typeof filters.limit === "number" ? sorted.slice(0, filters.limit) : sorted;
 }
 
 export function buildServiceDetail(input: {

--- a/packages/shared/src/docs.ts
+++ b/packages/shared/src/docs.ts
@@ -86,9 +86,19 @@ export function buildOpenApiDocument(input: {
         summary: "List marketplace services with live stats."
       }
     },
+    "/catalog/search": {
+      get: {
+        summary: "Search marketplace services and executable routes with machine-readable filters."
+      }
+    },
     "/catalog/services/{slug}": {
       get: {
         summary: "Get one marketplace service with endpoint docs and generated usage instructions."
+      }
+    },
+    "/catalog/routes/{provider}/{operation}": {
+      get: {
+        summary: "Get one executable marketplace route with machine-readable auth, pricing, and schema details."
       }
     },
     "/catalog/suggestions": {
@@ -386,6 +396,7 @@ export function buildLlmsTxt(input: {
     `Fast network: ${network.displayName}`,
     `Settlement token: ${network.tokenSymbol}`,
     `Marketplace catalog: ${baseUrl}/catalog/services`,
+    `Marketplace search: ${baseUrl}/catalog/search`,
     "Payment protocol for paid trigger routes: x402 over HTTP",
     `Payment headers for x402 routes: ${PAYMENT_REQUIRED_HEADER}, ${PAYMENT_SIGNATURE_HEADER}, ${PAYMENT_RESPONSE_HEADER}`,
     "Repeat retrieval auth: wallet challenge session with a Bearer access token scoped to the route or job resource",

--- a/packages/shared/src/network.ts
+++ b/packages/shared/src/network.ts
@@ -67,3 +67,7 @@ export function getDefaultMarketplaceNetworkConfig(): MarketplaceNetworkConfig {
 export function getMarketplaceAssetId(paymentNetwork: MarketplacePaymentNetwork): string {
   return paymentNetwork === "fast-testnet" ? FAST_TESTNET_USDC_ASSET_ID : FAST_MAINNET_USDC_ASSET_ID;
 }
+
+export function getMarketplaceTokenSymbol(paymentNetwork: MarketplacePaymentNetwork): MarketplaceTokenSymbol {
+  return paymentNetwork === "fast-testnet" ? "testUSDC" : "USDC";
+}

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -709,6 +709,10 @@ describe("shared marketplace helpers", () => {
         settlementMode: "verified_escrow"
       }
     });
+    const unfilteredSearch = buildCatalogSearchResults({
+      services: [searchableService],
+      apiBaseUrl: "https://api.marketplace.example.com"
+    });
 
     expect(fixedSearch[0]).toMatchObject({
       kind: "route",
@@ -718,7 +722,7 @@ describe("shared marketplace helpers", () => {
     });
     expect(fixedSearch[1]).toMatchObject({
       kind: "service",
-      routeRefs: ["mock.quick-insight", "mock.free-async-search"]
+      routeRefs: ["mock.quick-insight"]
     });
     expect(asyncSearch).toEqual([
       expect.objectContaining({
@@ -735,6 +739,10 @@ describe("shared marketplace helpers", () => {
         routeRefs: ["mock.free-async-search"]
       })
     ]);
+    expect(unfilteredSearch.find((result) => result.kind === "service")).toMatchObject({
+      kind: "service",
+      routeRefs: ["mock.free-async-search", "mock.quick-insight"]
+    });
   });
 
   it("computes service analytics and provider request queue state in the in-memory store", async () => {

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -573,13 +573,13 @@ describe("shared marketplace helpers", () => {
       webBaseUrl: "https://marketplace.example.com"
     });
 
-    expect(buildPriceRange(endpoints)).toBe("$0.05 USDC - $0.15 USDC");
+    expect(buildPriceRange(endpoints)).toBe("$0.05 testUSDC - $0.15 testUSDC");
     expect(detail.skillUrl).toBe("https://marketplace.example.com/skill.md");
     expect(detail.summary.endpointCount).toBe(2);
-    expect(detail.summary.settlementToken).toBe("USDC");
+    expect(detail.summary.settlementToken).toBe("testUSDC");
     expect(detail.useThisServicePrompt).toContain('I want to use the "Mock Research Signals" service');
     expect(detail.useThisServicePrompt).toContain("https://api.marketplace.example.com/api/mock/quick-insight");
-    expect(detail.useThisServicePrompt).toContain("($0.05 USDC)");
+    expect(detail.useThisServicePrompt).toContain("($0.05 testUSDC)");
   });
 
   it("derives explicit auth requirements for marketplace routes", () => {
@@ -660,7 +660,9 @@ describe("shared marketplace helpers", () => {
     expect(detail.authRequirement).toMatchObject({
       type: "x402"
     });
+    expect(detail.tokenSymbol).toBe("testUSDC");
     expect(detail.serviceSummary.slug).toBe("mock-research-signals");
+    expect(detail.serviceSummary.settlementToken).toBe("testUSDC");
   });
 
   it("builds mixed search results with deterministic ordering and filters", () => {
@@ -717,7 +719,8 @@ describe("shared marketplace helpers", () => {
     expect(fixedSearch[0]).toMatchObject({
       kind: "route",
       summary: {
-        ref: "mock.quick-insight"
+        ref: "mock.quick-insight",
+        tokenSymbol: "testUSDC"
       }
     });
     expect(fixedSearch[1]).toMatchObject({
@@ -729,6 +732,7 @@ describe("shared marketplace helpers", () => {
         kind: "route",
         summary: expect.objectContaining({
           ref: "mock.free-async-search",
+          tokenSymbol: "testUSDC",
           authRequirement: expect.objectContaining({
             type: "wallet_session"
           })

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -4,9 +4,12 @@ import { describe, expect, it } from "vitest";
 import {
   InMemoryMarketplaceStore,
   PostgresMarketplaceStore,
+  buildCatalogSearchResults,
+  buildMarketplaceRouteDetail,
   buildPriceRange,
   buildMarketplaceRoutes,
   buildPaymentRequirementForRoute,
+  buildRouteAuthRequirement,
   buildServiceDetail,
   buildOpenApiDocument,
   buildPayoutSplit,
@@ -577,6 +580,161 @@ describe("shared marketplace helpers", () => {
     expect(detail.useThisServicePrompt).toContain('I want to use the "Mock Research Signals" service');
     expect(detail.useThisServicePrompt).toContain("https://api.marketplace.example.com/api/mock/quick-insight");
     expect(detail.useThisServicePrompt).toContain("($0.05 USDC)");
+  });
+
+  it("derives explicit auth requirements for marketplace routes", () => {
+    const fixedRoute = TESTNET_MARKETPLACE_ROUTES.find((candidate) => candidate.routeId === "mock.quick-insight.v1");
+    const asyncRoute = TESTNET_MARKETPLACE_ROUTES.find((candidate) => candidate.routeId === "mock.async-report.v1");
+    if (!fixedRoute || !asyncRoute) {
+      throw new Error("Mock seeded routes are missing.");
+    }
+
+    expect(buildRouteAuthRequirement(fixedRoute)).toMatchObject({
+      type: "x402"
+    });
+    expect(buildRouteAuthRequirement({
+      ...fixedRoute,
+      routeId: "mock.prepaid-insight.v1",
+      operation: "prepaid-insight",
+      billing: {
+        type: "prepaid_credit" as const
+      },
+      price: "Prepaid credit"
+    })).toMatchObject({
+      type: "wallet_session"
+    });
+    expect(buildRouteAuthRequirement({
+      ...fixedRoute,
+      routeId: "mock.free-sync.v1",
+      operation: "free-sync",
+      billing: {
+        type: "free" as const
+      },
+      price: "Free"
+    })).toMatchObject({
+      type: "none"
+    });
+    expect(buildRouteAuthRequirement({
+      ...asyncRoute,
+      routeId: "mock.free-async.v1",
+      operation: "free-async",
+      billing: {
+        type: "free" as const
+      },
+      price: "Free"
+    })).toMatchObject({
+      type: "wallet_session"
+    });
+  });
+
+  it("builds marketplace route detail from the shared catalog", () => {
+    const service = TESTNET_SERVICE_DEFINITIONS.find((candidate) => candidate.slug === "mock-research-signals");
+    const route = TESTNET_MARKETPLACE_ROUTES.find((candidate) => candidate.routeId === "mock.quick-insight.v1");
+    if (!service || !route) {
+      throw new Error("Mock seeded service is missing.");
+    }
+
+    const publishedEndpoints = TESTNET_MARKETPLACE_ROUTES
+      .filter((candidate) => service.routeIds.includes(candidate.routeId))
+      .map((candidate) => buildPublishedEndpointFromRoute(candidate));
+    const detail = buildMarketplaceRouteDetail({
+      route: buildPublishedEndpointFromRoute(route),
+      service,
+      serviceEndpoints: publishedEndpoints,
+      analytics: {
+        totalCalls: 12,
+        revenueRaw: "420000",
+        successRate30d: 66.666,
+        volume30d: [{ date: "2026-03-18", amountRaw: "150000" }]
+      },
+      apiBaseUrl: "https://api.marketplace.example.com"
+    });
+
+    expect(detail).toMatchObject({
+      kind: "route",
+      ref: "mock.quick-insight",
+      routeId: "mock.quick-insight.v1",
+      billingType: "fixed_x402",
+      method: "POST"
+    });
+    expect(detail.authRequirement).toMatchObject({
+      type: "x402"
+    });
+    expect(detail.serviceSummary.slug).toBe("mock-research-signals");
+  });
+
+  it("builds mixed search results with deterministic ordering and filters", () => {
+    const service = TESTNET_SERVICE_DEFINITIONS.find((candidate) => candidate.slug === "mock-research-signals");
+    const fixedRoute = TESTNET_MARKETPLACE_ROUTES.find((candidate) => candidate.routeId === "mock.quick-insight.v1");
+    const asyncRoute = TESTNET_MARKETPLACE_ROUTES.find((candidate) => candidate.routeId === "mock.async-report.v1");
+    if (!service || !fixedRoute || !asyncRoute) {
+      throw new Error("Mock seeded service is missing.");
+    }
+
+    const searchableService = {
+      service,
+      endpoints: [
+        buildPublishedEndpointFromRoute(fixedRoute),
+        buildPublishedEndpointFromRoute({
+          ...asyncRoute,
+          routeId: "mock.free-async-search.v1",
+          operation: "free-async-search",
+          billing: {
+            type: "free" as const
+          },
+          price: "Free"
+        })
+      ],
+      analytics: {
+        totalCalls: 1,
+        revenueRaw: "50000",
+        successRate30d: 100,
+        volume30d: []
+      }
+    };
+
+    const fixedSearch = buildCatalogSearchResults({
+      services: [searchableService],
+      apiBaseUrl: "https://api.marketplace.example.com",
+      filters: {
+        q: "quick insight"
+      }
+    });
+    const asyncSearch = buildCatalogSearchResults({
+      services: [searchableService],
+      apiBaseUrl: "https://api.marketplace.example.com",
+      filters: {
+        mode: "async",
+        billingType: "free",
+        settlementMode: "verified_escrow"
+      }
+    });
+
+    expect(fixedSearch[0]).toMatchObject({
+      kind: "route",
+      summary: {
+        ref: "mock.quick-insight"
+      }
+    });
+    expect(fixedSearch[1]).toMatchObject({
+      kind: "service",
+      routeRefs: ["mock.quick-insight", "mock.free-async-search"]
+    });
+    expect(asyncSearch).toEqual([
+      expect.objectContaining({
+        kind: "route",
+        summary: expect.objectContaining({
+          ref: "mock.free-async-search",
+          authRequirement: expect.objectContaining({
+            type: "wallet_session"
+          })
+        })
+      }),
+      expect.objectContaining({
+        kind: "service",
+        routeRefs: ["mock.free-async-search"]
+      })
+    ]);
   });
 
   it("computes service analytics and provider request queue state in the in-memory store", async () => {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -247,6 +247,7 @@ export type ServiceSummary = MarketplaceServiceSummary | ExternalRegistryService
 export interface MarketplaceServiceCatalogEndpoint {
   endpointType: "marketplace_proxy";
   routeId: string;
+  ref?: string;
   title: string;
   description: string;
   price: string;
@@ -256,6 +257,7 @@ export interface MarketplaceServiceCatalogEndpoint {
   method: HttpMethod;
   path: string;
   proxyUrl: string;
+  authRequirement?: MarketplaceRouteAuthRequirement;
   requestSchemaJson: JsonSchema;
   responseSchemaJson: JsonSchema;
   requestExample: unknown;
@@ -299,6 +301,111 @@ export interface ExternalRegistryServiceDetail {
 }
 
 export type ServiceDetail = MarketplaceServiceDetail | ExternalRegistryServiceDetail;
+
+export type MarketplaceRouteAuthRequirement =
+  | {
+      type: "x402";
+      description: string;
+      paymentProtocol: "x402";
+      paymentHeaders: {
+        required: string;
+        signature: string;
+        response: string;
+        paymentIdentifier: string;
+      };
+    }
+  | {
+      type: "wallet_session";
+      description: string;
+      authorizationScheme: "Bearer";
+      challengeEndpoint: string;
+      sessionEndpoint: string;
+      resourceType: "api";
+    }
+  | {
+      type: "none";
+      description: string;
+    };
+
+export interface CatalogSearchFilters {
+  q?: string;
+  category?: string;
+  billingType?: RouteBillingType;
+  mode?: RouteMode;
+  settlementMode?: SettlementMode;
+  limit?: number;
+}
+
+export interface MarketplaceRouteSearchSummary {
+  ref: string;
+  routeId: string;
+  provider: string;
+  operation: string;
+  serviceSlug: string;
+  serviceName: string;
+  ownerName: string;
+  categories: string[];
+  title: string;
+  description: string;
+  price: string;
+  billingType: RouteBillingType;
+  tokenSymbol: MarketplaceTokenSymbol;
+  mode: RouteMode;
+  method: HttpMethod;
+  path: string;
+  proxyUrl: string;
+  settlementMode: SettlementMode;
+  settlementLabel: string;
+  settlementDescription: string;
+  authRequirement: MarketplaceRouteAuthRequirement;
+  usageNotes?: string;
+}
+
+export interface ServiceSearchResult {
+  kind: "service";
+  summary: ServiceSummary;
+  executableByMarketplace: boolean;
+  routeRefs: string[];
+}
+
+export interface RouteSearchResult {
+  kind: "route";
+  summary: MarketplaceRouteSearchSummary;
+}
+
+export type CatalogSearchResult = ServiceSearchResult | RouteSearchResult;
+
+export interface MarketplaceRouteDetail {
+  kind: "route";
+  ref: string;
+  routeId: string;
+  provider: string;
+  operation: string;
+  serviceSlug: string;
+  serviceName: string;
+  ownerName: string;
+  categories: string[];
+  title: string;
+  description: string;
+  price: string;
+  billingType: RouteBillingType;
+  tokenSymbol: MarketplaceTokenSymbol;
+  mode: RouteMode;
+  method: HttpMethod;
+  path: string;
+  proxyUrl: string;
+  settlementMode: SettlementMode;
+  settlementLabel: string;
+  settlementDescription: string;
+  authRequirement: MarketplaceRouteAuthRequirement;
+  requestSchemaJson: JsonSchema;
+  responseSchemaJson: JsonSchema;
+  requestExample: unknown;
+  responseExample: unknown;
+  usageNotes?: string;
+  asyncConfig?: RouteAsyncConfig | null;
+  serviceSummary: MarketplaceServiceSummary;
+}
 
 export interface SuggestionRecord {
   id: string;


### PR DESCRIPTION
## Summary
- add shared catalog search and route-detail contracts with explicit auth requirements
- add machine-readable catalog search and route-detail API endpoints
- replace the buyer CLI surface with search/show/use plus job retrieval and add an installable fast-marketplace bin

## Verification
- npm test
- npm run build

Closes #12