### PR TITLE
Allow external registry submissions without verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ test-results
 !.env*.example
 .envrc
 .direnv/
+.tmp/provider-seeds/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For `verified_escrow`, successful route charges and top-ups create provider payo
 
 - Creates a service as `external_registry`
 - Adds direct `GET` or `POST` endpoint listings with `publicUrl`, `docsUrl`, auth notes, and examples
-- Verifies website ownership
+- Does not need website verification to submit
 - Submits for admin review
 - After publish, appears in the catalog as a discovery-only external API
 - Marketplace does not proxy calls, collect payment, mint runtime auth, or track execution analytics
@@ -58,7 +58,7 @@ For `verified_escrow`, successful route charges and top-ups create provider payo
 
 - Log in at `/admin/login`
 - Reviews submitted provider services
-- Checks website verification and service completeness
+- Checks service completeness and website verification where required
 - Requests changes or publishes
 - Publishes discovery-only metadata for `external_registry` services
 - Publishes `marketplace_proxy` services as `verified_escrow`
@@ -235,11 +235,18 @@ Set `AGENT_WALLET_KEY`, `MARKETPLACE_API_BASE_URL`, and `MARKETPLACE_FAST_NETWOR
 
 ```bash
 npm run cli -- provider sync --spec ./provider-spec.json
-npm run cli -- provider verify --service <slug-or-id>
 npm run cli -- provider submit --service <slug-or-id>
 ```
 
-`provider verify` always creates a fresh verification challenge and prompts before the marketplace attempts verification. For arbitrary external sites, host the token outside this repo first; the CLI will not mutate deploy, DNS, or cloud env settings on its own.
+For `marketplace_proxy` services, run verification before submit:
+
+```bash
+npm run cli -- provider verify --service <slug-or-id>
+```
+
+`provider verify` always creates a fresh verification challenge and prompts before the marketplace attempts verification. For arbitrary external sites, host the token outside this repo first; the CLI will not mutate deploy, DNS, or cloud env settings on its own. Discovery-only `external_registry` services can submit without verification and still wait in `pending_review` until an admin publishes them.
+
+For curated x402 imports, keep local `ProviderSyncSpec` seed files under a gitignored path such as `.tmp/provider-seeds/` and use the normal `provider sync` plus `provider submit` flow with a Fast-operated provider account.
 
 9. Build runtime artifacts:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -410,12 +410,13 @@ Important constraints:
 6. For `topup_x402_variable` endpoints, set `minAmount` and `maxAmount`; the marketplace owns the top-up crediting flow.
 7. For async HTTP endpoints, require a provider runtime key and implement the marketplace async contract: execute returns `202` with `providerJobId`, poll routes expose `pollPath`, and webhook routes complete through the marketplace callback endpoint.
 8. For `prepaid_credit` endpoints, verify marketplace identity headers upstream and use the provider runtime credit APIs to reserve, capture, release, and when needed extend buyer credit reservations.
-9. Run `npm run cli -- provider verify --service <slug-or-id>` to mint a fresh verification challenge and show the exact URL and token the website must serve.
+9. For `marketplace_proxy`, run `npm run cli -- provider verify --service <slug-or-id>` to mint a fresh verification challenge and show the exact URL and token the website must serve.
 10. If verification requires touching deploy, DNS, or cloud env outside this repo, ask the user before taking that action. For arbitrary external sites, the agent should hand off the token and wait for confirmation rather than mutating infrastructure on its own.
 11. After the user confirms the verification token is live, continue the same `provider verify` flow so the marketplace performs the ownership check.
-12. Run `npm run cli -- provider submit --service <slug-or-id>` only after verification succeeds; this flow stops at `pending_review`, not admin publish.
+12. Run `npm run cli -- provider submit --service <slug-or-id>` when the draft is ready. `marketplace_proxy` requires verification first; `external_registry` can submit without verification and then wait in `pending_review` for admin publish.
 13. If building from marketplace demand, review provider-visible request intake and claim the request you want to build before syncing the draft.
 14. After admin publish, use the public service page and paid proxy routes as the canonical execution surface.
+15. For curated external imports, keep local `ProviderSyncSpec` seed files under a gitignored path such as `.tmp/provider-seeds/` and use the normal sync plus submit flow with a Fast-operated provider account.
 
 ### Provider spec shape
 
@@ -524,6 +525,7 @@ Example top-up billing:
 
 ### Website verification details
 
+- website verification is required for `marketplace_proxy` submit and not required for `external_registry`
 - the verification file path is `/.well-known/fast-marketplace-verification.txt`
 - `npm run cli -- provider verify --service <slug-or-id>` creates a fresh challenge and prints the exact HTTPS URL plus token
 - host the exact token with `200 OK` over HTTPS, then rerun the same command so the marketplace checks ownership
@@ -546,7 +548,7 @@ Important provider constraints:
 - webhook async routes require an HTTPS marketplace base URL so the marketplace can inject a callback URL
 - prepaid-credit upstreams should verify the signed marketplace identity headers before reserving or capturing credit
 - async providers should trust the signed marketplace identity headers and `X-MARKETPLACE-JOB-TOKEN` when correlating work
-- changing the service website host requires re-verification before submission
+- changing the website host requires re-verification before submitting a `marketplace_proxy` service
 - request intake claiming is exclusive once another provider has claimed it
 
 ## Admin and review workflow
@@ -554,7 +556,7 @@ Important provider constraints:
 1. Sign into `/admin/login` with the marketplace admin token.
 2. Open the internal review surfaces for suggestions and submitted provider services.
 3. Review suggestion intake, update statuses, and add operator notes as needed.
-4. Review submitted provider services for correctness, pricing, ownership verification, and marketplace fit.
+4. Review submitted provider services for correctness, marketplace fit, and website verification where required.
 5. Publish approved services under `verified_escrow` so they appear in the public catalog and route registry.
 6. Suspend services when they should no longer be publicly executable.
 
@@ -567,7 +569,7 @@ Important provider constraints:
 - `409 Conflict`: the payment identifier was reused with a different request body
 - insufficient prepaid credit: buy more service credit through the top-up route before retrying
 - permanent async failure after acceptance: escrow services use the marketplace refund policy; community/direct services require provider support
-- provider submission blocked: complete website verification or fix draft validation errors
+- provider submission blocked: complete required website verification for `marketplace_proxy` or fix draft validation errors
 - provider prepaid route failing upstream: confirm the runtime key, signed identity header verification, and reserve/capture/release flow
 - service website host changed: generate a new verification challenge and verify again
 - provider request claim conflict: another provider already claimed the request

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -61,6 +61,16 @@ async function createSiteSession(app: Express, wallet: Awaited<ReturnType<typeof
   return session.body.accessToken as string;
 }
 
+async function createProviderProfile(app: Express, providerToken: string, websiteUrl = "https://provider.example.com") {
+  return request(app)
+    .post("/provider/me")
+    .set("Authorization", `Bearer ${providerToken}`)
+    .send({
+      displayName: "Signal Labs",
+      websiteUrl
+    });
+}
+
 async function createTestApp(
   input: {
     deploymentNetwork?: "mainnet" | "testnet";
@@ -2975,13 +2985,7 @@ describe("marketplace api", () => {
     const { app } = await createTestApp();
     const providerToken = await createSiteSession(app, providerWallet);
 
-    const profile = await request(app)
-      .post("/provider/me")
-      .set("Authorization", `Bearer ${providerToken}`)
-      .send({
-        displayName: "Signal Labs",
-        websiteUrl: "https://provider.example.com"
-      });
+    const profile = await createProviderProfile(app, providerToken);
 
     expect(profile.status).toBe(201);
 
@@ -3046,6 +3050,14 @@ describe("marketplace api", () => {
       .set("Authorization", `Bearer ${providerToken}`);
 
     expect(submitted.status).toBe(202);
+    expect(submitted.body.service.status).toBe("pending_review");
+
+    const pendingPublicDetail = await request(app).get("/catalog/services/signal-labs-direct");
+    expect(pendingPublicDetail.status).toBe(404);
+
+    const pendingPublicList = await request(app).get("/catalog/services");
+    expect(pendingPublicList.status).toBe(200);
+    expect(pendingPublicList.body.services.some((service: { slug: string }) => service.slug === "signal-labs-direct")).toBe(false);
 
     const published = await request(app)
       .post(`/internal/provider-services/${serviceId}/publish`)
@@ -3079,18 +3091,224 @@ describe("marketplace api", () => {
     expect(routeResponse.status).toBe(404);
   });
 
+  it("rejects invalid external registry drafts without requiring website verification", async () => {
+    const providerWallet = await createTestWallet(PROVIDER_PRIVATE_KEY);
+    const { app } = await createTestApp();
+    const providerToken = await createSiteSession(app, providerWallet);
+
+    const profile = await createProviderProfile(app, providerToken);
+    expect(profile.status).toBe(201);
+
+    const missingWebsite = await request(app)
+      .post("/provider/services")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        serviceType: "external_registry",
+        slug: "signal-labs-no-website",
+        name: "Signal Labs No Website",
+        tagline: "Direct provider APIs",
+        about: "Discovery-only direct APIs that the marketplace lists but does not execute.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs No Website" service.',
+        setupInstructions: ["Read the provider docs first."],
+        websiteUrl: "https://provider.example.com"
+      });
+
+    expect(missingWebsite.status).toBe(201);
+
+    const missingWebsiteEndpoint = await request(app)
+      .post(`/provider/services/${missingWebsite.body.service.id}/endpoints`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        endpointType: "external_registry",
+        title: "Status",
+        description: "Returns service status directly from the provider.",
+        method: "GET",
+        publicUrl: "https://provider.example.com/api/status",
+        docsUrl: "https://provider.example.com/docs/status",
+        authNotes: "Bearer token required.",
+        requestExample: {},
+        responseExample: { status: "ok" }
+      });
+
+    expect(missingWebsiteEndpoint.status).toBe(201);
+
+    const clearedWebsite = await request(app)
+      .patch(`/provider/services/${missingWebsite.body.service.id}`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        websiteUrl: null
+      });
+
+    expect(clearedWebsite.status).toBe(200);
+
+    const missingWebsiteSubmit = await request(app)
+      .post(`/provider/services/${missingWebsite.body.service.id}/submit`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(missingWebsiteSubmit.status).toBe(400);
+    expect(missingWebsiteSubmit.body.error).toContain("websiteUrl is required");
+
+    const noEndpoints = await request(app)
+      .post("/provider/services")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        serviceType: "external_registry",
+        slug: "signal-labs-no-endpoints",
+        name: "Signal Labs No Endpoints",
+        tagline: "Direct provider APIs",
+        about: "Discovery-only direct APIs that the marketplace lists but does not execute.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs No Endpoints" service.',
+        setupInstructions: ["Read the provider docs first."],
+        websiteUrl: "https://provider.example.com"
+      });
+
+    expect(noEndpoints.status).toBe(201);
+
+    const noEndpointsSubmit = await request(app)
+      .post(`/provider/services/${noEndpoints.body.service.id}/submit`)
+      .set("Authorization", `Bearer ${providerToken}`);
+
+    expect(noEndpointsSubmit.status).toBe(400);
+    expect(noEndpointsSubmit.body.error).toContain("At least one endpoint is required");
+
+    const wrongEndpointType = await request(app)
+      .post("/provider/services")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        serviceType: "external_registry",
+        slug: "signal-labs-wrong-endpoint",
+        name: "Signal Labs Wrong Endpoint",
+        tagline: "Direct provider APIs",
+        about: "Discovery-only direct APIs that the marketplace lists but does not execute.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs Wrong Endpoint" service.',
+        setupInstructions: ["Read the provider docs first."],
+        websiteUrl: "https://provider.example.com"
+      });
+
+    expect(wrongEndpointType.status).toBe(201);
+
+    const wrongEndpointServiceId = wrongEndpointType.body.service.id as string;
+    const createdMarketplaceEndpoint = await request(app)
+      .post(`/provider/services/${wrongEndpointServiceId}/endpoints`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        endpointType: "marketplace_proxy",
+        operation: "quote",
+        method: "POST",
+        title: "Quote",
+        description: "Return a single quote snapshot.",
+        billingType: "fixed_x402",
+        price: "$0.25",
+        mode: "sync",
+        requestSchemaJson: {
+          type: "object",
+          properties: {
+            symbol: { type: "string" }
+          },
+          required: ["symbol"],
+          additionalProperties: false
+        },
+        responseSchemaJson: {
+          type: "object",
+          properties: {
+            symbol: { type: "string" },
+            price: { type: "number" }
+          },
+          required: ["symbol", "price"],
+          additionalProperties: false
+        },
+        requestExample: { symbol: "FAST" },
+        responseExample: { symbol: "FAST", price: 42.5 },
+        upstreamBaseUrl: "https://provider.example.com",
+        upstreamPath: "/api/quote",
+        upstreamAuthMode: "none"
+      });
+
+    expect(createdMarketplaceEndpoint.status).toBe(400);
+    expect(createdMarketplaceEndpoint.body.error).toContain("Endpoint validation failed");
+
+    const publicUrlMismatch = await request(app)
+      .post("/provider/services")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        serviceType: "external_registry",
+        slug: "signal-labs-public-mismatch",
+        name: "Signal Labs Public Mismatch",
+        tagline: "Direct provider APIs",
+        about: "Discovery-only direct APIs that the marketplace lists but does not execute.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs Public Mismatch" service.',
+        setupInstructions: ["Read the provider docs first."],
+        websiteUrl: "https://provider.example.com"
+      });
+
+    expect(publicUrlMismatch.status).toBe(201);
+
+    const publicUrlMismatchServiceId = publicUrlMismatch.body.service.id as string;
+    const publicUrlMismatchEndpoint = await request(app)
+      .post(`/provider/services/${publicUrlMismatchServiceId}/endpoints`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        endpointType: "external_registry",
+        title: "Status",
+        description: "Returns service status directly from the provider.",
+        method: "GET",
+        publicUrl: "https://other-provider.example.com/api/status",
+        docsUrl: "https://provider.example.com/docs/status",
+        authNotes: "Bearer token required.",
+        requestExample: {},
+        responseExample: { status: "ok" }
+      });
+
+    expect(publicUrlMismatchEndpoint.status).toBe(400);
+    expect(publicUrlMismatchEndpoint.body.error).toContain("publicUrl host must match");
+
+    const docsUrlMismatch = await request(app)
+      .post("/provider/services")
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        serviceType: "external_registry",
+        slug: "signal-labs-docs-mismatch",
+        name: "Signal Labs Docs Mismatch",
+        tagline: "Direct provider APIs",
+        about: "Discovery-only direct APIs that the marketplace lists but does not execute.",
+        categories: ["Research"],
+        promptIntro: 'I want to use the "Signal Labs Docs Mismatch" service.',
+        setupInstructions: ["Read the provider docs first."],
+        websiteUrl: "https://provider.example.com"
+      });
+
+    expect(docsUrlMismatch.status).toBe(201);
+
+    const docsUrlMismatchServiceId = docsUrlMismatch.body.service.id as string;
+    const docsUrlMismatchEndpoint = await request(app)
+      .post(`/provider/services/${docsUrlMismatchServiceId}/endpoints`)
+      .set("Authorization", `Bearer ${providerToken}`)
+      .send({
+        endpointType: "external_registry",
+        title: "Status",
+        description: "Returns service status directly from the provider.",
+        method: "GET",
+        publicUrl: "https://provider.example.com/api/status",
+        docsUrl: "https://docs.other-provider.example.com/status",
+        authNotes: "Bearer token required.",
+        requestExample: {},
+        responseExample: { status: "ok" }
+      });
+
+    expect(docsUrlMismatchEndpoint.status).toBe(400);
+    expect(docsUrlMismatchEndpoint.body.error).toContain("docsUrl host must match");
+  });
+
   it("returns 409 when an external service tries to add a duplicate external endpoint", async () => {
     const providerWallet = await createTestWallet(PROVIDER_PRIVATE_KEY);
     const { app } = await createTestApp();
     const providerToken = await createSiteSession(app, providerWallet);
 
-    const profile = await request(app)
-      .post("/provider/me")
-      .set("Authorization", `Bearer ${providerToken}`)
-      .send({
-        displayName: "Signal Labs",
-        websiteUrl: "https://provider.example.com"
-      });
+    const profile = await createProviderProfile(app, providerToken);
 
     expect(profile.status).toBe(201);
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3538,21 +3538,9 @@ async function validateProviderServiceForSubmit(detail: ProviderServiceDetailRec
     return { ok: false as const, statusCode: 400, error: "At least one endpoint is required before submit." };
   }
 
-  const verification = detail.verification;
-  if (!verification || verification.status !== "verified") {
-    return { ok: false as const, statusCode: 400, error: "Verify website ownership before submit." };
-  }
-
   const serviceUrl = new URL(detail.service.websiteUrl);
   const serviceHost = serviceUrl.host;
   const serviceHostname = serviceUrl.hostname;
-  if (verification.verifiedHost !== serviceHost) {
-    return {
-      ok: false as const,
-      statusCode: 400,
-      error: "Website URL changed since verification. Re-verify ownership before submit."
-    };
-  }
 
   if (detail.service.serviceType === "external_registry") {
     for (const endpoint of detail.endpoints) {
@@ -3582,6 +3570,19 @@ async function validateProviderServiceForSubmit(detail: ProviderServiceDetailRec
     }
 
     return { ok: true as const };
+  }
+
+  const verification = detail.verification;
+  if (!verification || verification.status !== "verified") {
+    return { ok: false as const, statusCode: 400, error: "Verify website ownership before submit." };
+  }
+
+  if (verification.verifiedHost !== serviceHost) {
+    return {
+      ok: false as const,
+      statusCode: 400,
+      error: "Website URL changed since verification. Re-verify ownership before submit."
+    };
   }
 
   if (!detail.service.payoutWallet) {

--- a/apps/web/components/provider-service-editor.tsx
+++ b/apps/web/components/provider-service-editor.tsx
@@ -83,7 +83,7 @@ export function ProviderServiceEditor({
     <ProviderSessionGate
       deploymentNetwork={deploymentNetwork}
       title="Provider service editor"
-      description="Edit metadata, configure endpoints, and complete ownership verification."
+      description="Edit metadata, configure endpoints, and complete any required verification."
     >
       {(session) => (
         <ProviderServiceEditorInner
@@ -425,26 +425,31 @@ function ProviderServiceEditorInner({
         <CardHeader>
           <CardTitle className="text-3xl">Website verification</CardTitle>
           <CardDescription>
-            Host the issued token on your site before submitting this service for review. If your deploy is set up to
-            serve this file from config, you can add the token there as an env var.
+            {detail.service.serviceType === "marketplace_proxy"
+              ? "Host the issued token on your site before submitting this service for review. If your deploy is set up to serve this file from config, you can add the token there as an env var."
+              : "Discovery-only listings submit without website verification in this flow. Admin review still checks the website URL and endpoint host metadata."}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="text-sm text-muted-foreground">
-            Current status: {detail.verification?.status ?? "not started"}
+            Current status: {detail.verification?.status ?? (detail.service.serviceType === "marketplace_proxy" ? "not started" : "not required")}
           </div>
           <div className="flex flex-wrap gap-3">
-            <Button type="button" onClick={onCreateVerificationChallenge} disabled={pending}>
-              Create challenge
-            </Button>
-            <Button type="button" variant="outline" onClick={onVerifyService} disabled={pending}>
-              Verify ownership
-            </Button>
+            {detail.service.serviceType === "marketplace_proxy" ? (
+              <>
+                <Button type="button" onClick={onCreateVerificationChallenge} disabled={pending}>
+                  Create challenge
+                </Button>
+                <Button type="button" variant="outline" onClick={onVerifyService} disabled={pending}>
+                  Verify ownership
+                </Button>
+              </>
+            ) : null}
             <Button type="button" variant="outline" onClick={onSubmitService} disabled={pending}>
               Submit for review
             </Button>
           </div>
-          {challenge ? (
+          {detail.service.serviceType === "marketplace_proxy" && challenge ? (
             <div className="grid gap-4 rounded-card border border-border bg-background/70 p-5 dark:bg-background/20">
               <div className="flex items-center justify-between gap-3">
                 <div>

--- a/apps/web/components/provider-service-review.test.tsx
+++ b/apps/web/components/provider-service-review.test.tsx
@@ -16,6 +16,58 @@ vi.mock("@/lib/api", () => ({
   submitProviderService: (...args: unknown[]) => submitProviderService(...args)
 }));
 
+function buildServiceDetail(overrides?: {
+  service?: Partial<{
+    serviceType: "marketplace_proxy" | "external_registry";
+    settlementMode: "verified_escrow" | "community_direct";
+    payoutWallet: string | null;
+    websiteUrl: string | null;
+  }>;
+  endpoints?: Array<Record<string, unknown>>;
+  verification?: {
+    status: "verified" | "failed" | "pending";
+    verifiedHost: string;
+    failureReason: string | null;
+  } | null;
+}) {
+  return {
+    service: {
+      id: "service_1",
+      providerAccountId: "provider_1",
+      serviceType: overrides?.service?.serviceType ?? "marketplace_proxy",
+      settlementMode: overrides?.service?.settlementMode ?? "verified_escrow",
+      slug: "signal-labs",
+      apiNamespace: overrides?.service?.serviceType === "external_registry" ? null : "signals",
+      name: "Signal Labs",
+      tagline: "Short-form market signals",
+      about: "Provider-authored signal endpoints.",
+      categories: ["Research"],
+      promptIntro: "Prompt intro",
+      setupInstructions: ["Use a funded Fast wallet."],
+      websiteUrl: overrides?.service?.websiteUrl ?? "https://provider.example.com",
+      payoutWallet: overrides?.service?.payoutWallet ?? "fast1provider000000000000000000000000000000000000000000000000000000",
+      featured: false,
+      status: "draft" as const,
+      createdAt: "2026-03-20T00:00:00.000Z",
+      updatedAt: "2026-03-20T00:00:00.000Z"
+    },
+    account: {
+      id: "provider_1",
+      ownerWallet: "fast1provider000000000000000000000000000000000000000000000000000000",
+      displayName: "Signal Labs",
+      bio: null,
+      websiteUrl: "https://provider.example.com",
+      contactEmail: null,
+      createdAt: "2026-03-20T00:00:00.000Z",
+      updatedAt: "2026-03-20T00:00:00.000Z"
+    },
+    endpoints: overrides?.endpoints ?? [],
+    verification: overrides?.verification ?? null,
+    latestReview: null,
+    latestPublishedVersionId: null
+  };
+}
+
 describe("ProviderServiceReview", () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -52,5 +104,93 @@ describe("ProviderServiceReview", () => {
 
     expect(screen.getByText(/no longer accessible from the connected wallet session/i)).toBeTruthy();
     expect(screen.getByRole("button", { name: /back to drafts/i })).toBeTruthy();
+  });
+
+  it("shows external registry host checks instead of blocking verification requirements", async () => {
+    fetchProviderService.mockResolvedValue(
+      buildServiceDetail({
+        service: {
+          serviceType: "external_registry",
+          payoutWallet: null
+        },
+        endpoints: [
+          {
+            id: "endpoint_1",
+            endpointType: "external_registry",
+            title: "Status",
+            description: "Returns service status directly from the provider.",
+            method: "GET",
+            publicUrl: "https://provider.example.com/api/status",
+            docsUrl: "https://docs.provider.example.com/status",
+            authNotes: "Bearer token required.",
+            requestExample: {},
+            responseExample: { status: "ok" }
+          }
+        ]
+      })
+    );
+
+    render(
+      <ProviderServiceReview
+        apiBaseUrl="https://api.marketplace.example.com"
+        deploymentNetwork="mainnet"
+        serviceId="service_1"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Website URL and endpoint hosts are set consistently")).toBeTruthy();
+    });
+
+    expect(screen.queryByText("Website verification succeeded")).toBeNull();
+    expect(screen.getByText("Marketplace runtime key is not required")).toBeTruthy();
+    expect(screen.getByText("not required")).toBeTruthy();
+  });
+
+  it("still shows verification as required for marketplace proxy drafts", async () => {
+    fetchProviderService.mockResolvedValue(
+      buildServiceDetail({
+        verification: null,
+        endpoints: [
+          {
+            id: "endpoint_1",
+            endpointType: "marketplace_proxy",
+            operation: "quote",
+            method: "POST",
+            title: "Quote",
+            description: "Return a single quote snapshot.",
+            billing: {
+              type: "fixed_x402",
+              price: "$0.25",
+              tokenSymbol: "USDC",
+              minAmount: null,
+              maxAmount: null
+            },
+            mode: "sync",
+            requestSchemaJson: { type: "object", additionalProperties: false },
+            responseSchemaJson: { type: "object", additionalProperties: false },
+            requestExample: {},
+            responseExample: {},
+            upstreamBaseUrl: "https://provider.example.com",
+            upstreamPath: "/api/quote",
+            upstreamAuthMode: "none"
+          }
+        ]
+      })
+    );
+
+    render(
+      <ProviderServiceReview
+        apiBaseUrl="https://api.marketplace.example.com"
+        deploymentNetwork="mainnet"
+        serviceId="service_1"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Website verification succeeded")).toBeTruthy();
+    });
+
+    expect(screen.getAllByText("missing").length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/components/provider-service-review.tsx
+++ b/apps/web/components/provider-service-review.tsx
@@ -21,7 +21,7 @@ export function ProviderServiceReview({
     <ProviderSessionGate
       deploymentNetwork={deploymentNetwork}
       title="Review service draft"
-      description="Confirm verification, endpoint coverage, and submit the draft for marketplace review."
+      description="Confirm the required draft metadata and submit the service for marketplace review."
     >
       {(session) => (
         <ProviderServiceReviewInner apiBaseUrl={apiBaseUrl} accessToken={session.accessToken} serviceId={serviceId} />
@@ -90,6 +90,7 @@ function ProviderServiceReviewInner({
   }
 
   const isMarketplaceService = detail.service.serviceType === "marketplace_proxy";
+  const externalHostConsistencyReady = !isMarketplaceService && isExternalRegistryHostConfigReady(detail);
   const checklist = [
     isMarketplaceService
       ? {
@@ -106,7 +107,9 @@ function ProviderServiceReviewInner({
       ok: isMarketplaceService ? Boolean(detail.service.payoutWallet) : true
     },
     { label: "At least one endpoint exists", ok: detail.endpoints.length > 0 },
-    { label: "Website verification succeeded", ok: detail.verification?.status === "verified" },
+    isMarketplaceService
+      ? { label: "Website verification succeeded", ok: detail.verification?.status === "verified" }
+      : { label: "Website URL and endpoint hosts are set consistently", ok: externalHostConsistencyReady },
     {
       label: isMarketplaceService ? "Runtime key is ready for Community, async, or prepaid flows" : "Marketplace runtime key is not required",
       ok: isMarketplaceService
@@ -151,8 +154,12 @@ function ProviderServiceReviewInner({
         </CardHeader>
         <CardContent className="grid gap-4 text-sm">
           <div className="rounded-card border border-border bg-background/70 p-5 dark:bg-background/20">
-            <div className="font-medium">Latest verification</div>
-            <div className="mt-2 text-muted-foreground">{detail.verification?.status ?? "not started"}</div>
+            <div className="font-medium">{isMarketplaceService ? "Latest verification" : "Website ownership verification"}</div>
+            <div className="mt-2 text-muted-foreground">
+              {isMarketplaceService
+                ? (detail.verification?.status ?? "not started")
+                : (detail.verification?.status ?? "not required")}
+            </div>
           </div>
           <div className="rounded-card border border-border bg-background/70 p-5 dark:bg-background/20">
             <div className="font-medium">Latest review</div>
@@ -200,4 +207,36 @@ function ProviderServiceReviewInner({
       </Card>
     </div>
   );
+}
+
+function isExternalRegistryHostConfigReady(detail: NonNullable<Awaited<ReturnType<typeof fetchProviderService>>>) {
+  if (!detail.service.websiteUrl || detail.endpoints.length === 0) {
+    return false;
+  }
+
+  let serviceHostname: string;
+  try {
+    serviceHostname = new URL(detail.service.websiteUrl).hostname;
+  } catch {
+    return false;
+  }
+
+  return detail.endpoints.every((endpoint) => {
+    if (endpoint.endpointType !== "external_registry") {
+      return false;
+    }
+
+    try {
+      return (
+        isSameOrSubdomain(serviceHostname, new URL(endpoint.publicUrl).hostname)
+        && isSameOrSubdomain(serviceHostname, new URL(endpoint.docsUrl).hostname)
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
+function isSameOrSubdomain(expectedHostname: string, candidateHostname: string) {
+  return candidateHostname === expectedHostname || candidateHostname.endsWith(`.${expectedHostname}`);
 }

--- a/apps/web/components/provider-services-dashboard.tsx
+++ b/apps/web/components/provider-services-dashboard.tsx
@@ -182,7 +182,7 @@ function ProviderServicesDashboardInner({
       <Card variant="frosted">
         <CardHeader>
           <CardTitle className="text-3xl">New service draft</CardTitle>
-          <CardDescription>Create the public service metadata first, then add endpoints and verification.</CardDescription>
+          <CardDescription>Create the public service metadata first, then add endpoints and any required verification.</CardDescription>
         </CardHeader>
         <CardContent>
           <form className="grid gap-4" onSubmit={onCreateService}>

--- a/packages/cli/src/provider.test.ts
+++ b/packages/cli/src/provider.test.ts
@@ -420,6 +420,43 @@ describe("provider cli", () => {
     });
   });
 
+  it("submits external registry specs without website verification and still enters pending_review", async () => {
+    const { apiUrl, store } = await startApiServer();
+    const spec = buildExternalRegistrySpec({
+      service: {
+        slug: "messari-direct"
+      },
+      endpoints: [
+        {
+          endpointType: "external_registry",
+          title: "Markets",
+          description: "Direct market data endpoint.",
+          method: "GET",
+          publicUrl: "https://provider.example.com/api/markets",
+          docsUrl: "https://docs.provider.example.com/markets",
+          authNotes: "Bearer token required.",
+          requestExample: {},
+          responseExample: { ok: true },
+          usageNotes: "Call the provider directly."
+        }
+      ]
+    });
+
+    await withAgentEnv(apiUrl, async (tempDir) => {
+      const syncResult = await syncProviderSpec({
+        specPath: await writeSpec(tempDir, "external-provider-spec.json", spec)
+      });
+
+      const submitted = await submitProviderService({ serviceRef: syncResult.service.slug, apiUrl });
+      expect(submitted.status).toBe("submitted");
+      expect(submitted.service.status).toBe("pending_review");
+
+      const detail = await store.getProviderServiceForOwner(syncResult.service.id, syncResult.wallet);
+      expect(detail?.service.status).toBe("pending_review");
+      expect(detail?.verification).toBeNull();
+    });
+  });
+
   it("preserves plain-text API errors from the wallet session flow", async () => {
     await withAgentEnv("http://127.0.0.1:9", async () => {
       await expect(createProviderSiteSession(
@@ -593,6 +630,34 @@ function buildMarketplaceEndpoint(input: {
     upstreamBaseUrl: "https://provider.example.com",
     upstreamPath: `/api/${input.operation}`,
     upstreamAuthMode: "none"
+  };
+}
+
+function buildExternalRegistrySpec(input: {
+  service: {
+    slug: string;
+  };
+  endpoints: ProviderSyncSpec["endpoints"];
+}): ProviderSyncSpec {
+  return {
+    profile: {
+      displayName: "Signal Labs",
+      bio: "Quant feeds for agent workflows.",
+      websiteUrl: "https://provider.example.com",
+      contactEmail: "ops@provider.example.com"
+    },
+    service: {
+      serviceType: "external_registry",
+      slug: input.service.slug,
+      name: "Signal Labs Direct",
+      tagline: "Direct provider APIs",
+      about: "Discovery-only direct APIs that the marketplace lists but does not execute.",
+      categories: ["Research"],
+      promptIntro: 'I want to use the "Signal Labs Direct" service.',
+      setupInstructions: ["Read the provider docs first."],
+      websiteUrl: "https://provider.example.com"
+    },
+    endpoints: input.endpoints
   };
 }
 

--- a/packages/cli/src/provider.ts
+++ b/packages/cli/src/provider.ts
@@ -340,7 +340,7 @@ export async function submitProviderService(input: {
   const session = await createProviderSiteSession(input, deps);
   const detail = await resolveProviderService(session.apiUrl, session.accessToken, input.serviceRef, deps);
 
-  if (!isVerificationReady(detail)) {
+  if (detail.service.serviceType === "marketplace_proxy" && !isVerificationReady(detail)) {
     return {
       status: "action_required",
       service: summarizeService(detail),


### PR DESCRIPTION
## Summary
- allow `external_registry` services to submit for admin review without website verification while keeping `marketplace_proxy` verification unchanged
- keep external listings behind the existing `pending_review` -> admin publish flow and update provider UI copy to match the new rules
- document local operator seeding for curated x402 imports via gitignored provider specs and extend API, CLI, and web tests

## Context
Implements the `#3 Permissionless x402 Indexing` direction from issue #29 as a curated `external_registry` import flow rather than a crawler.

## Verification
- `npm test`
- `npm run build`