### PR TITLE
Fix Fast REST x402 marketplace payments

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -185,6 +185,10 @@ describe("marketplace api", () => {
         expect.objectContaining({
           id: "shop-fast-amazon:amazon-order-status",
           endpoint: "https://shop.fast.xyz/api/amazon/order-status"
+        }),
+        expect.objectContaining({
+          id: "shopify-storefront:storefront-graphql",
+          endpoint: "https://{store_name}.myshopify.com/api/2026-04/graphql.json"
         })
       ])
     );

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -567,6 +567,13 @@ describe("marketplace api", () => {
     expect(await store.getCommerceFulfillmentByOrderId(order!.id)).toMatchObject({
       status: "pending_shipment"
     });
+
+    const duplicateBuy = await request(app)
+      .post("/api/shop-fast-amazon/amazon-buy")
+      .send(buyBody);
+
+    expect(duplicateBuy.status).toBe(400);
+    expect(duplicateBuy.body.error).toContain("already been used");
   });
 
   it("replays the same sync response for the same payment id and request", async () => {

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -22,7 +22,7 @@ const OTHER_PRIVATE_KEY = "44".repeat(32);
 
 async function createTestWallet(privateKey = TEST_PRIVATE_KEY) {
   const provider = new FastProvider({
-    rpcUrl: "https://api.fast.xyz/proxy"
+    url: "https://api.fast.xyz/proxy-rest"
   });
   const wallet = await MarketplaceFastWallet.fromPrivateKey(privateKey, provider);
   const exported = await wallet.exportKeys();

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2438,6 +2438,7 @@ async function resolveCommerceQuotePayment(input: {
   store: MarketplaceStore;
   route: PublishedEndpointVersionRecord;
   requestBody: unknown;
+  paymentId: string | null;
 }): Promise<{ quoteId: string; quotedPrice: string; price: string }> {
   const quoteId = commerceQuoteIdFromRequest(input.requestBody);
   commerceConsentFromRequest(input.requestBody);
@@ -2447,6 +2448,13 @@ async function resolveCommerceQuotePayment(input: {
   }
   if (quote.serviceId !== input.route.serviceId) {
     throw new Error("Commerce quote belongs to a different service.");
+  }
+  const existingOrder = await input.store.getCommerceOrderByQuoteId(quoteId);
+  if (existingOrder && existingOrder.paymentId !== input.paymentId) {
+    throw new Error("Commerce quote has already been used for an order.");
+  }
+  if (quote.status === "accepted" && existingOrder?.paymentId !== input.paymentId) {
+    throw new Error("Commerce quote has already been accepted.");
   }
   if (quote.status !== "quoted" && quote.status !== "accepted") {
     throw new Error(`Commerce quote is ${quote.status}.`);
@@ -2539,7 +2547,8 @@ async function handleX402Route(input: {
       ? await resolveCommerceQuotePayment({
           store: input.store,
           route: input.route,
-          requestBody
+          requestBody,
+          paymentId: paymentHeaders.paymentId
         })
       : null;
     requiredBody = buildPaymentRequiredResponse(input.route, paymentDestinationWallet, requestBody, commerceQuoteContext?.price);
@@ -2705,6 +2714,9 @@ async function handleX402Route(input: {
         requestId,
         requestBody
       });
+      if (commerceOrder.paymentId !== paymentHeaders.paymentId) {
+        throw new Error("Commerce quote has already been used for a different payment.");
+      }
     } catch (error) {
       const failedResponse = await buildRejectedSyncResponse({
         executeResult: {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -73,13 +73,16 @@ const app = createMarketplaceApi({
   siteProofToken: process.env.MARKETPLACE_SITE_PROOF
 });
 
-const server = app.listen(port, () => {
-  console.log(`Marketplace API listening on ${baseUrl}`);
-});
+const listenPorts = Array.from(new Set([port, 3000, 8080].filter((value) => Number.isFinite(value) && value > 0)));
+const servers = listenPorts.map((listenPort) =>
+  app.listen(listenPort, "0.0.0.0", () => {
+    console.log(`Marketplace API listening on 0.0.0.0:${listenPort} (${baseUrl})`);
+  })
+);
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {
   process.on(signal, async () => {
-    server.close();
+    await Promise.all(servers.map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
     await pool.end();
     process.exit(0);
   });

--- a/apps/apify-service/src/app.ts
+++ b/apps/apify-service/src/app.ts
@@ -67,6 +67,7 @@ export function createApifyServiceApp(options: ApifyServiceOptions): Express {
   });
 
   const runHandler: express.RequestHandler = async (req, res) => {
+    const actorInput = normalizeActorInput(options.actorId, req.body ?? {});
     let response: globalThis.Response;
     try {
       response = await fetch(buildActorRunUrl(upstreamBaseUrl, options.actorId), {
@@ -75,7 +76,7 @@ export function createApifyServiceApp(options: ApifyServiceOptions): Express {
           authorization: `Bearer ${options.apifyApiToken}`,
           "content-type": "application/json"
         },
-        body: JSON.stringify(req.body ?? {})
+        body: JSON.stringify(actorInput)
       });
     } catch (error) {
       return res.status(502).json({
@@ -202,6 +203,25 @@ export function createApifyServiceApp(options: ApifyServiceOptions): Express {
   });
 
   return app;
+}
+
+function normalizeActorInput(actorId: string, body: unknown): unknown {
+  if (!isJsonObject(body)) {
+    return body;
+  }
+
+  if (
+    actorId === "junglee/amazon-crawler"
+    && Array.isArray(body.startUrls)
+    && !Array.isArray(body.categoryOrProductUrls)
+  ) {
+    return {
+      ...body,
+      categoryOrProductUrls: body.startUrls
+    };
+  }
+
+  return body;
 }
 
 function normalizeUpstreamBaseUrl(input: string): string {

--- a/apps/facilitator/src/index.ts
+++ b/apps/facilitator/src/index.ts
@@ -14,6 +14,6 @@ app.use(
   })
 );
 
-app.listen(port, () => {
+app.listen(port, "0.0.0.0", () => {
   console.log(`Marketplace facilitator listening on http://localhost:${port}`);
 });

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -3,6 +3,7 @@ FROM node:20-bookworm-slim AS builder
 WORKDIR /app
 
 COPY package.json package-lock.json tsconfig.json tsup.config.ts ./
+COPY patches ./patches
 COPY apps/api/package.json apps/api/package.json
 COPY apps/facilitator/package.json apps/facilitator/package.json
 COPY apps/web/package.json apps/web/package.json
@@ -25,6 +26,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 COPY package.json package-lock.json ./
+COPY patches ./patches
 COPY apps/api/package.json apps/api/package.json
 COPY apps/facilitator/package.json apps/facilitator/package.json
 COPY apps/web/package.json apps/web/package.json
@@ -37,6 +39,6 @@ RUN npm ci --omit=dev
 
 COPY --from=builder /app/dist ./dist
 
-EXPOSE 3000
+EXPOSE 3000 8080
 
 CMD ["npm", "run", "start:api"]

--- a/docker/facilitator.Dockerfile
+++ b/docker/facilitator.Dockerfile
@@ -3,6 +3,7 @@ FROM node:20-bookworm-slim AS builder
 WORKDIR /app
 
 COPY package.json package-lock.json tsconfig.json tsup.config.ts ./
+COPY patches ./patches
 COPY apps/api/package.json apps/api/package.json
 COPY apps/facilitator/package.json apps/facilitator/package.json
 COPY apps/web/package.json apps/web/package.json
@@ -25,6 +26,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 COPY package.json package-lock.json ./
+COPY patches ./patches
 COPY apps/api/package.json apps/api/package.json
 COPY apps/facilitator/package.json apps/facilitator/package.json
 COPY apps/web/package.json apps/web/package.json

--- a/docker/valyu-service.Dockerfile
+++ b/docker/valyu-service.Dockerfile
@@ -3,6 +3,7 @@ FROM node:20-bookworm-slim AS builder
 WORKDIR /app
 
 COPY package.json package-lock.json tsconfig.json tsup.config.ts ./
+COPY patches ./patches
 COPY apps/api/package.json apps/api/package.json
 COPY apps/apify-service/package.json apps/apify-service/package.json
 COPY apps/facilitator/package.json apps/facilitator/package.json
@@ -27,6 +28,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 COPY package.json package-lock.json ./
+COPY patches ./patches
 COPY apps/api/package.json apps/api/package.json
 COPY apps/apify-service/package.json apps/apify-service/package.json
 COPY apps/facilitator/package.json apps/facilitator/package.json

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -3,6 +3,7 @@ FROM node:20-bookworm-slim AS builder
 WORKDIR /app
 
 COPY package.json package-lock.json tsconfig.json tsup.config.ts ./
+COPY patches ./patches
 COPY SKILL.md ./
 COPY apps/api/package.json apps/api/package.json
 COPY apps/facilitator/package.json apps/facilitator/package.json

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -3,6 +3,7 @@ FROM node:20-bookworm-slim AS builder
 WORKDIR /app
 
 COPY package.json package-lock.json tsconfig.json tsup.config.ts ./
+COPY patches ./patches
 COPY apps/api/package.json apps/api/package.json
 COPY apps/facilitator/package.json apps/facilitator/package.json
 COPY apps/web/package.json apps/web/package.json
@@ -25,6 +26,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 COPY package.json package-lock.json ./
+COPY patches ./patches
 COPY apps/api/package.json apps/api/package.json
 COPY apps/facilitator/package.json apps/facilitator/package.json
 COPY apps/web/package.json apps/web/package.json

--- a/docs/fast-shop-marketplace-integration.md
+++ b/docs/fast-shop-marketplace-integration.md
@@ -1,0 +1,238 @@
+# Fast Shop Marketplace Integration
+
+## Goal
+
+Add some of the APIs already running on `https://marketplace.fast.xyz` / `https://api.marketplace.fast.xyz` to the `shop.fast.xyz` experience, which is run from the local `fast-shop` repo.
+
+The intended integration is not to copy marketplace internals into `fast-shop`. `fast-shop` should understand the marketplace's public catalog and execution contracts, then use the hosted marketplace API for discovery and, where needed, invocation.
+
+## Marketplace Repo Shape
+
+`ai-agent-marketplace` is a Node 20+ TypeScript npm workspace.
+
+- `apps/api`: Express gateway. This is the primary integration surface for `fast-shop`. It serves catalog/docs endpoints and executes marketplace proxy routes.
+- `apps/web`: Next.js UI for `marketplace.fast.xyz`. Useful as UI reference, but not the thing `fast-shop` should call.
+- `apps/worker`: async job polling, refunds, stale-payment recovery, and provider payout settlement.
+- `packages/shared`: shared contracts, route/catalog builders, OpenAPI generation, billing/auth/payment helpers, payout logic, and store behavior.
+- `packages/cli`: working buyer/provider CLI. This is the best reference for programmatic marketplace discovery and invocation flows.
+- `packages/mcp`: local MCP server that reuses the CLI wallet/payment flow.
+
+## Live Hosts
+
+Use the API host for machine-readable data and execution:
+
+```ts
+const MARKETPLACE_API_BASE_URL = "https://api.marketplace.fast.xyz";
+```
+
+The website host is mostly presentation:
+
+```txt
+https://marketplace.fast.xyz
+```
+
+Current important detail: marketplace service pages point executable endpoints at `https://api.marketplace.fast.xyz`, not the bare web host.
+
+## Public API Contract For Fast Shop
+
+Useful marketplace API endpoints:
+
+```txt
+GET /catalog/services
+GET /catalog/search?q=...&category=...&limit=...
+GET /catalog/services/:slug
+GET /catalog/routes/:provider/:operation
+GET /openapi.json
+GET /.well-known/marketplace.json
+GET /llms.txt
+POST|GET /api/:provider/:operation
+GET /api/jobs/:jobToken
+```
+
+The key endpoints to start with are:
+
+- `GET /catalog/services`: list all published service summaries.
+- `GET /catalog/search`: query/filter service and endpoint matches.
+- `GET /catalog/services/:slug`: get service detail, endpoint examples, schemas, prompts, and executable proxy URLs.
+- `GET /catalog/routes/:provider/:operation`: get one executable route's detail before invoking it.
+
+## Service Types
+
+Marketplace services have two high-level types.
+
+### `marketplace_proxy`
+
+Executable through the marketplace API. These services expose endpoints with:
+
+- `endpointType: "marketplace_proxy"`
+- `ref`, usually `provider.operation`
+- `method`
+- `path`, for example `/api/apify-google-search/search-results`
+- `proxyUrl`, for example `https://api.marketplace.fast.xyz/api/apify-google-search/search-results`
+- `billingType`
+- `authRequirement`
+- `requestSchemaJson`
+- `responseSchemaJson`
+- `requestExample`
+- `responseExample`
+- `usageNotes`
+
+Use these when `fast-shop` should actually call marketplace-run APIs.
+
+### `external_registry`
+
+Discovery-only listings. These services expose direct provider metadata:
+
+- `endpointType: "external_registry"`
+- `publicUrl`
+- `docsUrl`
+- `authNotes`
+- `requestExample`
+- `responseExample`
+
+Do not route these through the marketplace API. Calls go directly to the external provider, and payment/auth are provider-defined.
+
+## Code To Reuse Or Mirror
+
+Use these files as references:
+
+- `apps/api/src/app.ts`: public API routes, especially `/catalog/*`, `/openapi.json`, `/llms.txt`, and `/.well-known/marketplace.json`.
+- `apps/web/lib/api.ts`: small fetch wrapper and service detail fetch logic.
+- `packages/shared/src/catalog.ts`: source of truth for service detail shape, endpoint shape, `proxyUrl`, prompts, and catalog search output.
+- `packages/shared/src/types.ts`: TypeScript interfaces for `ServiceSummary`, `ServiceDetail`, `MarketplaceServiceCatalogEndpoint`, `ExternalServiceCatalogEndpoint`, and `MarketplaceRouteDetail`.
+- `packages/cli/src/lib.ts`: reference implementation for route lookup, request construction, x402 handling, wallet-session handling, and job polling.
+
+For `fast-shop`, mirror the small HTTP client pattern from `apps/web/lib/api.ts`, not the marketplace store/admin/provider internals.
+
+## Suggested Fast Shop Client
+
+Add a small module in `fast-shop`, for example `src/marketplace-client.ts`:
+
+```ts
+const DEFAULT_MARKETPLACE_API_BASE_URL = "https://api.marketplace.fast.xyz";
+
+function marketplaceBaseUrl(): string {
+  return (process.env.MARKETPLACE_API_BASE_URL ?? DEFAULT_MARKETPLACE_API_BASE_URL).replace(/\/$/, "");
+}
+
+export async function fetchMarketplace<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${marketplaceBaseUrl()}${path}`, {
+    cache: "no-store",
+    ...init,
+    headers: {
+      ...(init?.headers ?? {})
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(await response.text() || `Marketplace request failed: ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+```
+
+Then fetch services or details:
+
+```ts
+const { services } = await fetchMarketplace<{ services: ServiceSummary[] }>("/catalog/services");
+
+const detail = await fetchMarketplace<ServiceDetail>(
+  "/catalog/services/apify-google-search-scraper"
+);
+```
+
+## Suggested Fast Shop Product Behavior
+
+Start with discovery/display rather than execution:
+
+1. Keep Fast Shop's own routes as-is: `/search`, `/products/:product_id`, `/quote`, `/orders`, order tracking, and cancellation.
+2. Add a "More agent APIs" or "Marketplace APIs" section to the `shop.fast.xyz` page.
+3. Source that section from `GET https://api.marketplace.fast.xyz/catalog/search` or `/catalog/services`.
+4. Use an allowlist of slugs/categories so only relevant marketplace APIs appear on the shop page.
+5. For each selected service, show the service name, tagline, categories, access model, pricing, and endpoint count.
+6. For `marketplace_proxy` services, expose endpoint examples or link to the executable `proxyUrl`.
+7. For `external_registry` services, link to `publicUrl` or `docsUrl` and avoid implying the marketplace executes those calls.
+
+## If Fast Shop Should Execute Marketplace APIs
+
+For a marketplace route:
+
+1. Fetch route detail:
+
+```txt
+GET https://api.marketplace.fast.xyz/catalog/routes/:provider/:operation
+```
+
+2. Build the invocation URL:
+
+```txt
+https://api.marketplace.fast.xyz/api/:provider/:operation
+```
+
+3. For `GET` routes, serialize input fields as query parameters.
+4. For `POST` routes, send JSON with `content-type: application/json`.
+5. Validate request bodies against `requestSchemaJson` when practical.
+6. If the route returns `402`, use `@fastxyz/x402-client` to pay and retry.
+7. If the response returns a `jobToken`, poll:
+
+```txt
+GET https://api.marketplace.fast.xyz/api/jobs/:jobToken
+```
+
+Async job retrieval requires the wallet/session flow described by the marketplace route detail and CLI code.
+
+## Rough Invocation Shape
+
+```ts
+async function callMarketplaceRoute(input: {
+  provider: string;
+  operation: string;
+  method: "GET" | "POST";
+  body?: unknown;
+}) {
+  const base = "https://api.marketplace.fast.xyz";
+  const url = new URL(`/api/${input.provider}/${input.operation}`, base);
+
+  if (input.method === "GET" && input.body && typeof input.body === "object") {
+    for (const [key, value] of Object.entries(input.body as Record<string, unknown>)) {
+      if (value !== undefined && value !== null) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  return fetch(url, {
+    method: input.method,
+    headers: input.method === "POST" ? { "content-type": "application/json" } : undefined,
+    body: input.method === "POST" ? JSON.stringify(input.body ?? {}) : undefined
+  });
+}
+```
+
+This only covers the raw request. Paid routes still need x402 handling, and async authenticated routes need wallet-session handling. Use `packages/cli/src/lib.ts` as the full reference for those flows.
+
+## What Not To Reuse In Fast Shop
+
+Avoid copying these into `fast-shop`:
+
+- marketplace database/store code
+- provider onboarding/admin review code
+- payout/refund worker internals
+- route registry generation internals
+- `apps/web` pages/components wholesale
+
+The clean boundary is: `fast-shop` consumes the hosted marketplace catalog and, for selected `marketplace_proxy` endpoints, calls the hosted marketplace API.
+
+## Practical First Cut
+
+Recommended first implementation in `fast-shop`:
+
+1. Add `MARKETPLACE_API_BASE_URL=https://api.marketplace.fast.xyz`.
+2. Add a minimal `marketplace-client.ts`.
+3. Fetch `/catalog/search?limit=...` server-side.
+4. Filter to selected slugs or categories.
+5. Render cards on the homepage.
+6. Link each card to the marketplace service detail page or show endpoint examples from `/catalog/services/:slug`.
+7. Add tests that mock the marketplace API response and assert the page still renders if the marketplace request fails.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,16 @@
   "packages": {
     "": {
       "name": "fast-agent-marketplace",
+      "hasInstallScript": true,
       "workspaces": [
         "apps/*",
         "packages/*"
       ],
       "dependencies": {
-        "@fastxyz/fast-connector": "0.1.2",
-        "@fastxyz/sdk": "1.0.1",
-        "@fastxyz/x402-client": "0.1.3",
-        "@fastxyz/x402-facilitator": "1.0.1",
+        "@fastxyz/fast-connector": "^0.1.3",
+        "@fastxyz/sdk": "^2.2.0",
+        "@fastxyz/x402-client": "^1.0.5",
+        "@fastxyz/x402-facilitator": "^1.0.5",
         "@fastxyz/x402-server": "1.0.1",
         "@noble/ed25519": "^2.3.0",
         "@noble/hashes": "^1.8.0",
@@ -21,6 +22,7 @@
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
         "express": "^4.21.2",
+        "patch-package": "^8.0.1",
         "pg": "^8.16.3",
         "zod": "^4.3.6",
         "zod-to-json-schema": "^3.24.6"
@@ -372,42 +374,37 @@
       }
     },
     "node_modules/@fastxyz/allset-sdk": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@fastxyz/allset-sdk/-/allset-sdk-0.1.12.tgz",
-      "integrity": "sha512-aMzrVq9ENwIA3RINfHhBe80AbIqWOct/PHPfqSGHMDekHZ8Q5VLIPDSohFPLzId5eyLVkGzOGS+Radzdv4q6fg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@fastxyz/allset-sdk/-/allset-sdk-1.0.4.tgz",
+      "integrity": "sha512-my8tr5Oa/dZ2FC4DNpHjKJDCBB2YV3RuH/VSPVyNNBnk4Gx/6OQGd33fYoTsP1o9u4oQOg2MFRfmRWdZoJq96Q==",
       "license": "MIT",
       "dependencies": {
-        "@mysten/bcs": "^2.0.2",
-        "@noble/ed25519": "^3.0.0",
+        "@fastxyz/schema": "2.0.0",
+        "@fastxyz/sdk": "2.2.0",
+        "@mysten/bcs": "^2.0.3",
+        "@noble/ed25519": "^3.0.1",
         "@noble/hashes": "^2.0.1",
         "bech32": "^2.0.0",
+        "effect": "^3.21.0",
         "viem": "^2.46.2"
       },
       "engines": {
         "node": ">=20"
-      },
-      "peerDependencies": {
-        "@fastxyz/sdk": ">=0.2.4"
-      },
-      "peerDependenciesMeta": {
-        "@fastxyz/sdk": {
-          "optional": true
-        }
       }
     },
     "node_modules/@fastxyz/allset-sdk/node_modules/@noble/ed25519": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.0.1.tgz",
-      "integrity": "sha512-t/T8LuK0ym8ALQudCCQCtrRdMSxBnRgHXw+wg+YsSlE6d+on7sX3flqlSJ2mOs9xEuchM36kj9SuX5MG7pXQMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.1.0.tgz",
+      "integrity": "sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@fastxyz/allset-sdk/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -417,25 +414,26 @@
       }
     },
     "node_modules/@fastxyz/fast-connector": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@fastxyz/fast-connector/-/fast-connector-0.1.2.tgz",
-      "integrity": "sha512-uq/GotuUqLXiz4dXRRBnXvKAqQZEegrfbKtY6I/fxBAKw+4OQvlyL4AgTk58m86bb3cyLqf9BeEvTNuCPxg+6w==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@fastxyz/fast-connector/-/fast-connector-0.1.3.tgz",
+      "integrity": "sha512-crxFSORO+542uJn82uhKLV0vb3Sj4x3M7f3NBo6p1Cuv40Dnvo2zZ49dgSUWgbmOly/BhgcPaan5lC3fkVvkPw==",
       "license": "MIT",
       "dependencies": {
         "@mysten/bcs": "^2.0.2",
-        "@noble/hashes": "^1.5.0"
+        "@noble/hashes": "^1.5.0",
+        "bech32": "^2.0.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@fastxyz/sdk": "^1.0.1"
+        "@fastxyz/sdk": ">=0.2.4"
       }
     },
     "node_modules/@fastxyz/schema": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@fastxyz/schema/-/schema-1.0.1.tgz",
-      "integrity": "sha512-SLdnJRHeZJ5uU+437nwcaqbpKk2IaE5FCRsKwCGMvss5E058UP/lWKhoiNXz1x4Xew+9lltyNd3K34aEeMy2nw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fastxyz/schema/-/schema-2.0.0.tgz",
+      "integrity": "sha512-aMMMoZJtJVQJCn+ER5Ec/Pdj5meSmqwbNjEHpwJy32PgiwJPoyDcXOCV7SU8igDUK5dDVEWQIm9WpJabtcN9PA==",
       "dependencies": {
         "@mysten/bcs": "^2.0.3",
         "bech32": "^2.0.0",
@@ -443,11 +441,11 @@
       }
     },
     "node_modules/@fastxyz/sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@fastxyz/sdk/-/sdk-1.0.1.tgz",
-      "integrity": "sha512-oE4llbFidOS6du4VmDuFMPgLv34bk/EQKwl0H1cWoibG9yZca47aWKVm2iwgYmsl9o1RVoHUOw4Lz4RVW71sJQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@fastxyz/sdk/-/sdk-2.2.0.tgz",
+      "integrity": "sha512-UG1ujd+tT1yWTVPP6ONG//OGC1Ag+cJX2GcmkL9YmmfFot5AjHfiKzhi1BGcgJtXv3tf1H+tiO53RiBUfcjGcw==",
       "dependencies": {
-        "@fastxyz/schema": "1.0.1",
+        "@fastxyz/schema": "2.0.0",
         "@mysten/bcs": "^2.0.3",
         "@noble/ed25519": "^3.0.1",
         "@noble/hashes": "^2.0.1",
@@ -478,46 +476,26 @@
       }
     },
     "node_modules/@fastxyz/x402-client": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@fastxyz/x402-client/-/x402-client-0.1.3.tgz",
-      "integrity": "sha512-9cAU6Sa7yqOBjSgBMuzyFNQHNBkUOn9owuB6mMjf/J/dosSyA6MTUvi1OBeGP0T2Q51ckXEPplMdmKqtmJdJxw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@fastxyz/x402-client/-/x402-client-1.0.5.tgz",
+      "integrity": "sha512-OEY8FzW3iRefqw7/+jYBxNbHEIAbupTucTydDwWq9bxPmhkuG5/+p1Lb99gL9T1z6+NCHNXCSC2xdxKVDAmYmA==",
       "license": "MIT",
       "dependencies": {
-        "@fastxyz/allset-sdk": "^0.1.8",
-        "@fastxyz/sdk": "^0.2.5",
-        "@mysten/bcs": "^2.0.2",
-        "@noble/ed25519": "^2.1.0",
-        "@noble/hashes": "^1.5.0",
-        "bech32": "^2.0.0",
+        "@fastxyz/allset-sdk": "1.0.4",
+        "@fastxyz/schema": "2.0.0",
+        "@fastxyz/sdk": "2.2.0",
+        "@fastxyz/x402-types": "1.0.1",
+        "effect": "^3.21.0",
         "viem": "^2.46.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@fastxyz/x402-client/node_modules/@fastxyz/sdk": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@fastxyz/sdk/-/sdk-0.2.5.tgz",
-      "integrity": "sha512-a2LxkxhmUEcqmGn159ausanthwB5EX2ebm+ElAhv/vwnHD4CwS269B1279RB75XitR0vANm8CZcLX2/+xCo6+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@mysten/bcs": "^2.0.2",
-        "@noble/ed25519": "^2.1.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/base": "^2.0.0",
-        "bech32": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@fastxyz/x402-facilitator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@fastxyz/x402-facilitator/-/x402-facilitator-1.0.1.tgz",
-      "integrity": "sha512-2E7STOOd5TknViz+wjgZ9/19jjKMA9bJUCWpPdrJTO3nOBH0Oo+XahBMy3+MsMloasxFQUPmynOo6rl2cJxgZQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@fastxyz/x402-facilitator/-/x402-facilitator-1.0.5.tgz",
+      "integrity": "sha512-yvO5GZNk6jz5BSL+V10FQFj+Khdtg2nZz3kET5yDYl4QXcgObFaW5mLajfOMW4dPwsk1aWxBS0MqMgtZNTOvnw==",
       "dependencies": {
-        "@fastxyz/schema": "1.0.1",
-        "@fastxyz/sdk": "1.0.1",
+        "@fastxyz/schema": "2.0.0",
+        "@fastxyz/sdk": "2.2.0",
         "@fastxyz/x402-types": "1.0.1",
         "viem": "^2.27.2"
       },
@@ -2906,6 +2884,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abitype": {
       "version": "1.2.3",
       "license": "MIT",
@@ -3091,6 +3075,18 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "dev": true,
@@ -3118,6 +3114,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -3178,6 +3192,37 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "dev": true,
@@ -3200,6 +3245,21 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "license": "Apache-2.0",
@@ -3220,6 +3280,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3371,6 +3449,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -3756,6 +3851,18 @@
         }
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "license": "MIT",
@@ -3770,6 +3877,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
       }
     },
     "node_modules/fix-dts-default-cjs-exports": {
@@ -3825,6 +3941,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fsevents": {
@@ -3912,6 +4042,27 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -4015,6 +4166,30 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "dev": true,
@@ -4024,6 +4199,24 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -4123,11 +4316,60 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-with-bigint": {
       "version": "3.5.8",
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
       "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -4487,6 +4729,31 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime": {
       "version": "1.6.0",
       "license": "MIT",
@@ -4512,6 +4779,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mlly": {
@@ -4664,6 +4940,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "license": "MIT",
@@ -4679,6 +4964,22 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ox": {
@@ -4725,6 +5026,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
       }
     },
     "node_modules/path-key": {
@@ -5361,7 +5691,6 @@
     "node_modules/semver": {
       "version": "7.7.4",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5406,6 +5735,23 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -5544,6 +5890,15 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/source-map": {
       "version": "0.7.6",
@@ -5717,6 +6072,18 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "dev": true,
@@ -5828,6 +6195,27 @@
       "version": "7.0.27",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -6005,6 +6393,15 @@
       "version": "7.18.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -6418,6 +6815,21 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
@@ -6436,8 +6848,8 @@
       "name": "@marketplace/cli",
       "version": "0.0.0",
       "dependencies": {
-        "@fastxyz/sdk": "1.0.1",
-        "@fastxyz/x402-client": "0.1.3",
+        "@fastxyz/sdk": "^2.2.0",
+        "@fastxyz/x402-client": "^1.0.5",
         "@noble/ed25519": "^3.0.1",
         "@noble/hashes": "^2.0.1",
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "vitest run",
     "test:mcp:ci-smoke": "node --import tsx scripts/verify-fast-pay-mcp-ci.ts",
     "test:web:smoke": "npm run build:web && playwright test --config apps/web/playwright.config.ts",
+    "postinstall": "patch-package",
     "dev:api": "tsx apps/api/src/index.ts",
     "dev:apify-service": "tsx apps/apify-service/src/index.ts",
     "dev:facilitator": "tsx apps/facilitator/src/index.ts",
@@ -34,10 +35,10 @@
     "start:cli": "node dist/packages/cli/index.js"
   },
   "dependencies": {
-    "@fastxyz/fast-connector": "0.1.2",
-    "@fastxyz/sdk": "1.0.1",
-    "@fastxyz/x402-client": "0.1.3",
-    "@fastxyz/x402-facilitator": "1.0.1",
+    "@fastxyz/fast-connector": "^0.1.3",
+    "@fastxyz/sdk": "^2.2.0",
+    "@fastxyz/x402-client": "^1.0.5",
+    "@fastxyz/x402-facilitator": "^1.0.5",
     "@fastxyz/x402-server": "1.0.1",
     "@noble/ed25519": "^2.3.0",
     "@noble/hashes": "^1.8.0",
@@ -45,6 +46,7 @@
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
     "express": "^4.21.2",
+    "patch-package": "^8.0.1",
     "pg": "^8.16.3",
     "zod": "^4.3.6",
     "zod-to-json-schema": "^3.24.6"
@@ -52,8 +54,8 @@
   "optionalDependencies": {
     "@esbuild/linux-x64": "0.27.4",
     "@next/swc-linux-x64-gnu": "^16.1.7",
-    "@tailwindcss/oxide-linux-x64-gnu": "4.2.1",
     "@rollup/rollup-linux-x64-gnu": "^4.59.0",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.2.1",
     "lightningcss-linux-x64-gnu": "1.31.1"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,8 +8,8 @@
     "fast-marketplace": "./dist/index.js"
   },
   "dependencies": {
-    "@fastxyz/sdk": "1.0.1",
-    "@fastxyz/x402-client": "0.1.3",
+    "@fastxyz/sdk": "^2.2.0",
+    "@fastxyz/x402-client": "^1.0.5",
     "@noble/ed25519": "^3.0.1",
     "@noble/hashes": "^2.0.1",
     "ajv": "^8.18.0",

--- a/packages/cli/src/lib.test.ts
+++ b/packages/cli/src/lib.test.ts
@@ -25,8 +25,81 @@ function jsonResponse(status: number, body: unknown, headers?: Record<string, st
   } as Response;
 }
 
-const FAST_MAINNET_USDC_ASSET_ID = "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130";
+const FAST_MAINNET_USDC_ASSET_ID = "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb";
 const API_URL = "http://localhost:3000";
+const FAST_REST_URL = "https://api.fast.xyz/proxy-rest";
+const PAYMENT_RECIPIENT = "fast19cjwajufyuqv883ydlvrp8xrhxejuvfe40pxq5dsrv675zgh89sqg9txs8";
+
+function fastAccountResponse(address: string) {
+  return jsonResponse(200, {
+    data: {
+      sender: address,
+      balance: "0",
+      next_nonce: 1,
+      pending_confirmation: null,
+      requested_state: [],
+      requested_certificates: null,
+      requested_validated_transaction: null,
+      token_balance: [
+        [FAST_MAINNET_USDC_ASSET_ID.slice(2), "100000000"]
+      ]
+    },
+    meta: {
+      timestamp: "2026-03-18T00:00:00.000Z"
+    }
+  });
+}
+
+function fastSubmitTransactionResponse(sender: string) {
+  return jsonResponse(200, {
+    data: {
+      Success: {
+        envelope: {
+          transaction: {
+            Release20260407: {
+              network_id: "fast:mainnet",
+              sender,
+              nonce: 1,
+              timestamp_nanos: "0",
+              claims: [
+                {
+                  TokenTransfer: {
+                    token_id: FAST_MAINNET_USDC_ASSET_ID.slice(2),
+                    recipient: PAYMENT_RECIPIENT,
+                    amount: "50000",
+                    user_data: null
+                  }
+                }
+              ],
+              archival: false,
+              fee_token: null
+            }
+          },
+          signature: {
+            Signature: "00".repeat(64)
+          }
+        },
+        signatures: []
+      }
+    },
+    meta: {
+      timestamp: "2026-03-18T00:00:00.000Z"
+    }
+  });
+}
+
+function maybeFastRestResponse(url: string) {
+  if (url.startsWith(`${FAST_REST_URL}/v1/accounts/`)) {
+    const address = decodeURIComponent(url.slice(`${FAST_REST_URL}/v1/accounts/`.length));
+    return fastAccountResponse(address);
+  }
+
+  if (url === `${FAST_REST_URL}/v1/submit-transaction`) {
+    return fastSubmitTransactionResponse(PAYMENT_RECIPIENT);
+  }
+
+  return null;
+}
 
 function buildServiceSummary(overrides: Record<string, unknown> = {}) {
   return {
@@ -324,6 +397,7 @@ describe("marketplace cli", () => {
 
       if (url.endsWith("/api/mock/quick-insight")) {
         const headers = new Headers(init?.headers);
+        expect(headers.get("content-type")).toBe("application/json");
         if (!headers.get("X-PAYMENT")) {
           return jsonResponse(402, {
             x402Version: 1,
@@ -331,7 +405,7 @@ describe("marketplace cli", () => {
               {
                 scheme: "exact",
                 network: "fast-mainnet",
-                maxAmountRequired: "0.05",
+                maxAmountRequired: "50000",
                 payTo: "fast19cjwajufyuqv883ydlvrp8xrhxejuvfe40pxq5dsrv675zgh89sqg9txs8",
                 asset: FAST_MAINNET_USDC_ASSET_ID
               }
@@ -340,6 +414,11 @@ describe("marketplace cli", () => {
         }
 
         return jsonResponse(200, { ok: true, route: "mock.quick-insight" }, { "payment-response": "encoded" });
+      }
+
+      const fastRestResponse = maybeFastRestResponse(url);
+      if (fastRestResponse) {
+        return fastRestResponse;
       }
 
       const body = JSON.parse(String(init?.body ?? "{}")) as {
@@ -461,7 +540,7 @@ describe("marketplace cli", () => {
               {
                 scheme: "exact",
                 network: "fast-mainnet",
-                maxAmountRequired: "0.05",
+                maxAmountRequired: "50000",
                 payTo: "fast19cjwajufyuqv883ydlvrp8xrhxejuvfe40pxq5dsrv675zgh89sqg9txs8",
                 asset: FAST_MAINNET_USDC_ASSET_ID
               }
@@ -470,6 +549,11 @@ describe("marketplace cli", () => {
         }
 
         return jsonResponse(200, { city: "Paris", forecast: "sunny" });
+      }
+
+      const fastRestResponse = maybeFastRestResponse(url);
+      if (fastRestResponse) {
+        return fastRestResponse;
       }
 
       const body = JSON.parse(String(init?.body ?? "{}")) as {

--- a/packages/cli/src/lib.ts
+++ b/packages/cli/src/lib.ts
@@ -443,7 +443,9 @@ export async function invokePaidRoute(
   if (!maxAmountRequired) {
     throw new Error("Marketplace did not return a usable payment requirement.");
   }
-  const amountRaw = decimalToRawString(maxAmountRequired, 6);
+  const amountRaw = maxAmountRequired.includes(".")
+    ? decimalToRawString(maxAmountRequired, 6)
+    : maxAmountRequired;
 
   await enforceSpendControls({
     routeKey: route.ref,
@@ -468,6 +470,7 @@ export async function invokePaidRoute(
       method: route.method,
       ...(requestTarget.body ? { body: requestTarget.body } : {}),
       headers: {
+        ...(requestTarget.body ? { "content-type": "application/json" } : {}),
         ...headers
       },
       wallet: loaded.paymentWallet,
@@ -884,7 +887,7 @@ function createProvider(input: {
     rpcUrl: input.rpcUrl
   });
   return new FastProvider({
-    rpcUrl: network.rpcUrl
+    url: network.rpcUrl
   });
 }
 
@@ -916,7 +919,11 @@ async function normalizeMarketplacePaymentRequirement(response: Response): Promi
       accepts: paymentRequired.accepts.map((accept) => ({
         ...accept,
         ...(accept.maxAmountRequired
-          ? { maxAmountRequired: decimalToRawString(accept.maxAmountRequired, 6) }
+          ? {
+              maxAmountRequired: accept.maxAmountRequired.includes(".")
+                ? decimalToRawString(accept.maxAmountRequired, 6)
+                : accept.maxAmountRequired
+            }
           : {})
       }))
     }),

--- a/packages/shared/src/fast-wallet.ts
+++ b/packages/shared/src/fast-wallet.ts
@@ -35,7 +35,7 @@ function tokenConfig(token: MarketplaceTokenSymbol): { tokenId: string; networkI
   }
 
   return {
-    tokenId: "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130",
+    tokenId: "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
     networkId: "fast:mainnet"
   };
 }

--- a/packages/shared/src/network.ts
+++ b/packages/shared/src/network.ts
@@ -2,7 +2,7 @@ export type MarketplaceDeploymentNetwork = "mainnet" | "testnet";
 export type MarketplacePaymentNetwork = "fast-mainnet" | "fast-testnet";
 export type MarketplaceTokenSymbol = "USDC" | "testUSDC";
 
-const FAST_MAINNET_USDC_ASSET_ID = "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130";
+const FAST_MAINNET_USDC_ASSET_ID = "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb";
 const FAST_TESTNET_USDC_ASSET_ID = "0xd73a0679a2be46981e2a8aedecd951c8b6690e7d5f8502b34ed3ff4cc2163b46";
 
 export interface MarketplaceNetworkConfig {
@@ -16,8 +16,8 @@ export interface MarketplaceNetworkConfig {
   shortLabel: string;
 }
 
-const MAINNET_RPC_URL = "https://api.fast.xyz/proxy";
-const TESTNET_RPC_URL = "https://testnet.api.fast.xyz/proxy";
+const MAINNET_RPC_URL = "https://api.fast.xyz/proxy-rest";
+const TESTNET_RPC_URL = "https://testnet.api.fast.xyz/proxy-rest";
 const DEFAULT_EXPLORER_URL = "https://explorer.fast.xyz";
 
 export function normalizeMarketplaceDeploymentNetwork(value: string | undefined | null): MarketplaceDeploymentNetwork {

--- a/packages/shared/src/refund.ts
+++ b/packages/shared/src/refund.ts
@@ -19,7 +19,7 @@ function createFastTreasurySender(input: FastTreasuryServiceInput) {
     rpcUrl: input.rpcUrl
   });
   const provider = new FastProvider({
-    rpcUrl: network.rpcUrl
+    url: network.rpcUrl
   });
 
   let walletPromise: Promise<MarketplaceFastWallet> | null = null;

--- a/packages/shared/src/seed.ts
+++ b/packages/shared/src/seed.ts
@@ -103,10 +103,38 @@ export const SHOP_FAST_EXECUTION_SERVICE_SEED: ProviderServiceRecord = {
   updatedAt: SEEDED_AT
 };
 
+export const SHOPIFY_STOREFRONT_SERVICE_SEED: ProviderServiceRecord = {
+  id: "service_shopify_storefront",
+  providerAccountId: MARKETPLACE_PROVIDER_ACCOUNT_SEED.id,
+  serviceType: "external_registry",
+  settlementMode: null,
+  slug: "shopify-storefront",
+  apiNamespace: null,
+  name: "Shopify Storefront",
+  tagline: "Shop-specific Storefront GraphQL commerce primitives for product discovery, cart, and checkout.",
+  about:
+    "Shopify Storefront is a discovery-only listing for Shopify's Storefront GraphQL API. Each Shopify merchant exposes a shop-specific endpoint for querying products and collections, adding items to cart, calculating contextual pricing, and starting checkout flows.",
+  categories: ["Commerce", "Shopping", "UCP", "Checkout"],
+  featured: true,
+  promptIntro: 'I want to use the "Shopify Storefront" commerce API.',
+  setupInstructions: [
+    "Replace {store_name} with the merchant's Shopify store subdomain.",
+    "Use POST GraphQL requests against the Storefront API endpoint.",
+    "Use a Storefront access token when the merchant requires token-based access.",
+    "Do not execute checkout through the marketplace until merchant-specific quote, consent, order, and fulfillment records are wired."
+  ],
+  websiteUrl: "https://shopify.dev/docs/api/storefront",
+  payoutWallet: null,
+  status: "published",
+  createdAt: SEEDED_AT,
+  updatedAt: SEEDED_AT
+};
+
 export const SEEDED_PROVIDER_SERVICE_IDS = [
   MOCK_PROVIDER_SERVICE_SEED.id,
   SHOP_FAST_SERVICE_SEED.id,
-  SHOP_FAST_EXECUTION_SERVICE_SEED.id
+  SHOP_FAST_EXECUTION_SERVICE_SEED.id,
+  SHOPIFY_STOREFRONT_SERVICE_SEED.id
 ];
 
 function buildQuickInsightRoute(config: MarketplaceNetworkConfig): MarketplaceRoute {
@@ -536,11 +564,51 @@ function buildShopFastExternalEndpointDrafts(): ExternalProviderEndpointDraftRec
   ];
 }
 
+function buildShopifyExternalEndpointDrafts(): ExternalProviderEndpointDraftRecord[] {
+  return [
+    buildExternalEndpointDraft({
+      id: "draft_shopify_storefront_graphql",
+      serviceId: SHOPIFY_STOREFRONT_SERVICE_SEED.id,
+      title: "Storefront GraphQL",
+      description:
+        "Use a shop-specific Shopify Storefront GraphQL endpoint for product discovery, cart creation, pricing, and checkout primitives.",
+      publicUrl: "https://{store_name}.myshopify.com/api/2026-04/graphql.json",
+      docsUrl: "https://shopify.dev/docs/api/storefront/2026-04",
+      authNotes:
+        "Shop-specific endpoint. Tokenless requests are possible for limited public storefront queries; merchant-provided Storefront access tokens are required for token-based access.",
+      requestExample: {
+        query: "query Products($first: Int!) { products(first: $first) { nodes { id title handle } } }",
+        variables: {
+          first: 3
+        }
+      },
+      responseExample: {
+        data: {
+          products: {
+            nodes: [
+              {
+                id: "gid://shopify/Product/123",
+                title: "Example Product",
+                handle: "example-product"
+              }
+            ]
+          }
+        }
+      },
+      usageNotes:
+        "Discovery-only listing. Endpoint host is merchant-specific and checkout execution should remain merchant-controlled until marketplace quote, consent, order, and fulfillment records are implemented for that shop."
+    })
+  ];
+}
+
 function buildExternalEndpointDraft(input: {
   id: string;
+  serviceId?: string;
   title: string;
   description: string;
   publicUrl: string;
+  docsUrl?: string;
+  authNotes?: string;
   requestExample: unknown;
   responseExample: unknown;
   usageNotes: string;
@@ -548,7 +616,7 @@ function buildExternalEndpointDraft(input: {
   return {
     endpointType: "external_registry",
     id: input.id,
-    serviceId: SHOP_FAST_SERVICE_SEED.id,
+    serviceId: input.serviceId ?? SHOP_FAST_SERVICE_SEED.id,
     routeId: null,
     operation: null,
     title: input.title,
@@ -560,8 +628,8 @@ function buildExternalEndpointDraft(input: {
     responseSchemaJson: null,
     method: "POST",
     publicUrl: input.publicUrl,
-    docsUrl: "https://shop.fast.xyz/.well-known/ucp",
-    authNotes: "Discovery-only listing. Marketplace execution is not enabled yet.",
+    docsUrl: input.docsUrl ?? "https://shop.fast.xyz/.well-known/ucp",
+    authNotes: input.authNotes ?? "Discovery-only listing. Marketplace execution is not enabled yet.",
     requestExample: input.requestExample,
     responseExample: input.responseExample,
     usageNotes: input.usageNotes,
@@ -626,6 +694,16 @@ function buildSeededServiceGroups(config: MarketplaceNetworkConfig) {
       }),
       routes: [],
       externalEndpoints: buildShopFastExternalEndpointDrafts()
+    },
+    {
+      service: SHOPIFY_STOREFRONT_SERVICE_SEED,
+      publishedService: buildPublishedServiceVersion({
+        service: SHOPIFY_STOREFRONT_SERVICE_SEED,
+        routeIds: [],
+        versionId: "published_service_shopify_storefront_v1"
+      }),
+      routes: [],
+      externalEndpoints: buildShopifyExternalEndpointDrafts()
     },
     {
       service: SHOP_FAST_EXECUTION_SERVICE_SEED,

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -708,6 +708,7 @@ describe("shared marketplace helpers", () => {
     ]);
     expect(listServiceDefinitions(mainnetConfig).map((service) => service.slug)).toEqual([
       "shop-fast-amazon",
+      "shopify-storefront",
       "shop-fast-amazon-execute"
     ]);
   });
@@ -1640,6 +1641,16 @@ describe("shared marketplace helpers", () => {
     expect(executable?.service.apiNamespace).toBe("shop-fast-amazon");
     expect(executable?.endpoints.map((endpoint) => endpoint.endpointType === "marketplace_proxy" ? endpoint.operation : null))
       .toEqual(["amazon-quote", "amazon-buy"]);
+
+    const shopify = await store.getPublishedServiceBySlug("shopify-storefront");
+    expect(shopify?.service.serviceType).toBe("external_registry");
+    expect(shopify?.service.categories).toContain("UCP");
+    expect(shopify?.endpoints).toHaveLength(1);
+    expect(shopify?.endpoints[0]).toMatchObject({
+      endpointType: "external_registry",
+      title: "Storefront GraphQL",
+      publicUrl: "https://{store_name}.myshopify.com/api/2026-04/graphql.json"
+    });
   });
 
   it("persists commerce quote, consent, order, and fulfillment records", async () => {
@@ -1749,6 +1760,10 @@ describe("shared marketplace helpers", () => {
         expect.objectContaining({
           id: "shop-fast-amazon:amazon-order-status",
           endpoint: "https://shop.fast.xyz/api/amazon/order-status"
+        }),
+        expect.objectContaining({
+          id: "shopify-storefront:storefront-graphql",
+          endpoint: "https://{store_name}.myshopify.com/api/2026-04/graphql.json"
         })
       ])
     );

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -1704,6 +1704,18 @@ describe("shared marketplace helpers", () => {
       status: "placed",
       providerOrderId: "order_store_test"
     });
+    const duplicateOrder = await store.createCommerceOrder({
+      quoteId: "quote_store_test",
+      paymentId: "payment_commerce_test_2",
+      buyerWallet: consent.buyerWallet,
+      routeId: "shop-fast-amazon.amazon-buy.v1",
+      requestId: "request_commerce_test_2",
+      requestBody: { quoteId: "quote_store_test" }
+    });
+    expect(duplicateOrder).toMatchObject({
+      id: order.id,
+      paymentId: "payment_commerce_test"
+    });
     expect(await store.getCommerceFulfillmentByOrderId(order.id)).toMatchObject({
       status: "pending_shipment"
     });

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -49,7 +49,7 @@ const TESTNET_SERVICE_DEFINITIONS = listServiceDefinitions(TESTNET_NETWORK_CONFI
 
 async function createTestWallet() {
   const provider = new FastProvider({
-    rpcUrl: "https://api.fast.xyz/proxy"
+    url: "https://api.fast.xyz/proxy-rest"
   });
 
   const wallet = await MarketplaceFastWallet.fromPrivateKey(TEST_PRIVATE_KEY, provider);
@@ -135,7 +135,11 @@ describe("upstream x402 payment policy", () => {
         network: "base",
         maxAmountRequired: "100",
         payTo: "0x0000000000000000000000000000000000000001",
-        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        resource: "https://provider.example.com/run",
+        description: "Test payment",
+        mimeType: "application/json",
+        maxTimeoutSeconds: 60
       }
     ], policy!)).toMatchObject({
       network: "base",
@@ -156,14 +160,22 @@ describe("upstream x402 payment policy", () => {
         network: "arbitrum",
         maxAmountRequired: "100",
         payTo: "0x0000000000000000000000000000000000000001",
-        asset: policy.asset
+        asset: policy.asset,
+        resource: "https://provider.example.com/run",
+        description: "Test payment",
+        mimeType: "application/json",
+        maxTimeoutSeconds: 60
       },
       {
         scheme: "exact",
         network: "base",
         maxAmountRequired: "100",
         payTo: "0x0000000000000000000000000000000000000001",
-        asset: policy.asset
+        asset: policy.asset,
+        resource: "https://provider.example.com/run",
+        description: "Test payment",
+        mimeType: "application/json",
+        maxTimeoutSeconds: 60
       }
     ], policy)).toMatchObject({
       network: "base",
@@ -176,7 +188,11 @@ describe("upstream x402 payment policy", () => {
         network: "base",
         maxAmountRequired: "101",
         payTo: "0x0000000000000000000000000000000000000001",
-        asset: policy.asset
+        asset: policy.asset,
+        resource: "https://provider.example.com/run",
+        description: "Test payment",
+        mimeType: "application/json",
+        maxTimeoutSeconds: 60
       }
     ], policy)).toThrow("did not match");
   });
@@ -204,14 +220,22 @@ describe("upstream x402 payment policy", () => {
               network: "arbitrum",
               maxAmountRequired: "100",
               payTo: "0x0000000000000000000000000000000000000001",
-              asset: "0x0000000000000000000000000000000000000002"
+              asset: "0x0000000000000000000000000000000000000002",
+              resource: "https://provider.example.com/run",
+              description: "Test payment",
+              mimeType: "application/json",
+              maxTimeoutSeconds: 60
             },
             {
               scheme: "exact",
               network: "base",
               maxAmountRequired: "100",
               payTo: "0x0000000000000000000000000000000000000001",
-              asset: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+              asset: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+              resource: "https://provider.example.com/run",
+              description: "Test payment",
+              mimeType: "application/json",
+              maxTimeoutSeconds: 60
             }
           ]
         }), {
@@ -693,7 +717,7 @@ describe("shared marketplace helpers", () => {
     );
 
     expect(mainnetConfig.tokenSymbol).toBe("USDC");
-    expect(mainnetRequirement.asset).toBe("0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130");
+    expect(mainnetRequirement.asset).toBe("0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb");
     expect(testnetRequirement.asset).toBe("0xd73a0679a2be46981e2a8aedecd951c8b6690e7d5f8502b34ed3ff4cc2163b46");
   });
 

--- a/packages/shared/src/store.ts
+++ b/packages/shared/src/store.ts
@@ -840,6 +840,7 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
   private readonly commerceConsentIdByQuoteWallet = new Map<string, string>();
   private readonly commerceOrdersById = new Map<string, CommerceOrderRecord>();
   private readonly commerceOrderIdByPaymentId = new Map<string, string>();
+  private readonly commerceOrderIdByQuoteId = new Map<string, string>();
   private readonly commerceFulfillmentsById = new Map<string, CommerceFulfillmentRecord>();
   private readonly providerRuntimeKeysByServiceId = new Map<string, ProviderRuntimeKeyRecord>();
   private readonly suggestionsById = new Map<string, SuggestionRecord>();
@@ -1739,6 +1740,13 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
         return clone(existing);
       }
     }
+    const existingQuoteOrderId = this.commerceOrderIdByQuoteId.get(input.quoteId);
+    if (existingQuoteOrderId) {
+      const existing = this.commerceOrdersById.get(existingQuoteOrderId);
+      if (existing) {
+        return clone(existing);
+      }
+    }
 
     const now = timestamp();
     const record: CommerceOrderRecord = {
@@ -1757,6 +1765,7 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
     };
     this.commerceOrdersById.set(record.id, record);
     this.commerceOrderIdByPaymentId.set(record.paymentId, record.id);
+    this.commerceOrderIdByQuoteId.set(record.quoteId, record.id);
     return clone(record);
   }
 
@@ -1783,6 +1792,11 @@ export class InMemoryMarketplaceStore implements MarketplaceStore {
 
   async getCommerceOrderByPaymentId(paymentId: string): Promise<CommerceOrderRecord | null> {
     const id = this.commerceOrderIdByPaymentId.get(paymentId);
+    return clone(id ? (this.commerceOrdersById.get(id) ?? null) : null);
+  }
+
+  async getCommerceOrderByQuoteId(quoteId: string): Promise<CommerceOrderRecord | null> {
+    const id = this.commerceOrderIdByQuoteId.get(quoteId);
     return clone(id ? (this.commerceOrdersById.get(id) ?? null) : null);
   }
 
@@ -4221,7 +4235,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
 
       CREATE TABLE IF NOT EXISTS commerce_orders (
         id TEXT PRIMARY KEY,
-        quote_id TEXT NOT NULL REFERENCES commerce_quotes(quote_id) ON DELETE RESTRICT,
+        quote_id TEXT NOT NULL UNIQUE REFERENCES commerce_quotes(quote_id) ON DELETE RESTRICT,
         payment_id TEXT NOT NULL UNIQUE,
         buyer_wallet TEXT NOT NULL,
         route_id TEXT NOT NULL,
@@ -4243,6 +4257,9 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS commerce_orders_quote_id_idx
+      ON commerce_orders(quote_id);
 
       CREATE TABLE IF NOT EXISTS credit_accounts (
         id TEXT PRIMARY KEY,
@@ -6355,6 +6372,16 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
     requestId: string;
     requestBody: unknown;
   }): Promise<CommerceOrderRecord> {
+    const existingPayment = await this.pool.query("SELECT * FROM commerce_orders WHERE payment_id = $1", [input.paymentId]);
+    if (existingPayment.rowCount) {
+      return mapCommerceOrderRow(existingPayment.rows[0]);
+    }
+
+    const existingQuote = await this.pool.query("SELECT * FROM commerce_orders WHERE quote_id = $1", [input.quoteId]);
+    if (existingQuote.rowCount) {
+      return mapCommerceOrderRow(existingQuote.rows[0]);
+    }
+
     const result = await this.pool.query(
       `
       INSERT INTO commerce_orders (
@@ -6362,7 +6389,7 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
       ) VALUES (
         $1, $2, $3, $4, $5, $6, 'pending', $7::jsonb
       )
-      ON CONFLICT (payment_id) DO UPDATE
+      ON CONFLICT (quote_id) DO UPDATE
       SET updated_at = commerce_orders.updated_at
       RETURNING *
       `,
@@ -6411,6 +6438,11 @@ export class PostgresMarketplaceStore implements MarketplaceStore {
 
   async getCommerceOrderByPaymentId(paymentId: string): Promise<CommerceOrderRecord | null> {
     const result = await this.pool.query("SELECT * FROM commerce_orders WHERE payment_id = $1", [paymentId]);
+    return result.rowCount ? mapCommerceOrderRow(result.rows[0]) : null;
+  }
+
+  async getCommerceOrderByQuoteId(quoteId: string): Promise<CommerceOrderRecord | null> {
+    const result = await this.pool.query("SELECT * FROM commerce_orders WHERE quote_id = $1", [quoteId]);
     return result.rowCount ? mapCommerceOrderRow(result.rows[0]) : null;
   }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1318,6 +1318,7 @@ export interface MarketplaceStore {
     responseBody?: unknown;
   }): Promise<CommerceOrderRecord>;
   getCommerceOrderByPaymentId(paymentId: string): Promise<CommerceOrderRecord | null>;
+  getCommerceOrderByQuoteId(quoteId: string): Promise<CommerceOrderRecord | null>;
   recordCommerceFulfillment(input: {
     orderId: string;
     status: CommerceFulfillmentStatus;

--- a/patches/@fastxyz+x402-facilitator+1.0.5.patch
+++ b/patches/@fastxyz+x402-facilitator+1.0.5.patch
@@ -1,0 +1,213 @@
+diff --git a/node_modules/@fastxyz/x402-facilitator/dist/fast-bcs.js b/node_modules/@fastxyz/x402-facilitator/dist/fast-bcs.js
+index 980d6a5..5a7e286 100644
+--- a/node_modules/@fastxyz/x402-facilitator/dist/fast-bcs.js
++++ b/node_modules/@fastxyz/x402-facilitator/dist/fast-bcs.js
+@@ -38,12 +38,27 @@ const CAMEL_TO_SNAKE = {
+  * number arrays. The Effect Schema encode path expects the exact Type format (real bigints,
+  * branded Uint8Arrays), which the JSON-roundtripped data doesn't match.
+  */
+-export function toBcsFormat(value) {
++function convertStringForBcs(key, value) {
++    if ((key === 'sender' || key === 'recipient') && (value.startsWith('fast1') || value.startsWith('set1'))) {
++        return Array.from(fromFastAddress(value.startsWith('set1') ? `fast1${value.slice(4)}` : value));
++    }
++    if (key === 'sender' || key === 'recipient' || key === 'token_id' || key === 'tokenId' || key === 'fee_token' || key === 'feeToken' || key === 'user_data' || key === 'userData') {
++        const normalized = value.startsWith('0x') ? value.slice(2) : value;
++        if (/^[0-9a-fA-F]+$/.test(normalized) && normalized.length % 2 === 0) {
++            return Array.from(fromHex(normalized));
++        }
++    }
++    return undefined;
++}
++export function toBcsFormat(value, key) {
+     if (value === null || value === undefined)
+         return value;
+     if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean')
+         return value;
+     if (typeof value === 'string') {
++        const converted = convertStringForBcs(key, value);
++        if (converted)
++            return converted;
+         // Convert decimal numeric strings to bigint (handles JSON roundtrip of bigints)
+         if (/^\d+$/.test(value))
+             return BigInt(value);
+@@ -52,7 +67,7 @@ export function toBcsFormat(value) {
+     if (value instanceof Uint8Array)
+         return Array.from(value);
+     if (Array.isArray(value))
+-        return value.map(toBcsFormat);
++        return value.map((item) => toBcsFormat(item, key));
+     if (!isRecord(value))
+         return value;
+     // Typed variant: {type: "Foo", value: {...}} → {Foo: {...}}
+@@ -61,13 +76,13 @@ export function toBcsFormat(value) {
+         if (variantValue === null || variantValue === undefined) {
+             return { [value.type]: variantValue };
+         }
+-        return { [value.type]: toBcsFormat(variantValue) };
++        return { [value.type]: toBcsFormat(variantValue, value.type) };
+     }
+     // Regular object: convert keys from camelCase to snake_case
+     const result = {};
+     for (const [key, val] of Object.entries(value)) {
+         const snakeKey = CAMEL_TO_SNAKE[key] ?? key;
+-        result[snakeKey] = toBcsFormat(val);
++        result[snakeKey] = toBcsFormat(val, snakeKey);
+     }
+     return result;
+ }
+@@ -159,8 +174,9 @@ export function serializeFastTransaction(transaction) {
+     // Keyed variant: {Release20260319: {...}} or {Release20260407: {...}}
+     const version = detectVersion(transaction);
+     if (version) {
++        const bcsCompatible = toBcsFormat(transaction[version]);
+         return VersionedTransactionBcs.serialize({
+-            [version]: transaction[version],
++            [version]: bcsCompatible,
+         }).toBytes();
+     }
+     // Typed variant: {type: "Release20260319", value: {...}}
+@@ -174,9 +190,10 @@ export function serializeFastTransaction(transaction) {
+         }
+     }
+     // Bare transaction — infer version from shape
+-    const inferredVersion = inferBareVersion(transaction);
++    const bcsCompatible = toBcsFormat(transaction);
++    const inferredVersion = inferBareVersion(bcsCompatible);
+     return VersionedTransactionBcs.serialize({
+-        [inferredVersion]: transaction,
++        [inferredVersion]: bcsCompatible,
+     }).toBytes();
+ }
+ export function serializeVersionedTransaction(transaction, version) {
+diff --git a/node_modules/@fastxyz/x402-facilitator/dist/verify.js b/node_modules/@fastxyz/x402-facilitator/dist/verify.js
+index a96361e..aa2bcbd 100644
+--- a/node_modules/@fastxyz/x402-facilitator/dist/verify.js
++++ b/node_modules/@fastxyz/x402-facilitator/dist/verify.js
+@@ -238,6 +238,15 @@ function toByteArray(value) {
+         return value;
+     }
+     if (typeof value === 'string') {
++        if (value.startsWith('fast1') || value.startsWith('set1')) {
++            try {
++                const canonical = value.startsWith('set1') ? `fast1${value.slice(4)}` : value;
++                return fastAddressToBytes(canonical);
++            }
++            catch {
++                return null;
++            }
++        }
+         if (!/^(?:0x)?[0-9a-fA-F]+$/.test(value)) {
+             return null;
+         }
+diff --git a/node_modules/@fastxyz/x402-facilitator/src/fast-bcs.ts b/node_modules/@fastxyz/x402-facilitator/src/fast-bcs.ts
+index 70217a2..2c27c6b 100644
+--- a/node_modules/@fastxyz/x402-facilitator/src/fast-bcs.ts
++++ b/node_modules/@fastxyz/x402-facilitator/src/fast-bcs.ts
+@@ -88,16 +88,43 @@ const CAMEL_TO_SNAKE: Record<string, string> = {
+  * number arrays. The Effect Schema encode path expects the exact Type format (real bigints,
+  * branded Uint8Arrays), which the JSON-roundtripped data doesn't match.
+  */
+-export function toBcsFormat(value: unknown): unknown {
++function convertStringForBcs(key: string | undefined, value: string): unknown {
++  if ((key === 'sender' || key === 'recipient') && (value.startsWith('fast1') || value.startsWith('set1'))) {
++    return Array.from(fromFastAddress(value.startsWith('set1') ? `fast1${value.slice(4)}` : value));
++  }
++
++  if (
++    key === 'sender'
++    || key === 'recipient'
++    || key === 'token_id'
++    || key === 'tokenId'
++    || key === 'fee_token'
++    || key === 'feeToken'
++    || key === 'user_data'
++    || key === 'userData'
++  ) {
++    const normalized = value.startsWith('0x') ? value.slice(2) : value;
++    if (/^[0-9a-fA-F]+$/.test(normalized) && normalized.length % 2 === 0) {
++      return Array.from(fromHex(normalized));
++    }
++  }
++
++  return undefined;
++}
++
++export function toBcsFormat(value: unknown, key?: string): unknown {
+   if (value === null || value === undefined) return value;
+   if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') return value;
+   if (typeof value === 'string') {
++    const converted = convertStringForBcs(key, value);
++    if (converted) return converted;
++
+     // Convert decimal numeric strings to bigint (handles JSON roundtrip of bigints)
+     if (/^\d+$/.test(value)) return BigInt(value);
+     return value;
+   }
+   if (value instanceof Uint8Array) return Array.from(value);
+-  if (Array.isArray(value)) return value.map(toBcsFormat);
++  if (Array.isArray(value)) return value.map((item) => toBcsFormat(item, key));
+   if (!isRecord(value)) return value;
+ 
+   // Typed variant: {type: "Foo", value: {...}} → {Foo: {...}}
+@@ -106,14 +133,14 @@ export function toBcsFormat(value: unknown): unknown {
+     if (variantValue === null || variantValue === undefined) {
+       return { [value.type as string]: variantValue };
+     }
+-    return { [value.type as string]: toBcsFormat(variantValue) };
++    return { [value.type as string]: toBcsFormat(variantValue, value.type as string) };
+   }
+ 
+   // Regular object: convert keys from camelCase to snake_case
+   const result: Record<string, unknown> = {};
+   for (const [key, val] of Object.entries(value)) {
+     const snakeKey = CAMEL_TO_SNAKE[key] ?? key;
+-    result[snakeKey] = toBcsFormat(val);
++    result[snakeKey] = toBcsFormat(val, snakeKey);
+   }
+   return result;
+ }
+@@ -224,8 +251,9 @@ export function serializeFastTransaction(transaction: VersionedFastTransaction |
+   // Keyed variant: {Release20260319: {...}} or {Release20260407: {...}}
+   const version = detectVersion(transaction);
+   if (version) {
++    const bcsCompatible = toBcsFormat(transaction[version]) as Record<string, unknown>;
+     return VersionedTransactionBcs.serialize({
+-      [version]: transaction[version],
++      [version]: bcsCompatible,
+     } as any).toBytes();
+   }
+ 
+@@ -241,9 +269,10 @@ export function serializeFastTransaction(transaction: VersionedFastTransaction |
+   }
+ 
+   // Bare transaction — infer version from shape
+-  const inferredVersion = inferBareVersion(transaction);
++  const bcsCompatible = toBcsFormat(transaction) as Record<string, unknown>;
++  const inferredVersion = inferBareVersion(bcsCompatible);
+   return VersionedTransactionBcs.serialize({
+-    [inferredVersion]: transaction,
++    [inferredVersion]: bcsCompatible,
+   } as any).toBytes();
+ }
+ 
+diff --git a/node_modules/@fastxyz/x402-facilitator/src/verify.ts b/node_modules/@fastxyz/x402-facilitator/src/verify.ts
+index 3e5172f..9d8f58f 100644
+--- a/node_modules/@fastxyz/x402-facilitator/src/verify.ts
++++ b/node_modules/@fastxyz/x402-facilitator/src/verify.ts
+@@ -301,6 +301,15 @@ function toByteArray(value: unknown): Uint8Array | null {
+   }
+ 
+   if (typeof value === 'string') {
++    if (value.startsWith('fast1') || value.startsWith('set1')) {
++      try {
++        const canonical = value.startsWith('set1') ? `fast1${value.slice(4)}` : value;
++        return fastAddressToBytes(canonical);
++      } catch {
++        return null;
++      }
++    }
++
+     if (!/^(?:0x)?[0-9a-fA-F]+$/.test(value)) {
+       return null;
+     }

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "docker/api.Dockerfile"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/scripts/railway-provider-batch.mjs
+++ b/scripts/railway-provider-batch.mjs
@@ -1,0 +1,351 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const services = [
+  {
+    type: "marketplace-api",
+    name: "marketplace-api",
+    serviceName: "Fast Marketplace API",
+    description: "Express marketplace API gateway for catalog, x402 execution, async jobs, and provider routing."
+  },
+  {
+    type: "apify",
+    name: "apify-amazon-product-scraper",
+    actorId: "junglee/amazon-crawler",
+    serviceName: "Amazon Product Scraper Proxy",
+    description: "Run the Amazon Product Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-apple-app-store-scraper",
+    actorId: "4bdullatif/appstore-scraper",
+    serviceName: "Apple App Store Scraper Proxy",
+    description: "Run the Apple App Store Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-cheerio-scraper",
+    actorId: "apify/cheerio-scraper",
+    serviceName: "Cheerio Scraper Proxy",
+    description: "Run the Cheerio Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-contact-info-scraper",
+    actorId: "vdrmota/contact-info-scraper",
+    serviceName: "Contact Info Scraper Proxy",
+    description: "Run the Contact Info Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-ecommerce-scraping-tool",
+    actorId: "apify/e-commerce-scraping-tool",
+    serviceName: "E-commerce Scraping Tool Proxy",
+    description: "Run the E-commerce Scraping Tool actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-facebook-ads-library-scraper",
+    actorId: "curious_coder/facebook-ads-library-scraper",
+    serviceName: "Facebook Ads Library Scraper Proxy",
+    description: "Run the Facebook Ads Library Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-facebook-posts-scraper",
+    actorId: "apify/facebook-posts-scraper",
+    serviceName: "Facebook Posts Scraper Proxy",
+    description: "Run the Facebook Posts Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-g2-product-reviews-scraper",
+    actorId: "powerai/g2-product-reviews-scraper",
+    serviceName: "G2 Product Reviews Scraper Proxy",
+    description: "Run the G2 Product Reviews Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-google-places-scraper",
+    actorId: "compass/crawler-google-places",
+    serviceName: "Google Places Scraper Proxy",
+    description: "Run the Google Places Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-google-play-scraper",
+    actorId: "curious_coder/google-play-scraper",
+    serviceName: "Google Play Scraper Proxy",
+    description: "Run the Google Play Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-google-search-scraper",
+    actorId: "apify/google-search-scraper",
+    serviceName: "Google Search Results Scraper Proxy",
+    description: "Run the Google Search Results Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-indeed-scraper",
+    actorId: "misceres/indeed-scraper",
+    serviceName: "Indeed Scraper Proxy",
+    description: "Run the Indeed Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-instagram-scraper",
+    actorId: "apify/instagram-scraper",
+    serviceName: "Instagram Scraper Proxy",
+    description: "Run the Instagram Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-leads-finder",
+    actorId: "code_crafter/leads-finder",
+    serviceName: "Leads Finder Proxy",
+    description: "Run the Leads Finder actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-linkedin-company-employees",
+    actorId: "harvestapi/linkedin-company-employees",
+    serviceName: "LinkedIn Company Employees Scraper Proxy",
+    description: "Run the LinkedIn Company Employees Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-linkedin-jobs-scraper",
+    actorId: "bebity/linkedin-jobs-scraper",
+    serviceName: "LinkedIn Jobs Scraper Proxy",
+    description: "Run the LinkedIn Jobs Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-linkedin-profile-scraper",
+    actorId: "dev_fusion/linkedin-profile-scraper",
+    serviceName: "LinkedIn Profile Scraper Proxy",
+    description: "Run the LinkedIn Profile Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-reddit-community-scraper",
+    actorId: "shahidirfan/reddit-community-scraper",
+    serviceName: "Reddit Community Scraper Proxy",
+    description: "Run the Reddit Community Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-tiktok-scraper",
+    actorId: "clockworks/tiktok-scraper",
+    serviceName: "TikTok Scraper Proxy",
+    description: "Run the TikTok Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-trustpilot-reviews-scraper",
+    actorId: "automation-lab/trustpilot",
+    serviceName: "Trustpilot Reviews Scraper Proxy",
+    description: "Run the Trustpilot Reviews Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-tweet-scraper",
+    actorId: "apidojo/tweet-scraper",
+    serviceName: "Tweet Scraper Proxy",
+    description: "Run the Tweet Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-web-scraper",
+    actorId: "apify/web-scraper",
+    serviceName: "Web Scraper Proxy",
+    description: "Run the Web Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-website-content-crawler",
+    actorId: "apify/website-content-crawler",
+    serviceName: "Website Content Crawler Proxy",
+    description: "Run the Website Content Crawler actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "apify",
+    name: "apify-youtube-scraper",
+    actorId: "streamers/youtube-scraper",
+    serviceName: "YouTube Scraper Proxy",
+    description: "Run the YouTube Scraper actor through a marketplace-hosted async proxy."
+  },
+  {
+    type: "tavily",
+    name: "tavily-mainnet",
+    serviceName: "Tavily Proxy",
+    description: "Search, extract, crawl, and map the web through a marketplace-hosted proxy."
+  }
+];
+
+function parseArgs(argv) {
+  const args = { command: argv[2], envFile: ".env.local", services: null };
+  for (let index = 3; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--env-file") args.envFile = argv[++index];
+    else if (arg === "--services") args.services = new Set(argv[++index].split(",").map((value) => value.trim()));
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+function readEnvFile(envFile) {
+  const resolved = path.resolve(envFile);
+  const content = fs.readFileSync(resolved, "utf8");
+  const env = {};
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#") || !trimmed.includes("=")) continue;
+    const equalsIndex = trimmed.indexOf("=");
+    const key = trimmed.slice(0, equalsIndex);
+    let value = trimmed.slice(equalsIndex + 1);
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    env[key] = value;
+  }
+  return env;
+}
+
+function runRailway(args, options = {}) {
+  const result = spawnSync("railway", args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    input: options.input,
+    stdio: options.input === undefined ? ["ignore", "pipe", "pipe"] : ["pipe", "pipe", "pipe"]
+  });
+
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim();
+    const stdout = result.stdout.trim();
+    throw new Error(`railway ${args.join(" ")} failed${stderr ? `: ${stderr}` : ""}${stdout ? `\n${stdout}` : ""}`);
+  }
+
+  return result.stdout.trim();
+}
+
+function listExistingServices() {
+  return new Map(JSON.parse(runRailway(["service", "list", "--json"])).map((service) => [service.name, service]));
+}
+
+function selectedServices(args) {
+  return services.filter((service) => !args.services || args.services.has(service.name));
+}
+
+function setVars(service, vars) {
+  const entries = Object.entries(vars).filter(([, value]) => value !== undefined && value !== "");
+  if (entries.length === 0) return;
+  runRailway([
+    "variable",
+    "set",
+    "--service",
+    service.name,
+    "--skip-deploys",
+    ...entries.map(([key, value]) => `${key}=${value}`)
+  ]);
+}
+
+function setSecret(service, key, value) {
+  if (!value) throw new Error(`${key} is required for ${service.name}`);
+  runRailway(["variable", "set", "--service", service.name, "--skip-deploys", "--stdin", key], { input: value });
+}
+
+function configure(args) {
+  const env = readEnvFile(args.envFile);
+  const existing = listExistingServices();
+  const skipped = [];
+
+  for (const service of selectedServices(args)) {
+    if (!existing.has(service.name)) {
+      skipped.push(service.name);
+      continue;
+    }
+
+    if (service.type === "marketplace-api") {
+      setVars(service, {
+        MARKETPLACE_BASE_URL: "https://marketplace-api-production.up.railway.app",
+        MARKETPLACE_WEB_BASE_URL: "https://marketplace.fast.xyz",
+        MARKETPLACE_FAST_NETWORK: "mainnet",
+        MARKETPLACE_FACILITATOR_URL: "https://api.fast.xyz/x402",
+        MARKETPLACE_TREASURY_ADDRESS: env.MARKETPLACE_TREASURY_ADDRESS,
+        MARKETPLACE_ADMIN_TOKEN: env.MARKETPLACE_ADMIN_TOKEN,
+        MARKETPLACE_SESSION_SECRET: env.MARKETPLACE_SESSION_SECRET,
+        MARKETPLACE_SECRETS_KEY: env.MARKETPLACE_SECRETS_KEY,
+        FAST_RPC_URL: env.FAST_RPC_URL,
+        RAILPACK_BUILD_CMD: "npm run build:runtime",
+        RAILPACK_START_CMD: "npm run start:api",
+        NIXPACKS_BUILD_CMD: "npm run build:runtime",
+        NIXPACKS_START_CMD: "npm run start:api"
+      });
+    } else if (service.type === "apify") {
+      setSecret(service, "APIFY_API_TOKEN", env.APIFY_API_TOKEN);
+      setVars(service, {
+        APIFY_ACTOR_ID: service.actorId,
+        APIFY_API_BASE_URL: "https://api.apify.com/v2",
+        APIFY_SERVICE_NAME: service.serviceName,
+        APIFY_SERVICE_DESCRIPTION: service.description,
+        APIFY_DEFAULT_POLL_AFTER_MS: "5000",
+        APIFY_DATASET_ITEM_LIMIT: "100",
+        RAILPACK_BUILD_CMD: "npm run build:runtime",
+        RAILPACK_START_CMD: "npm run start:apify-service",
+        NIXPACKS_BUILD_CMD: "npm run build:runtime",
+        NIXPACKS_START_CMD: "npm run start:apify-service"
+      });
+    } else {
+      setSecret(service, "TAVILY_API_KEY", env.TAVILY_API_KEY);
+      setVars(service, {
+        TAVILY_API_BASE_URL: "https://api.tavily.com",
+        RAILPACK_BUILD_CMD: "npm run build:runtime",
+        RAILPACK_START_CMD: "npm run start:tavily-service",
+        NIXPACKS_BUILD_CMD: "npm run build:runtime",
+        NIXPACKS_START_CMD: "npm run start:tavily-service"
+      });
+    }
+
+    console.log(`configured ${service.name}`);
+  }
+
+  for (const service of skipped) console.log(`skipped missing ${service}`);
+}
+
+function deploy(args) {
+  const existing = listExistingServices();
+  for (const service of selectedServices(args)) {
+    if (!existing.has(service.name)) {
+      console.log(`skipped missing ${service.name}`);
+      continue;
+    }
+    runRailway(["up", "--service", service.name, "--detach", "--message", `Deploy ${service.name}`]);
+    console.log(`deployed ${service.name}`);
+  }
+}
+
+function domains(args) {
+  const existing = listExistingServices();
+  for (const service of selectedServices(args)) {
+    if (!existing.has(service.name)) {
+      console.log(`skipped missing ${service.name}`);
+      continue;
+    }
+    const output = runRailway(["domain", "--service", service.name, "--json"]);
+    console.log(`${service.name} ${output}`);
+  }
+}
+
+const args = parseArgs(process.argv);
+
+if (args.command === "configure") configure(args);
+else if (args.command === "deploy") deploy(args);
+else if (args.command === "domains") domains(args);
+else {
+  console.error("Usage: railway-provider-batch.mjs <configure|deploy|domains> [--env-file PATH] [--services a,b]");
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Update Fast packages to current x402/Fast SDK versions and switch Fast provider URLs to /proxy-rest
- Patch x402 facilitator parsing for Fast REST certificates with Release20260407, fast1 addresses, and REST hex fields
- Add Railway deployment config/helpers and copy patch-package patches into Docker builds
- Map Amazon Apify documented startUrls input to categoryOrProductUrls upstream

## Verification
- npm run typecheck
- npm test -- apps/apify-service/src/app.test.ts packages/cli/src/lib.test.ts packages/shared/src/shared.test.ts
- npm run build:runtime
- Live Railway Amazon paid call accepted payment, created job_d605eb2209b8c7540d91eb9b, and completed successfully