### PR TITLE
Remove redundant test job from build-push workflow

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,36 +17,13 @@ on:
       - 'package-lock.json'
       - 'tsup.config.ts'
       - '.github/workflows/build-push.yml'
-  pull_request:
-    branches:
-      - main
 
 env:
   REGISTRY: ghcr.io
 
 jobs:
-  test:
-    name: Lint and Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Test
-        run: npm test
-
   build-and-push:
     name: Build and Push ${{ matrix.service }}
-    needs: test
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
CI already runs tests on PRs via ci.yml. The build workflow only needs to build and push images on push to main.