### PR TITLE
Fix Fast REST deployment config after x402 update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ PORT=3000
 # Optional on API when refund support is enabled in-process:
 # MARKETPLACE_TREASURY_PRIVATE_KEY=<fast-ed25519-private-key-hex>
 # MARKETPLACE_TREASURY_KEYFILE=/run/secrets/marketplace-treasury.key
-# FAST_RPC_URL=https://api.fast.xyz/proxy
+# FAST_RPC_URL=https://api.fast.xyz/proxy-rest
 # Optional on API for marketplace-paid upstream Base x402 requests:
 # MARKETPLACE_UPSTREAM_EVM_PRIVATE_KEY=0xreplace_me
 # MARKETPLACE_UPSTREAM_EVM_ADDRESS=0xreplace_me
@@ -34,7 +34,7 @@ MARKETPLACE_TREASURY_PRIVATE_KEY=<fast-ed25519-private-key-hex>
 # MARKETPLACE_TREASURY_KEYFILE=/run/secrets/marketplace-treasury.key
 # MARKETPLACE_SECRETS_KEY=replace-with-long-random-secrets-key
 # MARKETPLACE_FAST_NETWORK=mainnet
-FAST_RPC_URL=https://api.fast.xyz/proxy
+FAST_RPC_URL=https://api.fast.xyz/proxy-rest
 WORKER_POLL_INTERVAL_MS=5000
 # Required on worker when async polling may hit upstream Base x402 endpoints:
 # MARKETPLACE_UPSTREAM_EVM_PRIVATE_KEY=0xreplace_me
@@ -56,7 +56,7 @@ MARKETPLACE_WEB_BASE_URL=https://marketplace.fast.xyz
 # FACILITATOR INSTANCE (apps/facilitator)
 # ============================================================================
 FACILITATOR_PORT=4020
-FACILITATOR_FAST_RPC_URL=https://api.fast.xyz/proxy
+FACILITATOR_FAST_RPC_URL=https://api.fast.xyz/proxy-rest
 # Optional:
 # FACILITATOR_EVM_PRIVATE_KEY=0xreplace_me
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Optional refund worker variables:
 
 ```bash
 export MARKETPLACE_TREASURY_PRIVATE_KEY=<fast-ed25519-private-key-hex>
-export FAST_RPC_URL=https://api.fast.xyz/proxy
+export FAST_RPC_URL=https://api.fast.xyz/proxy-rest
 ```
 
 Optional upstream x402 payment variables for marketplace-proxied providers:
@@ -128,7 +128,7 @@ Optional facilitator variables:
 
 ```bash
 export FACILITATOR_PORT=4020
-export FACILITATOR_FAST_RPC_URL=https://api.fast.xyz/proxy
+export FACILITATOR_FAST_RPC_URL=https://api.fast.xyz/proxy-rest
 export FACILITATOR_EVM_PRIVATE_KEY=<evm-private-key-if-you-later-enable-evm-settlement>
 ```
 
@@ -315,7 +315,7 @@ DATABASE_URL=postgres://...
 MARKETPLACE_TREASURY_PRIVATE_KEY=<fast-ed25519-private-key-hex>
 MARKETPLACE_SECRETS_KEY=change-me-again
 MARKETPLACE_FAST_NETWORK=mainnet
-FAST_RPC_URL=https://api.fast.xyz/proxy
+FAST_RPC_URL=https://api.fast.xyz/proxy-rest
 WORKER_POLL_INTERVAL_MS=5000
 ```
 
@@ -329,7 +329,7 @@ Facilitator environment:
 
 ```bash
 FACILITATOR_PORT=4020
-FACILITATOR_FAST_RPC_URL=https://api.fast.xyz/proxy
+FACILITATOR_FAST_RPC_URL=https://api.fast.xyz/proxy-rest
 ```
 
 Required web environment:

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -73,16 +73,13 @@ const app = createMarketplaceApi({
   siteProofToken: process.env.MARKETPLACE_SITE_PROOF
 });
 
-const listenPorts = Array.from(new Set([port, 3000, 8080].filter((value) => Number.isFinite(value) && value > 0)));
-const servers = listenPorts.map((listenPort) =>
-  app.listen(listenPort, "0.0.0.0", () => {
-    console.log(`Marketplace API listening on 0.0.0.0:${listenPort} (${baseUrl})`);
-  })
-);
+const server = app.listen(port, "0.0.0.0", () => {
+  console.log(`Marketplace API listening on 0.0.0.0:${port} (${baseUrl})`);
+});
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {
   process.on(signal, async () => {
-    await Promise.all(servers.map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+    await new Promise<void>((resolve) => server.close(() => resolve()));
     await pool.end();
     process.exit(0);
   });

--- a/apps/apify-service/src/app.test.ts
+++ b/apps/apify-service/src/app.test.ts
@@ -130,6 +130,49 @@ describe("apify service", () => {
     ]);
   });
 
+  it("maps documented Amazon startUrls to the Apify actor categoryOrProductUrls field", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      data: {
+        id: "run_amazon",
+        status: "RUNNING",
+        defaultDatasetId: "dataset_amazon",
+        defaultKeyValueStoreId: "store_amazon"
+      }
+    }), {
+      status: 201,
+      headers: {
+        "content-type": "application/json"
+      }
+    }));
+
+    const app = createApifyServiceApp({
+      apifyApiToken: "apify-test-token",
+      actorId: "junglee/amazon-crawler"
+    });
+
+    const startUrls = [{ url: "https://www.amazon.com/dp/B09X7MPX8L" }];
+    const response = await request(app)
+      .post("/scrape-products")
+      .send({
+        startUrls,
+        maxItems: 1
+      });
+
+    expect(response.status).toBe(202);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.apify.com/v2/acts/junglee%2Famazon-crawler/runs",
+      expect.objectContaining({
+        method: "POST"
+      })
+    );
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(JSON.parse(String(init?.body))).toEqual({
+      startUrls,
+      categoryOrProductUrls: startUrls,
+      maxItems: 1
+    });
+  });
+
   it("registers Google Search actor routes in OpenAPI", async () => {
     const app = createApifyServiceApp({
       apifyApiToken: "apify-test-token",


### PR DESCRIPTION
## Summary
- align documented FAST_RPC_URL and FACILITATOR_FAST_RPC_URL examples with the new Fast REST /proxy-rest endpoint
- restore the API process to bind only the configured PORT instead of also binding hard-coded fallback ports
- add a regression test proving Amazon Apify startUrls are forwarded as categoryOrProductUrls upstream

## Verification
- npm run typecheck
- npm test -- apps/apify-service/src/app.test.ts packages/cli/src/lib.test.ts packages/shared/src/shared.test.ts
- npm test -- apps/api/src/app.test.ts
- npm run build:runtime
- npm test (one transient Tavily /map ECONNRESET in full parallel run; isolated apps/tavily-service/src/app.test.ts rerun passed)