### PR TITLE
Add build-push workflow for GHCR image publishing

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,105 @@
+name: Build & Push Docker Images
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/**'
+      - 'apps/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsup.config.ts'
+      - '.github/workflows/build-push.yml'
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  test:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+  build-and-push:
+    name: Build and Push ${{ matrix.service }}
+    needs: test
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - service: api
+            dockerfile: docker/api.Dockerfile
+            image: ghcr.io/fastxyz/marketplace-api
+          - service: web
+            dockerfile: docker/web.Dockerfile
+            image: ghcr.io/fastxyz/marketplace-web
+          - service: worker
+            dockerfile: docker/worker.Dockerfile
+            image: ghcr.io/fastxyz/marketplace-worker
+          - service: facilitator
+            dockerfile: docker/facilitator.Dockerfile
+            image: ghcr.io/fastxyz/marketplace-facilitator
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.10.0
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=ref,event=branch,suffix=-{{sha}}
+            type=ref,event=branch,suffix=-latest
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - name: Set Up Docker Buildx
+        uses: docker/setup-buildx-action@v3.12.0
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}


### PR DESCRIPTION
Matrix build for api, web, worker, and facilitator services using existing docker/*.Dockerfile files. Runs tests on PRs, builds and pushes to GHCR on push to main.