### PR TITLE
Refine marketplace service page and table UX

### DIFF
--- a/apps/web/app/catalog/services/[slug]/route.ts
+++ b/apps/web/app/catalog/services/[slug]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+import { fetchServiceDetail } from "@/lib/api";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const detail = await fetchServiceDetail(slug);
+
+  if (!detail) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(detail);
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -172,8 +172,20 @@
     padding: 0 24px 80px;
   }
 
+  .page-shell {
+    margin: 0 auto;
+    padding: 0 24px 80px;
+  }
+
+  .section-sep {
+    padding-top: 64px;
+  }
+
   .page-section {
-    width: min(100%, var(--section-width));
+    margin: 0 auto;
+  }
+
+  .section-container {
     margin: 0 auto;
   }
 
@@ -182,9 +194,19 @@
     gap: 24px;
   }
 
+  .section-stack {
+    display: grid;
+    gap: 24px;
+  }
+
   .page-header {
     display: grid;
     gap: 12px;
+  }
+
+  .page-intro {
+    display: grid;
+    gap: 16px;
   }
 
   .page-title,
@@ -301,6 +323,17 @@
     color: var(--foreground);
   }
 
+  .btn-fast-ghost.btn-fast-sm {
+    border: 0;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  .btn-fast-ghost.btn-fast-sm:hover {
+    background: transparent;
+    transform: none;
+  }
+
   .btn-fast-sm {
     padding: 0.6rem 1rem;
     font-size: 0.875rem;
@@ -334,9 +367,16 @@
   .fast-card-dark,
   .terminal-surface {
     background: var(--foreground);
-    border: 1px solid color-mix(in srgb, var(--foreground) 80%, white 20%);
+    border: 1px solid transparent;
     border-radius: 24px;
     color: var(--background);
+  }
+
+  .prompt-block {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 24px;
+    color: var(--card-foreground);
   }
 
   .badge-fast {
@@ -419,14 +459,73 @@
     border-bottom: 1px solid color-mix(in srgb, var(--background) 16%, transparent);
   }
 
+  .terminal-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    border-top: 1px solid color-mix(in srgb, var(--background) 16%, transparent);
+  }
+
+  .terminal-toolbar .btn-fast-ghost {
+    color: color-mix(in srgb, var(--background) 88%, transparent);
+    border-color: transparent;
+  }
+
+  .terminal-toolbar .btn-fast-ghost:hover {
+    color: var(--background);
+    background: transparent;
+  }
+
+  .prompt-block .terminal-toolbar {
+    border-bottom: 1px solid var(--border);
+  }
+
+  .prompt-block .terminal-footer {
+    border-top: 1px solid var(--border);
+  }
+
+  .prompt-block .terminal-toolbar .btn-fast-ghost {
+    color: var(--foreground);
+  }
+
+  .prompt-block .terminal-toolbar .btn-fast-ghost:hover {
+    color: var(--foreground);
+  }
+
   .terminal-body {
-    padding: 1.5rem;
+    padding: 1rem;
+    background: #000;
+    color: var(--background);
+    border-radius: 20px;
+    border: 1px solid transparent;
+    box-shadow: none;
+  }
+
+  .wallet-connect-button {
+    background: #000;
+    color: var(--background);
+    border-color: transparent;
+  }
+
+  .wallet-connect-button:hover {
+    background: #000;
+    color: var(--background);
+    transform: translateY(-1px);
   }
 
   .terminal-code {
     margin: 0;
-    color: var(--background);
+    color: inherit;
     white-space: pre-wrap;
+  }
+
+  .prompt-block .terminal-body {
+    background: transparent;
+    color: inherit;
+    border: 0;
+    box-shadow: none;
   }
 
   .terminal-dots {
@@ -442,6 +541,43 @@
   }
 }
 
+.dark .terminal-body {
+  background: var(--card);
+  color: var(--foreground);
+}
+
+.dark .terminal-surface {
+  background: var(--card);
+  color: var(--foreground);
+}
+
+.dark .terminal-surface .terminal-toolbar {
+  border-bottom: 1px solid var(--border);
+}
+
+.dark .terminal-surface .terminal-footer {
+  border-top: 1px solid var(--border);
+}
+
+.dark .terminal-surface .terminal-toolbar .btn-fast-ghost {
+  color: var(--foreground);
+}
+
+.dark .terminal-surface .terminal-toolbar .btn-fast-ghost:hover {
+  color: var(--foreground);
+}
+
+.dark .wallet-connect-button {
+  background: var(--card);
+  color: var(--foreground);
+  border-color: var(--border);
+}
+
+.dark .wallet-connect-button:hover {
+  background: var(--card);
+  color: var(--foreground);
+}
+
 @media (min-width: 1024px) {
   .nav-shell,
   .footer-shell {
@@ -450,6 +586,11 @@
   }
 
   .page-main {
+    padding-left: 40px;
+    padding-right: 40px;
+  }
+
+  .page-shell {
     padding-left: 40px;
     padding-right: 40px;
   }

--- a/apps/web/components/marketplace-home.test.tsx
+++ b/apps/web/components/marketplace-home.test.tsx
@@ -1,12 +1,16 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { MarketplaceHome } from "./marketplace-home";
+
+const { fetchServiceDetailMock } = vi.hoisted(() => ({
+  fetchServiceDetailMock: vi.fn()
+}));
 
 vi.mock("next/link", () => ({
   default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
@@ -16,9 +20,63 @@ vi.mock("next/link", () => ({
   )
 }));
 
+vi.mock("@/lib/api", () => ({
+  fetchServiceDetail: (...args: unknown[]) => fetchServiceDetailMock(...args)
+}));
+
 describe("MarketplaceHome", () => {
-  it("renders services and filters them by search", async () => {
+  it("renders services and filters them by search and category", async () => {
     const user = userEvent.setup();
+    fetchServiceDetailMock.mockReset();
+    fetchServiceDetailMock.mockImplementation(async (slug: string) => {
+      if (slug === "instagram-scraper") {
+        return {
+          serviceType: "external_registry",
+          summary: {
+            serviceType: "external_registry",
+            slug: "instagram-scraper",
+            name: "Instagram Scraper",
+            ownerName: "Fast Marketplace",
+            tagline: "Scrape public Instagram data.",
+            categories: ["Social"],
+            settlementMode: null,
+            settlementLabel: "External API",
+            settlementDescription: "Calls go directly to the provider. The marketplace lists discovery metadata only.",
+            priceRange: "See provider docs",
+            settlementToken: null,
+            totalCalls: null,
+            revenue: null,
+            successRate30d: null,
+            volume30d: [],
+            accessModelLabel: "External API",
+            accessModelDescription: "Calls go directly to the provider. The marketplace only lists docs and direct endpoints.",
+            endpointCount: 1,
+            websiteUrl: "https://www.instagram.com"
+          },
+          about: "Instagram scraper detail",
+          useThisServicePrompt: "Use Instagram Scraper",
+          skillUrl: null,
+          websiteUrl: "https://www.instagram.com",
+          endpoints: [
+            {
+              endpointType: "external_registry",
+              endpointId: "instagram-direct",
+              title: "Scrape Posts",
+              description: "Fetch Instagram posts",
+              method: "POST",
+              publicUrl: "https://api.instagram.example.com/posts",
+              docsUrl: "https://docs.instagram.example.com",
+              authNotes: null,
+              requestExample: {},
+              responseExample: {},
+              usageNotes: null
+            }
+          ]
+        };
+      }
+
+      return null;
+    });
 
     render(
       <MarketplaceHome
@@ -82,7 +140,7 @@ describe("MarketplaceHome", () => {
             volume30d: [],
             accessModelLabel: "External API",
             accessModelDescription: "Calls go directly to the provider. The marketplace only lists docs and direct endpoints.",
-            websiteUrl: "https://www.apollo.io"
+            websiteUrl: "https://stableenrich.dev"
           }
         ]}
       />
@@ -106,5 +164,40 @@ describe("MarketplaceHome", () => {
     });
 
     expect(screen.getByText("Instagram Scraper")).toBeTruthy();
+
+    await user.clear(screen.getByPlaceholderText("Search services, owners, or categories"));
+    await user.selectOptions(screen.getByRole("combobox", { name: "Filter by category" }), "Sales");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Instagram Scraper")).toBeNull();
+    });
+
+    expect(screen.queryByText("Amazon Product Scraper")).toBeNull();
+    expect(screen.getByText("StableEnrich Apollo API")).toBeTruthy();
+
+    const categoryFilter = screen.getByRole("combobox", { name: "Filter by category" });
+    expect(within(categoryFilter).getByRole("option", { name: "All categories" })).toBeTruthy();
+    expect(within(categoryFilter).getByRole("option", { name: "Research" })).toBeTruthy();
+    expect(within(categoryFilter).getByRole("option", { name: "Sales" })).toBeTruthy();
+    expect(within(categoryFilter).getByRole("option", { name: "Social" })).toBeTruthy();
+
+    await user.selectOptions(categoryFilter, "");
+    await user.hover(screen.getByText("Instagram Scraper"));
+
+    await waitFor(() => {
+      expect(fetchServiceDetailMock).toHaveBeenCalledWith("instagram-scraper", "http://localhost:3000");
+    });
+
+    await user.click(screen.getByText("Instagram Scraper"));
+
+    expect(fetchServiceDetailMock).toHaveBeenCalledTimes(1);
+
+    expect(screen.getByText("Endpoint")).toBeTruthy();
+    expect(screen.getByText("Scrape Posts")).toBeTruthy();
+    expect(screen.getByText("api.instagram.example.com/posts")).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Scrape Posts Fetch Instagram posts direct/i }).getAttribute("href")).toBe(
+      "/services/instagram-scraper?endpoint=instagram-direct"
+    );
+    expect(screen.getByRole("columnheader", { name: /details/i })).toBeTruthy();
   });
 });

--- a/apps/web/components/marketplace-home.tsx
+++ b/apps/web/components/marketplace-home.tsx
@@ -9,7 +9,13 @@ import { ServicesDataTable } from "@/components/services-data-table";
 
 export function MarketplaceHome({ services }: { services: ServiceSummary[] }) {
   const [query, setQuery] = useState("");
+  const [category, setCategory] = useState("");
   const deferredQuery = useDeferredValue(query);
+
+  const categories = useMemo(
+    () => [...new Set(services.flatMap((service) => service.categories))].sort((left, right) => left.localeCompare(right)),
+    [services]
+  );
 
   const filtered = useMemo(() => {
     const search = deferredQuery.trim().toLowerCase();
@@ -18,32 +24,63 @@ export function MarketplaceHome({ services }: { services: ServiceSummary[] }) {
       const haystack = [service.name, service.ownerName, service.tagline, ...service.categories]
         .join(" ")
         .toLowerCase();
+      const matchesCategory = !category || service.categories.includes(category);
 
-      return !search || haystack.includes(search);
+      return (!search || haystack.includes(search)) && matchesCategory;
     });
-  }, [deferredQuery, services]);
+  }, [category, deferredQuery, services]);
 
   const providerCount = useMemo(() => new Set(services.map((service) => service.ownerName)).size, [services]);
   const endpointCount = useMemo(() => services.reduce((sum, service) => sum + service.endpointCount, 0), [services]);
 
   return (
     <main>
-      <section className="py-16">
+      <section className="py-8">
         <div className="page-main page-stack">
-          <div className="page-header">
-            <h1 className="section-title">APIs for agents</h1>
-            <p className="page-copy">Browse live web services, compare pricing and performance, and pay with USDC on Fast.xyz</p>
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)] lg:items-start">
+            <div className="page-header">
+              <h1 className="section-title">APIs for agents</h1>
+              <p className="page-copy">Browse live web services, compare pricing and performance, and pay with USDC on Fast.xyz</p>
+            </div>
+
+            <div className="grid justify-items-start gap-3 lg:justify-items-end">
+              <div className="terminal-label">AI Agents start here</div>
+              <div className="terminal-surface w-fit overflow-hidden">
+                <div className="terminal-body">
+                <pre className="terminal-code overflow-x-auto whitespace-pre-wrap text-sm">{`curl -L https://marketplace.fast.xyz/skill.md`}</pre>
+                </div>
+              </div>
+            </div>
           </div>
 
           <div className="glass-card-elevated p-6">
-            <label className="grid gap-3">
-              <span className="page-eyebrow">Search services, owners, or categories</span>
-              <Input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search services, owners, or categories"
-              />
-            </label>
+            <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_240px]">
+              <label className="grid gap-3">
+                <span className="page-eyebrow">Search services, owners, or categories</span>
+                <Input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Search services, owners, or categories"
+                />
+              </label>
+
+              <label className="grid gap-3">
+                <span className="page-eyebrow">Category</span>
+                <select
+                  className="native-select min-h-12"
+                  value={category}
+                  onChange={(event) => setCategory(event.target.value)}
+                  aria-label="Filter by category"
+                >
+                  <option value="">All categories</option>
+                  {categories.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
 
             <div className="mt-6">
               <ServicesDataTable services={filtered} />

--- a/apps/web/components/service-page.test.tsx
+++ b/apps/web/components/service-page.test.tsx
@@ -8,6 +8,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import { ServicePage } from "./service-page";
 
+const { useSearchParamsMock } = vi.hoisted(() => ({
+  useSearchParamsMock: vi.fn()
+}));
+
 vi.mock("next/link", () => ({
   default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
     <a href={href} {...props}>
@@ -16,9 +20,16 @@ vi.mock("next/link", () => ({
   )
 }));
 
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => useSearchParamsMock()
+}));
+
 describe("ServicePage", () => {
-  it("renders service stats, prompt copy, and endpoint examples", async () => {
+  it("renders service stats, prompt copy, and simplified endpoint examples", async () => {
     const user = userEvent.setup();
+    useSearchParamsMock.mockReturnValue({
+      get: () => null
+    });
 
     render(
       <ServicePage
@@ -87,8 +98,73 @@ describe("ServicePage", () => {
     expect(screen.getByRole("heading", { name: "Mock Research Signals" })).toBeTruthy();
     expect(screen.getByText("A mock service for wallet and x402 smoke tests.")).toBeTruthy();
     expect(screen.getByText(/available endpoints \(1\)/i)).toBeTruthy();
+    expect(screen.getByText("Suggest an endpoint")).toBeTruthy();
+    expect(screen.getByText("Suggest a source")).toBeTruthy();
     expect(screen.getByText("Open canonical SKILL.md")).toBeTruthy();
     await user.click(screen.getByRole("button", { name: /quick insight/i }));
-    expect(screen.getByText("Pay and run this endpoint with the Fast extension")).toBeTruthy();
+    expect(screen.getByText("Proxy URL")).toBeTruthy();
+    expect(screen.getByText("https://api.marketplace.example.com/api/mock/quick-insight")).toBeTruthy();
+    expect(screen.getByText("Request example")).toBeTruthy();
+    expect(screen.getByText("Response example")).toBeTruthy();
+    expect(screen.queryByText("Pay and run this endpoint with the Fast extension")).toBeNull();
+    expect(screen.queryByText("Request body")).toBeNull();
+  });
+
+  it("opens the requested endpoint from the query string", () => {
+    useSearchParamsMock.mockReturnValue({
+      get: (key: string) => (key === "endpoint" ? "mock.quick-insight.v1" : null)
+    });
+
+    render(
+      <ServicePage
+        deploymentNetwork="mainnet"
+        service={{
+          serviceType: "marketplace_proxy",
+          summary: {
+            serviceType: "marketplace_proxy",
+            slug: "mock-research-signals",
+            name: "Mock Research Signals",
+            ownerName: "Fast Marketplace",
+            tagline: "Synthetic paid research endpoints.",
+            categories: ["Research"],
+            settlementMode: "verified_escrow",
+            settlementLabel: "Verified",
+            settlementDescription: "Marketplace escrow, refunds, and payout reconciliation.",
+            priceRange: "$0.0001 USDC",
+            settlementToken: "USDC",
+            endpointCount: 1,
+            totalCalls: 18,
+            revenue: "0.42",
+            successRate30d: 75,
+            volume30d: []
+          },
+          about: "A mock service for wallet and x402 smoke tests.",
+          useThisServicePrompt: "I want to use the Mock Research Signals service.",
+          skillUrl: "https://marketplace.example.com/skill.md",
+          endpoints: [
+            {
+              endpointType: "marketplace_proxy",
+              routeId: "mock.quick-insight.v1",
+              title: "Quick Insight",
+              description: "Instant paid insight.",
+              price: "$0.0001",
+              billingType: "fixed_x402",
+              tokenSymbol: "USDC",
+              mode: "sync",
+              method: "POST",
+              path: "/api/mock/quick-insight",
+              proxyUrl: "https://api.marketplace.example.com/api/mock/quick-insight",
+              requestSchemaJson: { type: "object" },
+              responseSchemaJson: { type: "object" },
+              requestExample: { query: "alpha" },
+              responseExample: { summary: "alpha" }
+            }
+          ]
+        }}
+      />
+    );
+
+    expect(screen.getAllByText("Proxy URL").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("https://api.marketplace.example.com/api/mock/quick-insight").length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/components/service-page.tsx
+++ b/apps/web/components/service-page.tsx
@@ -2,12 +2,12 @@
 
 import React from "react";
 import Link from "next/link";
-import { ArrowUpRight } from "lucide-react";
+import { useSearchParams } from "next/navigation";
+import { ArrowLeft, ArrowUpRight } from "lucide-react";
 import type { MarketplaceServiceCatalogEndpoint, ServiceDetail } from "@marketplace/shared";
 import type { WebDeploymentNetwork } from "@/lib/network";
 
 import { CopyButton } from "@/components/copy-button";
-import { EndpointBrowserRunner } from "@/components/endpoint-browser-runner";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -29,6 +29,13 @@ export function ServicePage({
   deploymentNetwork: WebDeploymentNetwork;
 }) {
   const isMarketplaceService = service.serviceType === "marketplace_proxy";
+  const searchParams = useSearchParams();
+  const requestedEndpoint = searchParams.get("endpoint") ?? undefined;
+  const [expandedEndpoint, setExpandedEndpoint] = React.useState<string | undefined>(requestedEndpoint);
+
+  React.useEffect(() => {
+    setExpandedEndpoint(requestedEndpoint);
+  }, [requestedEndpoint, service.summary.slug]);
 
   return (
     <main className="page-main">
@@ -36,9 +43,9 @@ export function ServicePage({
         <div className="app-container page-stack">
           <div className={isMarketplaceService ? "page-stack" : "grid gap-6 xl:grid-cols-[1.08fr_0.92fr] xl:items-start"}>
             <div className="page-stack">
-              <div className="page-header max-w-none">
-                <Link href="/" className="page-link">
-                  Back to marketplace
+              <div className="page-header max-w-none pt-4">
+                <Link href="/" className="page-link inline-flex w-fit items-center">
+                  <ArrowLeft className="h-4 w-4" />
                 </Link>
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge variant="outline">{service.summary.ownerName}</Badge>
@@ -57,10 +64,7 @@ export function ServicePage({
                   )}
                 </div>
                 <h1 className="section-title">{service.summary.name}</h1>
-                <p className="page-copy">{service.summary.tagline}</p>
-                <p className="max-w-3xl text-sm leading-7 text-muted-foreground">
-                  {isMarketplaceService ? service.summary.settlementDescription : service.summary.accessModelDescription}
-                </p>
+                <p className="max-w-3xl text-sm leading-7 text-muted-foreground">{service.about}</p>
               </div>
             </div>
 
@@ -89,104 +93,102 @@ export function ServicePage({
           </div>
 
           <div className="grid gap-6 xl:grid-cols-[0.9fr_1.1fr]">
-            <Card>
-              <CardHeader>
-                <Badge variant="eyebrow">About this service</Badge>
-                <CardTitle>Service profile</CardTitle>
+            <Card className="prompt-block">
+              <CardHeader className="terminal-toolbar px-6 py-4">
+                <div className="terminal-label">Available endpoints ({service.endpoints.length})</div>
               </CardHeader>
-              <CardContent className="grid gap-6 text-sm leading-7 text-muted-foreground">
-                <p>{service.about}</p>
-                <div className="flex flex-wrap gap-3">
-                  <Button onClick={() => window.location.assign(`/suggest?service=${service.summary.slug}&type=endpoint`)}>
-                    Suggest an endpoint
-                  </Button>
-                  <Button variant="outline" onClick={() => window.location.assign("/suggest?type=source")}>
-                    Suggest a source
-                  </Button>
-                </div>
+              <CardContent>
+                <Accordion
+                  type="single"
+                  collapsible
+                  className="w-full"
+                  value={expandedEndpoint ?? ""}
+                  onValueChange={(value) => setExpandedEndpoint(value || undefined)}
+                >
+                  {isMarketplaceService
+                    ? service.endpoints.map((endpoint) => (
+                        <AccordionItem key={endpoint.routeId} value={endpoint.routeId}>
+                          <AccordionTrigger>
+                            <div className="grid flex-1 gap-3 md:grid-cols-[auto_1fr_auto] md:items-center">
+                              <Badge variant="secondary" className="w-fit">
+                                {endpoint.method}
+                              </Badge>
+                              <div className="text-left">
+                                <div className="text-lg font-medium tracking-[-0.03em]">{endpoint.title}</div>
+                                <div className="text-sm leading-7 text-muted-foreground">{endpoint.description}</div>
+                              </div>
+                              <div className="text-sm font-medium text-foreground">
+                                {endpoint.price}
+                                {usesTokenPrice(endpoint.billingType) ? ` ${endpoint.tokenSymbol}` : ""}
+                              </div>
+                            </div>
+                          </AccordionTrigger>
+                          <AccordionContent>
+                            <div className="grid gap-5 lg:grid-cols-2">
+                              <div className="lg:col-span-2">
+                                <DetailRow label="Proxy URL" value={endpoint.proxyUrl} copyValue={endpoint.proxyUrl} />
+                              </div>
+                              <ExampleBlock label="Request example" value={JSON.stringify(endpoint.requestExample, null, 2)} />
+                              <ExampleBlock label="Response example" value={JSON.stringify(endpoint.responseExample, null, 2)} />
+                            </div>
+                          </AccordionContent>
+                        </AccordionItem>
+                      ))
+                    : service.endpoints.map((endpoint) => (
+                        <AccordionItem key={endpoint.endpointId} value={endpoint.endpointId}>
+                          <AccordionTrigger>
+                            <div className="grid flex-1 gap-3 md:grid-cols-[auto_1fr] md:items-center">
+                              <Badge variant="secondary" className="w-fit">
+                                {endpoint.method}
+                              </Badge>
+                              <div className="text-left">
+                                <div className="text-lg font-medium tracking-[-0.03em]">{endpoint.title}</div>
+                                <div className="text-sm leading-7 text-muted-foreground">{endpoint.description}</div>
+                              </div>
+                            </div>
+                          </AccordionTrigger>
+                          <AccordionContent>
+                            <div className="grid gap-5 lg:grid-cols-2">
+                              <Card className="h-full">
+                                <CardHeader className="pb-4">
+                                  <Badge variant="eyebrow">Direct URLs</Badge>
+                                  <CardTitle className="text-xl">Provider endpoint</CardTitle>
+                                </CardHeader>
+                                <CardContent className="grid gap-4">
+                                  <DetailRow label="Public URL" value={endpoint.publicUrl} copyValue={endpoint.publicUrl} />
+                                  <DetailRow label="Docs URL" value={endpoint.docsUrl} copyValue={endpoint.docsUrl} />
+                                  {endpoint.authNotes ? <p className="text-sm leading-7 text-muted-foreground">Auth: {endpoint.authNotes}</p> : null}
+                                  {endpoint.usageNotes ? <p className="text-sm leading-7 text-muted-foreground">{endpoint.usageNotes}</p> : null}
+                                </CardContent>
+                              </Card>
+                              <ExampleBlock label="Request example" value={JSON.stringify(endpoint.requestExample, null, 2)} />
+                              <ExampleBlock label="Response example" value={JSON.stringify(endpoint.responseExample, null, 2)} />
+                            </div>
+                          </AccordionContent>
+                        </AccordionItem>
+                      ))}
+                </Accordion>
               </CardContent>
             </Card>
 
             <PromptBlock
               prompt={service.useThisServicePrompt}
-              description={
-                isMarketplaceService
-                  ? "Includes setup, the marketplace skill, and exact call parameters for each available endpoint."
-                  : "Includes setup, direct endpoint URLs, and provider-auth details for each available endpoint."
-              }
               skillUrl={service.skillUrl}
             />
           </div>
 
           <Card>
             <CardHeader>
-              <Badge variant="eyebrow">Available endpoints ({service.endpoints.length})</Badge>
-              <CardTitle>{isMarketplaceService ? "Request docs, pricing, and examples" : "Direct endpoint docs and examples"}</CardTitle>
+              <Badge variant="eyebrow">Have a request?</Badge>
+              <CardTitle>Suggest marketplace coverage</CardTitle>
             </CardHeader>
-            <CardContent>
-              <Accordion type="single" collapsible className="w-full">
-                {isMarketplaceService
-                  ? service.endpoints.map((endpoint) => (
-                      <AccordionItem key={endpoint.routeId} value={endpoint.routeId}>
-                        <AccordionTrigger>
-                          <div className="grid flex-1 gap-3 md:grid-cols-[auto_1fr_auto] md:items-center">
-                            <Badge variant="secondary" className="w-fit">
-                              {endpoint.method}
-                            </Badge>
-                            <div className="text-left">
-                              <div className="text-lg font-medium tracking-[-0.03em]">{endpoint.title}</div>
-                              <div className="text-sm leading-7 text-muted-foreground">{endpoint.description}</div>
-                            </div>
-                            <div className="text-sm font-medium text-foreground">
-                              {endpoint.price}
-                              {usesTokenPrice(endpoint.billingType) ? ` ${endpoint.tokenSymbol}` : ""}
-                            </div>
-                          </div>
-                        </AccordionTrigger>
-                        <AccordionContent>
-                          <div className="grid gap-5 lg:grid-cols-2">
-                            <DetailCard title="Direct marketplace route" label="Proxy URL" value={endpoint.proxyUrl} copyValue={endpoint.proxyUrl} notes={endpoint.usageNotes} />
-                            <ExampleBlock label="Request example" value={JSON.stringify(endpoint.requestExample, null, 2)} />
-                            <ExampleBlock label="Response example" value={JSON.stringify(endpoint.responseExample, null, 2)} />
-                            <EndpointBrowserRunner endpoint={endpoint} deploymentNetwork={deploymentNetwork} />
-                          </div>
-                        </AccordionContent>
-                      </AccordionItem>
-                    ))
-                  : service.endpoints.map((endpoint) => (
-                      <AccordionItem key={endpoint.endpointId} value={endpoint.endpointId}>
-                        <AccordionTrigger>
-                          <div className="grid flex-1 gap-3 md:grid-cols-[auto_1fr] md:items-center">
-                            <Badge variant="secondary" className="w-fit">
-                              {endpoint.method}
-                            </Badge>
-                            <div className="text-left">
-                              <div className="text-lg font-medium tracking-[-0.03em]">{endpoint.title}</div>
-                              <div className="text-sm leading-7 text-muted-foreground">{endpoint.description}</div>
-                            </div>
-                          </div>
-                        </AccordionTrigger>
-                        <AccordionContent>
-                          <div className="grid gap-5 lg:grid-cols-2">
-                            <Card className="h-full">
-                              <CardHeader className="pb-4">
-                                <Badge variant="eyebrow">Direct URLs</Badge>
-                                <CardTitle className="text-xl">Provider endpoint</CardTitle>
-                              </CardHeader>
-                              <CardContent className="grid gap-4">
-                                <DetailRow label="Public URL" value={endpoint.publicUrl} copyValue={endpoint.publicUrl} />
-                                <DetailRow label="Docs URL" value={endpoint.docsUrl} copyValue={endpoint.docsUrl} />
-                                {endpoint.authNotes ? <p className="text-sm leading-7 text-muted-foreground">Auth: {endpoint.authNotes}</p> : null}
-                                {endpoint.usageNotes ? <p className="text-sm leading-7 text-muted-foreground">{endpoint.usageNotes}</p> : null}
-                              </CardContent>
-                            </Card>
-                            <ExampleBlock label="Request example" value={JSON.stringify(endpoint.requestExample, null, 2)} />
-                            <ExampleBlock label="Response example" value={JSON.stringify(endpoint.responseExample, null, 2)} />
-                          </div>
-                        </AccordionContent>
-                      </AccordionItem>
-                    ))}
-              </Accordion>
+            <CardContent className="flex flex-wrap gap-3">
+              <Button onClick={() => window.location.assign(`/suggest?service=${service.summary.slug}&type=endpoint`)}>
+                Suggest an endpoint
+              </Button>
+              <Button variant="outline" onClick={() => window.location.assign("/suggest?type=source")}>
+                Suggest a source
+              </Button>
             </CardContent>
           </Card>
         </div>
@@ -197,58 +199,29 @@ export function ServicePage({
 
 function PromptBlock({
   prompt,
-  description,
   skillUrl
 }: {
   prompt: string;
-  description: string;
   skillUrl?: string | null;
 }) {
   return (
-    <div className="terminal-surface">
+    <div className="prompt-block">
       <div className="terminal-toolbar">
-        <div className="text-sm font-medium">Agent-ready prompt block</div>
+        <div className="terminal-label">Setup and exact call parameters for AI Agents</div>
         <CopyButton value={prompt} />
       </div>
       <div className="terminal-body">
-        <div className="terminal-label">Setup and exact call parameters</div>
-        <p className="max-w-3xl text-sm leading-7 text-background/70">{description}</p>
         <pre className="terminal-code overflow-x-auto whitespace-pre-wrap">{prompt}</pre>
-        {skillUrl ? (
-          <Link href={skillUrl} className="inline-flex items-center gap-2 text-sm text-background/72 transition-opacity hover:opacity-100">
+      </div>
+      {skillUrl ? (
+        <div className="terminal-footer">
+          <Link href={skillUrl} className="terminal-label inline-flex items-center gap-2 transition-opacity hover:opacity-80">
             Open canonical SKILL.md
             <ArrowUpRight className="size-4" />
           </Link>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
     </div>
-  );
-}
-
-function DetailCard({
-  title,
-  label,
-  value,
-  copyValue,
-  notes
-}: {
-  title: string;
-  label: string;
-  value: string;
-  copyValue: string;
-  notes?: string | null;
-}) {
-  return (
-    <Card className="h-full">
-      <CardHeader className="pb-4">
-        <Badge variant="eyebrow">{label}</Badge>
-        <CardTitle className="text-xl">{title}</CardTitle>
-      </CardHeader>
-      <CardContent className="grid gap-4">
-        <DetailRow label={label} value={value} copyValue={copyValue} />
-        {notes ? <p className="text-sm leading-7 text-muted-foreground">{notes}</p> : null}
-      </CardContent>
-    </Card>
   );
 }
 
@@ -262,13 +235,13 @@ function DetailRow({
   copyValue: string;
 }) {
   return (
-    <div className="detail-pair">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <div className="detail-key">{label}</div>
-          <div className="detail-value mt-1">{value}</div>
-        </div>
+    <div className="terminal-surface h-full">
+      <div className="terminal-toolbar">
+        <div className="text-sm font-medium">{label}</div>
         <CopyButton value={copyValue} />
+      </div>
+      <div className="terminal-body">
+        <pre className="terminal-code overflow-x-auto whitespace-pre-wrap text-sm">{value}</pre>
       </div>
     </div>
   );

--- a/apps/web/components/services-data-table.tsx
+++ b/apps/web/components/services-data-table.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 import {
   type ColumnDef,
   flexRender,
@@ -10,8 +11,15 @@ import {
   useReactTable,
   type SortingState
 } from "@tanstack/react-table";
-import type { ServiceSummary } from "@marketplace/shared";
+import type {
+  ExternalServiceCatalogEndpoint,
+  MarketplaceServiceCatalogEndpoint,
+  ServiceDetail,
+  ServiceSummary
+} from "@marketplace/shared";
 
+import { fetchServiceDetail } from "@/lib/api";
+import { getClientApiBaseUrl } from "@/lib/api-base-url";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
@@ -90,69 +98,134 @@ function faviconUrlFromWebsiteUrl(websiteUrl: string): string | null {
   }
 }
 
-const columns: ColumnDef<ServiceSummary>[] = [
-  {
-    accessorKey: "name",
-    header: "Service",
-    cell: ({ row }) => {
-      const service = row.original;
-      const websiteUrl = serviceWebsiteUrl(service) ?? inferWebsiteUrlFromServiceName(service.name);
-
-      return (
-        <div className="flex items-center gap-3">
-          <ServiceFavicon
-            serviceName={service.name}
-            websiteUrl={websiteUrl}
-          />
-          <div>
-            <div>{service.name}</div>
-            <div>{service.tagline}</div>
-          </div>
-        </div>
-      );
-    }
-  },
-  {
-    accessorKey: "ownerName",
-    header: "Provider",
-    cell: ({ row }) => {
-      const service = row.original;
-
-      return <span>{service.ownerName}</span>;
-    }
-  },
-  {
-    id: "access",
-    header: "Access",
-    accessorFn: serviceAccessLabel
-  },
-  {
-    id: "pricing",
-    header: "Pricing",
-    accessorFn: servicePricingLabel
-  },
-  {
-    accessorKey: "endpointCount",
-    header: "Endpoints"
-  },
-  {
-    id: "traffic",
-    header: "Calls",
-    accessorFn: serviceTrafficLabel
-  },
-  {
-    id: "open",
-    header: "Open",
-    cell: ({ row }) => (
-      <Link href={`/services/${row.original.slug}`}>
-        View
-      </Link>
-    )
-  }
-];
-
 export function ServicesDataTable({ services }: { services: ServiceSummary[] }) {
   const [sorting, setSorting] = React.useState<SortingState>([{ id: "name", desc: false }]);
+  const [expandedSlug, setExpandedSlug] = React.useState<string | null>(null);
+  const [detailsBySlug, setDetailsBySlug] = React.useState<Record<string, ServiceDetail>>({});
+  const [loadingSlug, setLoadingSlug] = React.useState<string | null>(null);
+  const clientApiBaseUrl = React.useMemo(() => getClientApiBaseUrl(), []);
+  const detailsBySlugRef = React.useRef(detailsBySlug);
+  const inFlightDetailsRef = React.useRef<Record<string, Promise<ServiceDetail | null>>>({});
+
+  React.useEffect(() => {
+    detailsBySlugRef.current = detailsBySlug;
+  }, [detailsBySlug]);
+
+  const loadDetails = React.useCallback(async (service: ServiceSummary) => {
+    const cachedDetail = detailsBySlugRef.current[service.slug];
+    if (cachedDetail) {
+      return cachedDetail;
+    }
+
+    const inFlightDetail = inFlightDetailsRef.current[service.slug];
+    if (inFlightDetail) {
+      return inFlightDetail;
+    }
+
+    setLoadingSlug(service.slug);
+    const request = (async () => {
+      const detail = await fetchServiceDetail(service.slug, clientApiBaseUrl);
+      if (detail) {
+        setDetailsBySlug((current) => ({ ...current, [service.slug]: detail }));
+      }
+
+      return detail;
+    })();
+
+    inFlightDetailsRef.current[service.slug] = request;
+
+    try {
+      return await request;
+    } finally {
+      delete inFlightDetailsRef.current[service.slug];
+      setLoadingSlug((current) => (current === service.slug ? null : current));
+    }
+  }, [clientApiBaseUrl]);
+
+  const preloadDetails = React.useCallback((service: ServiceSummary) => {
+    void loadDetails(service);
+  }, [loadDetails]);
+
+  const toggleExpanded = React.useCallback(async (service: ServiceSummary) => {
+    if (expandedSlug === service.slug) {
+      setExpandedSlug(null);
+      return;
+    }
+
+    setExpandedSlug(service.slug);
+    await loadDetails(service);
+  }, [expandedSlug, loadDetails]);
+
+  const columns = React.useMemo<ColumnDef<ServiceSummary>[]>(() => [
+    {
+      accessorKey: "name",
+      header: "Service",
+      cell: ({ row }) => {
+        const service = row.original;
+        const websiteUrl = inferWebsiteUrlFromServiceName(service.name) ?? serviceWebsiteUrl(service);
+
+        return (
+          <div className="flex items-center gap-3">
+            <ServiceFavicon
+              serviceName={service.name}
+              websiteUrl={websiteUrl}
+            />
+            <div>
+              <div>{service.name}</div>
+              <div>{service.tagline}</div>
+            </div>
+          </div>
+        );
+      }
+    },
+    {
+      accessorKey: "ownerName",
+      header: "Provider",
+      cell: ({ row }) => <span>{row.original.ownerName}</span>
+    },
+    {
+      id: "access",
+      header: "Access",
+      accessorFn: serviceAccessLabel
+    },
+    {
+      id: "pricing",
+      header: "Pricing",
+      accessorFn: servicePricingLabel
+    },
+    {
+      accessorKey: "endpointCount",
+      header: "Endpoints"
+    },
+    {
+      id: "traffic",
+      header: "Calls",
+      accessorFn: serviceTrafficLabel
+    },
+    {
+      id: "details",
+      header: "Details",
+      cell: ({ row }) => {
+        const expanded = expandedSlug === row.original.slug;
+
+        return (
+          <div className="flex justify-end">
+            <Link
+              href={`/services/${row.original.slug}`}
+              onClick={(event) => event.stopPropagation()}
+              aria-label={`Open ${row.original.name} details`}
+            >
+              <ChevronRight
+                className={`h-4 w-4 text-muted-foreground transition-transform ${
+                  expanded ? "rotate-90" : "group-hover/table-row:rotate-90"
+                }`}
+              />
+            </Link>
+          </div>
+        );
+      }
+    }
+  ], [expandedSlug]);
 
   const table = useReactTable({
     data: services,
@@ -195,15 +268,38 @@ export function ServicesDataTable({ services }: { services: ServiceSummary[] }) 
       </TableHeader>
       <TableBody>
         {table.getRowModel().rows.length ? (
-          table.getRowModel().rows.map((row) => (
-            <TableRow key={row.id}>
-              {row.getVisibleCells().map((cell) => (
-                <TableCell key={cell.id} className="py-4">
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </TableCell>
-              ))}
-            </TableRow>
-          ))
+          table.getRowModel().rows.map((row) => {
+            const service = row.original;
+            const expanded = expandedSlug === service.slug;
+            const detail = detailsBySlug[service.slug];
+            const loading = loadingSlug === service.slug;
+
+            return (
+              <React.Fragment key={row.id}>
+                <TableRow
+                  className="group/table-row cursor-pointer"
+                  onMouseEnter={() => preloadDetails(service)}
+                  onFocus={() => preloadDetails(service)}
+                  onTouchStart={() => preloadDetails(service)}
+                  onClick={() => void toggleExpanded(service)}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id} className="py-4">
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+                {expanded ? (
+                  <TableRow>
+                    <TableCell colSpan={columns.length} className="bg-muted/20 px-2 py-4">
+                      {loading && !detail ? <div className="text-sm text-muted-foreground">Loading details…</div> : null}
+                      {detail ? <EndpointSubtable detail={detail} /> : null}
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+              </React.Fragment>
+            );
+          })
         ) : (
           <TableRow>
             <TableCell colSpan={columns.length}>No services found.</TableCell>
@@ -211,6 +307,88 @@ export function ServicesDataTable({ services }: { services: ServiceSummary[] }) 
         )}
       </TableBody>
     </Table>
+  );
+}
+
+function EndpointSubtable({ detail }: { detail: ServiceDetail }) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid grid-cols-[360px_minmax(0,1fr)_120px] gap-4 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+        <div>Endpoint</div>
+        <div>Description</div>
+        <div>Price</div>
+      </div>
+      <div className="grid gap-2">
+        {detail.serviceType === "marketplace_proxy"
+          ? detail.endpoints.map((endpoint) => (
+              <MarketplaceEndpointRow
+                key={endpoint.routeId}
+                endpoint={endpoint}
+                serviceSlug={detail.summary.slug}
+              />
+            ))
+          : detail.endpoints.map((endpoint) => (
+              <ExternalEndpointRow
+                key={endpoint.endpointId}
+                endpoint={endpoint}
+                serviceSlug={detail.summary.slug}
+              />
+            ))}
+      </div>
+    </div>
+  );
+}
+
+function MarketplaceEndpointRow({
+  endpoint,
+  serviceSlug
+}: {
+  endpoint: MarketplaceServiceCatalogEndpoint;
+  serviceSlug: string;
+}) {
+  const href = `/services/${serviceSlug}?endpoint=${encodeURIComponent(endpoint.routeId)}`;
+
+  return (
+    <div className="grid grid-cols-[360px_minmax(0,1fr)_120px] gap-4">
+      <Link href={href} className="text-sm font-medium text-foreground hover:opacity-80">
+        <div>{endpoint.method}</div>
+        <div className="text-muted-foreground">{endpoint.path}</div>
+      </Link>
+      <Link href={href} className="text-sm hover:opacity-80">
+        <div className="font-medium text-foreground">{endpoint.title}</div>
+        <div className="text-muted-foreground">{endpoint.description}</div>
+        <div className="text-muted-foreground">{endpoint.mode}</div>
+      </Link>
+      <div className="text-sm font-medium text-foreground">
+        {endpoint.price}
+        {endpoint.billingType === "fixed_x402" || endpoint.billingType === "topup_x402_variable" ? ` ${endpoint.tokenSymbol}` : ""}
+      </div>
+    </div>
+  );
+}
+
+function ExternalEndpointRow({
+  endpoint,
+  serviceSlug
+}: {
+  endpoint: ExternalServiceCatalogEndpoint;
+  serviceSlug: string;
+}) {
+  const href = `/services/${serviceSlug}?endpoint=${encodeURIComponent(endpoint.endpointId)}`;
+
+  return (
+    <div className="grid grid-cols-[360px_minmax(0,1fr)_120px] gap-4">
+      <Link href={href} className="text-sm font-medium text-foreground hover:opacity-80">
+        <div>{endpoint.method}</div>
+        <div className="text-muted-foreground">{endpoint.publicUrl.replace(/^https?:\/\//, "")}</div>
+      </Link>
+      <Link href={href} className="text-sm hover:opacity-80">
+        <div className="font-medium text-foreground">{endpoint.title}</div>
+        <div className="text-muted-foreground">{endpoint.description}</div>
+        <div className="text-muted-foreground">direct</div>
+      </Link>
+      <div className="text-sm font-medium text-foreground">Provider</div>
+    </div>
   );
 }
 

--- a/apps/web/components/site-footer.test.tsx
+++ b/apps/web/components/site-footer.test.tsx
@@ -22,7 +22,6 @@ describe("SiteFooter", () => {
     const links = screen.getAllByRole("link");
 
     expect(links).toHaveLength(2);
-    expect(screen.getByText("Socials")).toBeTruthy();
     expect(screen.getByRole("link", { name: "X.com" }).getAttribute("href")).toBe("https://x.com/pi2_labs");
     expect(screen.getByRole("link", { name: "LinkedIn" }).getAttribute("href")).toBe(
       "https://www.linkedin.com/company/fast-xyz"

--- a/apps/web/components/site-footer.tsx
+++ b/apps/web/components/site-footer.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import { Linkedin } from "lucide-react";
 
 import { FastLogo } from "@/components/fast-logo";
 
@@ -17,16 +18,49 @@ export function SiteFooter() {
             <FastLogo height={16} />
           </div>
           <div className="flex items-center gap-5">
-            <span className="footer-label">Socials</span>
-            {socialLinks.map((link) => (
-              <Link key={link.href} href={link.href} className="footer-link text-sm" target="_blank" rel="noreferrer">
-                {link.label}
-              </Link>
-            ))}
+            <Link
+              href={socialLinks[0].href}
+              className="footer-link text-muted-foreground transition-colors hover:text-foreground"
+              target="_blank"
+              rel="noreferrer"
+              aria-label={socialLinks[0].label}
+              title={socialLinks[0].label}
+            >
+              <XIcon className="h-4 w-4" />
+            </Link>
+            <Link
+              href={socialLinks[1].href}
+              className="footer-link text-muted-foreground transition-colors hover:text-foreground"
+              target="_blank"
+              rel="noreferrer"
+              aria-label={socialLinks[1].label}
+              title={socialLinks[1].label}
+            >
+              <Linkedin className="h-4 w-4" />
+            </Link>
           </div>
           <p className="text-sm text-muted-foreground">© {new Date().getFullYear()} Fast Marketplace</p>
         </div>
       </div>
     </footer>
+  );
+}
+
+function XIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+    >
+      <path
+        d="M5 4L19 20M19 4L5 20"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }

--- a/apps/web/components/site-header.test.tsx
+++ b/apps/web/components/site-header.test.tsx
@@ -54,9 +54,7 @@ describe("SiteHeader", () => {
     expect(mobileNav).toBeTruthy();
     expect(within(mobileNav).getByText("Stats")).toBeTruthy();
     expect(within(mobileNav).getByText("Spend")).toBeTruthy();
-    expect(within(mobileNav).getByText("Suggest")).toBeTruthy();
     expect(within(mobileNav).getByText("Providers")).toBeTruthy();
-    expect(within(mobileNav).getByText("SKILL.md")).toBeTruthy();
   });
 
   it("does not render the mainnet badge in the navbar", () => {

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -28,14 +28,8 @@ export function SiteHeader({
       <Link href="/me/spend" className="fast-nav-link" onClick={() => setMobileMenuOpen(false)}>
         Spend
       </Link>
-      <Link href="/suggest" className="fast-nav-link" onClick={() => setMobileMenuOpen(false)}>
-        Suggest
-      </Link>
       <Link href="/providers" className="fast-nav-link" onClick={() => setMobileMenuOpen(false)}>
         Providers
-      </Link>
-      <Link href="/skill.md" className="fast-nav-link" onClick={() => setMobileMenuOpen(false)}>
-        SKILL.md
       </Link>
     </>
   );
@@ -77,12 +71,12 @@ export function SiteHeader({
             >
               {mobileMenuOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
             </button>
-            <ModeToggle />
             <WalletLoginButton
               apiBaseUrl={apiBaseUrl}
               deploymentNetwork={deploymentNetwork}
               networkLabel={networkLabel}
             />
+            <ModeToggle />
           </div>
         </div>
       </div>

--- a/apps/web/components/wallet-login-button.test.tsx
+++ b/apps/web/components/wallet-login-button.test.tsx
@@ -111,4 +111,33 @@ describe("WalletLoginButton", () => {
       deploymentNetwork: "mainnet"
     });
   });
+
+  it("shows an actionable error when wallet auth receives the Next app HTML instead of API JSON", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("<!DOCTYPE html><html><body>Not the API</body></html>", {
+        status: 404,
+        headers: {
+          "content-type": "text/html"
+        }
+      })
+    );
+
+    render(
+      <WalletLoginButton
+        apiBaseUrl=""
+        deploymentNetwork="mainnet"
+        networkLabel="Mainnet"
+      />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /connect to fast/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /wallet auth hit the web app instead of the api\. for localhost dev, run the api server and set marketplace_api_base_url=http:\/\/localhost:3000 before starting the web app\./i
+        )
+      ).toBeTruthy();
+    });
+  });
 });

--- a/apps/web/components/wallet-login-button.tsx
+++ b/apps/web/components/wallet-login-button.tsx
@@ -38,6 +38,16 @@ interface SessionState {
   resourceId: string;
 }
 
+function normalizeAuthFailureMessage(message: string): string {
+  const trimmed = message.trim();
+
+  if (trimmed.startsWith("<!DOCTYPE html>") || trimmed.startsWith("<html")) {
+    return "Wallet auth hit the web app instead of the API. For localhost dev, run the API server and set MARKETPLACE_API_BASE_URL=http://localhost:3000 before starting the web app.";
+  }
+
+  return trimmed || "Wallet login failed.";
+}
+
 export function WalletLoginButton({
   apiBaseUrl,
   deploymentNetwork,
@@ -110,7 +120,7 @@ export function WalletLoginButton({
       });
 
       if (!challengeResponse.ok) {
-        throw new Error(await challengeResponse.text());
+        throw new Error(normalizeAuthFailureMessage(await challengeResponse.text()));
       }
 
       const challenge = (await challengeResponse.json()) as WalletChallengeResponse;
@@ -129,7 +139,7 @@ export function WalletLoginButton({
       });
 
       if (!sessionResponse.ok) {
-        throw new Error(await sessionResponse.text());
+        throw new Error(normalizeAuthFailureMessage(await sessionResponse.text()));
       }
 
       const walletSession = (await sessionResponse.json()) as WalletSessionResponse;
@@ -197,6 +207,7 @@ export function WalletLoginButton({
           <Button
             type="button"
             size="sm"
+            className="wallet-connect-button"
             onClick={() => void connectWallet()}
             disabled={pending}
             aria-label="Connect to Fast"
@@ -212,15 +223,7 @@ export function WalletLoginButton({
                   aria-hidden="true"
                   width={146}
                   height={52}
-                  className="block h-4 w-auto dark:hidden"
-                />
-                <img
-                  src="/brand/fast-logo-dark.svg"
-                  alt=""
-                  aria-hidden="true"
-                  width={146}
-                  height={52}
-                  className="hidden h-4 w-auto dark:block"
+                  className="block h-4 w-auto"
                 />
               </>
             )}

--- a/apps/web/lib/api-base-url.test.ts
+++ b/apps/web/lib/api-base-url.test.ts
@@ -3,14 +3,24 @@ import { describe, expect, it } from "vitest";
 import { getClientApiBaseUrl } from "./api-base-url";
 
 describe("getClientApiBaseUrl", () => {
-  it("uses same-origin in development when the env still points at the production API", () => {
+  it("defaults localhost web dev to the local API port when no client API base URL is configured", () => {
+    expect(
+      getClientApiBaseUrl({
+        NODE_ENV: "development",
+        MARKETPLACE_API_BASE_URL: undefined,
+        NEXT_PUBLIC_MARKETPLACE_API_BASE_URL: undefined
+      })
+    ).toBe("http://localhost:3000");
+  });
+
+  it("keeps an explicitly configured production API base URL in development", () => {
     expect(
       getClientApiBaseUrl({
         NODE_ENV: "development",
         MARKETPLACE_API_BASE_URL: "https://api.marketplace.fast.xyz",
         NEXT_PUBLIC_MARKETPLACE_API_BASE_URL: "https://api.marketplace.fast.xyz"
       })
-    ).toBe("");
+    ).toBe("https://api.marketplace.fast.xyz");
   });
 
   it("keeps an explicitly configured non-production client API base URL", () => {

--- a/apps/web/lib/api-base-url.ts
+++ b/apps/web/lib/api-base-url.ts
@@ -1,7 +1,7 @@
-const DEFAULT_PRODUCTION_API_BASE_URL = "https://api.marketplace.fast.xyz";
+const DEFAULT_LOCAL_API_BASE_URL = "http://localhost:3000";
 
 export function getServerApiBaseUrl(): string {
-  return process.env.MARKETPLACE_API_BASE_URL ?? "http://localhost:3000";
+  return process.env.MARKETPLACE_API_BASE_URL ?? DEFAULT_LOCAL_API_BASE_URL;
 }
 
 export function getClientApiBaseUrl(
@@ -9,9 +9,10 @@ export function getClientApiBaseUrl(
 ): string {
   const configured = env.NEXT_PUBLIC_MARKETPLACE_API_BASE_URL ?? env.MARKETPLACE_API_BASE_URL ?? "";
 
-  // Local web dev should default to same-origin unless a non-production API was explicitly configured.
-  if (env.NODE_ENV !== "production" && configured === DEFAULT_PRODUCTION_API_BASE_URL) {
-    return "";
+  if (env.NODE_ENV !== "production") {
+    if (!configured) {
+      return DEFAULT_LOCAL_API_BASE_URL;
+    }
   }
 
   return configured;

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -79,8 +79,8 @@ export async function fetchServices(): Promise<ServiceSummary[]> {
   return data.services;
 }
 
-export async function fetchServiceDetail(slug: string): Promise<ServiceDetail | null> {
-  const response = await fetch(`${getApiBaseUrl()}/catalog/services/${slug}`, {
+export async function fetchServiceDetail(slug: string, apiBaseUrl?: string): Promise<ServiceDetail | null> {
+  const response = await fetch(`${(apiBaseUrl ?? getApiBaseUrl()).replace(/\/$/, "")}/catalog/services/${slug}`, {
     cache: "no-store"
   });
 


### PR DESCRIPTION
Refines the marketplace service detail page and table UX. Adds a new `/catalog/services/[slug]` API route for server-side service detail fetching, refactors `marketplace-home.tsx` and `services-data-table.tsx` layout classes, and introduces `service-page.tsx` with its test suite. Also updates shared CSS utility classes (`page-shell`, `section-sep`, `section-container`, `section-stack`, `page-intro`) and adds a ghost-small button variant. Affects `apps/web` components, CSS, and lib files.