### PR TITLE
Validate Archive.is captures

### DIFF
--- a/apps/archive-is-service/provider-spec.mainnet.template.json
+++ b/apps/archive-is-service/provider-spec.mainnet.template.json
@@ -106,7 +106,8 @@
                 "archiveUrl",
                 "capturedAt",
                 "archiveId",
-                "sourceHost"
+                "sourceHost",
+                "validation"
               ],
               "properties": {
                 "originalUrl": {
@@ -133,6 +134,29 @@
                 },
                 "sourceHost": {
                   "type": "string"
+                },
+                "validation": {
+                  "type": "object",
+                  "required": [
+                    "status"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "usable",
+                        "broken",
+                        "unchecked"
+                      ]
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "additionalProperties": false
@@ -156,7 +180,10 @@
             "archiveUrl": "https://archive.today/20240501120000/https://example.com/articles/launch",
             "capturedAt": "2024-05-01T12:00:00.000Z",
             "archiveId": "20240501120000",
-            "sourceHost": "archive.today"
+            "sourceHost": "archive.today",
+            "validation": {
+              "status": "usable"
+            }
           }
         ]
       },

--- a/apps/archive-is-service/src/app.test.ts
+++ b/apps/archive-is-service/src/app.test.ts
@@ -1,9 +1,16 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 
 import { ArchiveIsError, type ListSnapshotsResult } from "@marketplace/archive-is";
 
 import { createArchiveIsServiceApp, normalizeArchiveIsTimeoutMs } from "./app.js";
+import { buildSnapshotsRequestSchema, buildSnapshotsResponseSchema } from "./openapi.js";
+
+const appDir = dirname(fileURLToPath(import.meta.url));
 
 function buildResult(): ListSnapshotsResult {
   return {
@@ -66,6 +73,50 @@ describe("archive-is service", () => {
     expect(listSnapshots).toHaveBeenCalledWith(expect.objectContaining({
       archiveHost: "archive.is"
     }));
+  });
+
+  it("enables snapshot validation in the production SDK path", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(
+        '<https://example.com/articles/launch>; rel="original", <http://archive.md/20240501120000/https://example.com/articles/launch>; rel="memento"; datetime="Wed, 01 May 2024 12:00:00 GMT"',
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/link-format"
+          }
+        }
+      ))
+      .mockResolvedValueOnce(new Response("<html><article>Archived article content</article></html>", {
+        status: 200
+      }));
+    const originalFetch = globalThis.fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+
+    try {
+      const app = createArchiveIsServiceApp({
+        archiveHost: "archive.today"
+      });
+
+      const response = await request(app)
+        .post("/snapshots")
+        .send({
+          url: "https://example.com/articles/launch",
+          limit: 1
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.snapshots).toEqual([
+        expect.objectContaining({
+          archiveUrl: "http://archive.md/20240501120000/https://example.com/articles/launch",
+          validation: {
+            status: "usable"
+          }
+        })
+      ]);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.stubGlobal("fetch", originalFetch);
+    }
   });
 
   it("maps invalid input to 400", async () => {
@@ -157,8 +208,21 @@ describe("archive-is service", () => {
     expect(response.body.servers).toEqual([{ url: "/" }]);
     expect(Object.keys(response.body.paths)).toEqual(["/snapshots"]);
     expect(response.body.paths["/snapshots"].post.operationId).toBe("list-snapshots");
+    expect(response.body.paths["/snapshots"].post.responses["200"].content["application/json"].schema.properties.snapshots.items.required)
+      .toContain("validation");
     expect(response.body.paths["/health"]).toBeUndefined();
     expect(response.body.paths["/.well-known/fast-marketplace-verification.txt"]).toBeUndefined();
+  });
+
+  it("keeps the provider spec template aligned with the OpenAPI schemas", () => {
+    const providerSpec = JSON.parse(readFileSync(join(appDir, "../provider-spec.mainnet.template.json"), "utf8"));
+    const endpoint = providerSpec.endpoints[0];
+
+    expect(endpoint.requestSchemaJson).toEqual(buildSnapshotsRequestSchema());
+    expect(endpoint.responseSchemaJson).toEqual(buildSnapshotsResponseSchema());
+    expect(endpoint.responseExample.snapshots[0].validation).toEqual({
+      status: "usable"
+    });
   });
 
   it("serves the marketplace verification token when configured", async () => {

--- a/apps/archive-is-service/src/app.ts
+++ b/apps/archive-is-service/src/app.ts
@@ -19,7 +19,10 @@ export function createArchiveIsServiceApp(options: ArchiveIsServiceOptions = {})
   const app = express();
   const archiveHost = options.archiveHost ?? "archive.today";
   const timeoutMs = options.timeoutMs ?? 10_000;
-  const listSnapshotsImpl = options.listSnapshots ?? ((input) => listSnapshots(input, { timeoutMs }));
+  const listSnapshotsImpl = options.listSnapshots ?? ((input) => listSnapshots(input, {
+    timeoutMs,
+    validateSnapshots: true
+  }));
 
   app.use(express.json({ limit: "64kb" }));
 

--- a/apps/archive-is-service/src/openapi.ts
+++ b/apps/archive-is-service/src/openapi.ts
@@ -22,7 +22,10 @@ export const ARCHIVE_IS_ROUTE = {
         archiveUrl: "https://archive.today/20240501120000/https://example.com/articles/launch",
         capturedAt: "2024-05-01T12:00:00.000Z",
         archiveId: "20240501120000",
-        sourceHost: "archive.today"
+        sourceHost: "archive.today",
+        validation: {
+          status: "usable"
+        }
       }
     ]
   }
@@ -187,7 +190,20 @@ export function buildSnapshotsResponseSchema(): Record<string, unknown> {
                 { type: "null" }
               ]
             },
-            sourceHost: { type: "string" }
+            sourceHost: { type: "string" },
+            validation: {
+              type: "object",
+              required: ["status"],
+              properties: {
+                status: {
+                  type: "string",
+                  enum: ["usable", "broken", "unchecked"]
+                },
+                reason: { type: "string" },
+                statusCode: { type: "integer" }
+              },
+              additionalProperties: false
+            }
           },
           additionalProperties: false
         }

--- a/apps/archive-is-service/src/openapi.ts
+++ b/apps/archive-is-service/src/openapi.ts
@@ -179,7 +179,7 @@ export function buildSnapshotsResponseSchema(): Record<string, unknown> {
         type: "array",
         items: {
           type: "object",
-          required: ["originalUrl", "archiveUrl", "capturedAt", "archiveId", "sourceHost"],
+          required: ["originalUrl", "archiveUrl", "capturedAt", "archiveId", "sourceHost", "validation"],
           properties: {
             originalUrl: { type: "string", format: "uri" },
             archiveUrl: { type: "string", format: "uri" },

--- a/packages/archive-is/src/index.test.ts
+++ b/packages/archive-is/src/index.test.ts
@@ -18,6 +18,29 @@ function readFixture(name: string): string {
   return readFileSync(join(fixtureDir, name), "utf8");
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, reject, resolve };
+}
+
+async function waitForFetchCallCount(fetchImpl: ReturnType<typeof vi.fn<typeof fetch>>, count: number): Promise<void> {
+  for (let attempts = 0; attempts < 20; attempts += 1) {
+    if (fetchImpl.mock.calls.length === count) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  expect(fetchImpl).toHaveBeenCalledTimes(count);
+}
+
 describe("archive-is sdk", () => {
   it("constructs Archive.today TimeMap URLs while preserving query and fragment boundaries", () => {
     expect(buildTimeMapUrl({
@@ -260,6 +283,105 @@ describe("archive-is sdk", () => {
             status: "unchecked",
             reason: "validation_http_error",
             statusCode: 403
+          }
+        }
+      ]
+    });
+  });
+
+  it("marks archive security checks unchecked instead of generic HTTP errors", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(readFixture("timemap-link-format.txt"), {
+        status: 200,
+        headers: {
+          "content-type": "application/link-format"
+        }
+      }))
+      .mockResolvedValueOnce(new Response("<html><h1>One more step</h1><div>Please complete the security check to access</div><div id=\"g-recaptcha\"></div></html>", {
+        status: 429
+      }));
+
+    await expect(listSnapshots({
+      url: "https://example.com/articles/launch",
+      limit: 1
+    }, {
+      fetch: fetchImpl,
+      validateSnapshots: true
+    })).resolves.toMatchObject({
+      count: 1,
+      snapshots: [
+        {
+          archiveUrl: "http://archive.md/20240720170010/https://example.com/articles/launch",
+          validation: {
+            status: "unchecked",
+            reason: "archive_security_check",
+            statusCode: 429
+          }
+        }
+      ]
+    });
+  });
+
+  it("validates snapshot pages concurrently while preserving response order", async () => {
+    const validations = [
+      deferred<Response>(),
+      deferred<Response>(),
+      deferred<Response>()
+    ];
+    const validationQueue = [...validations];
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(readFixture("timemap-link-format.txt"), {
+        status: 200,
+        headers: {
+          "content-type": "application/link-format"
+        }
+      }))
+      .mockImplementation(() => {
+        const validation = validationQueue.shift();
+        if (!validation) {
+          throw new Error("unexpected fetch");
+        }
+
+        return validation.promise;
+      });
+
+    const resultPromise = listSnapshots({
+      url: "https://example.com/articles/launch",
+      limit: 3
+    }, {
+      fetch: fetchImpl,
+      validateSnapshots: true
+    });
+    await waitForFetchCallCount(fetchImpl, 4);
+
+    validations[1]?.resolve(new Response("<html><pre>Error: Error -32602: Invalid InterceptionId.</pre></html>", {
+      status: 200
+    }));
+    validations[2]?.resolve(new Response("<html><pre>Error: Task timed-out after 15 seconds of inactivity</pre></html>", {
+      status: 200
+    }));
+    validations[0]?.resolve(new Response("<html><article>Archived article content</article></html>", {
+      status: 200
+    }));
+
+    await expect(resultPromise).resolves.toMatchObject({
+      snapshots: [
+        {
+          archiveUrl: "http://archive.md/20240720170010/https://example.com/articles/launch",
+          validation: { status: "usable" }
+        },
+        {
+          archiveUrl: "http://archive.md/20240615153045/https://example.com/articles/launch",
+          validation: {
+            status: "broken",
+            reason: "archive_invalid_interception_id"
+          }
+        },
+        {
+          archiveUrl: "http://archive.md/20240501120000/https://example.com/articles/launch",
+          validation: {
+            status: "broken",
+            reason: "archive_task_timeout"
           }
         }
       ]

--- a/packages/archive-is/src/index.test.ts
+++ b/packages/archive-is/src/index.test.ts
@@ -181,6 +181,137 @@ describe("archive-is sdk", () => {
     });
   });
 
+  it("annotates archive snapshots that resolve to archive.md error pages when validation is enabled", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(readFixture("timemap-link-format.txt"), {
+        status: 200,
+        headers: {
+          "content-type": "application/link-format"
+        }
+      }))
+      .mockResolvedValueOnce(new Response("<html><article>Archived article content</article></html>", {
+        status: 200
+      }))
+      .mockResolvedValueOnce(new Response("<html><pre>Error: Error -32602: Invalid InterceptionId.</pre></html>", {
+        status: 200
+      }))
+      .mockResolvedValueOnce(new Response("<html><pre>Error: Task timed-out after 15 seconds of inactivity</pre></html>", {
+        status: 429
+      }));
+
+    await expect(listSnapshots({
+      url: "https://example.com/articles/launch",
+      limit: 3
+    }, {
+      fetch: fetchImpl,
+      validateSnapshots: true
+    })).resolves.toMatchObject({
+      count: 3,
+      snapshots: [
+        {
+          archiveUrl: "http://archive.md/20240720170010/https://example.com/articles/launch",
+          validation: {
+            status: "usable"
+          }
+        },
+        {
+          archiveUrl: "http://archive.md/20240615153045/https://example.com/articles/launch",
+          validation: {
+            status: "broken",
+            reason: "archive_invalid_interception_id"
+          }
+        },
+        {
+          archiveUrl: "http://archive.md/20240501120000/https://example.com/articles/launch",
+          validation: {
+            status: "broken",
+            reason: "archive_task_timeout",
+            statusCode: 429
+          }
+        }
+      ]
+    });
+  });
+
+  it("marks snapshots unchecked when validation cannot read the archive page", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(readFixture("timemap-link-format.txt"), {
+        status: 200,
+        headers: {
+          "content-type": "application/link-format"
+        }
+      }))
+      .mockResolvedValueOnce(new Response("Forbidden", {
+        status: 403
+      }));
+
+    await expect(listSnapshots({
+      url: "https://example.com/articles/launch",
+      limit: 1
+    }, {
+      fetch: fetchImpl,
+      validateSnapshots: true
+    })).resolves.toMatchObject({
+      count: 1,
+      snapshots: [
+        {
+          archiveUrl: "http://archive.md/20240720170010/https://example.com/articles/launch",
+          validation: {
+            status: "unchecked",
+            reason: "validation_http_error",
+            statusCode: 403
+          }
+        }
+      ]
+    });
+  });
+
+  it("preserves Archive.md redirect cookies while validating a snapshot page", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(readFixture("timemap-link-format.txt"), {
+        status: 200,
+        headers: {
+          "content-type": "application/link-format"
+        }
+      }))
+      .mockResolvedValueOnce(new Response("", {
+        status: 302,
+        headers: {
+          location: "https://archive.md/20240720170010/https://example.com/articles/launch",
+          "set-cookie": "qki=abc123; Max-Age=3600; Domain=.archive.md; Path=/"
+        }
+      }))
+      .mockResolvedValueOnce(new Response("<html><article>Archived article content</article></html>", {
+        status: 200
+      }));
+
+    await expect(listSnapshots({
+      url: "https://example.com/articles/launch",
+      limit: 1
+    }, {
+      fetch: fetchImpl,
+      validateSnapshots: true
+    })).resolves.toMatchObject({
+      count: 1,
+      snapshots: [
+        {
+          archiveUrl: "http://archive.md/20240720170010/https://example.com/articles/launch",
+          validation: {
+            status: "usable"
+          }
+        }
+      ]
+    });
+    expect(fetchImpl).toHaveBeenLastCalledWith(
+      "https://archive.md/20240720170010/https://example.com/articles/launch",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          cookie: "qki=abc123"
+        })
+      })
+    );
+  });
+
   it("rejects invalid inputs with typed errors", async () => {
     await expect(listSnapshots({
       url: "ftp://example.com/file"

--- a/packages/archive-is/src/index.test.ts
+++ b/packages/archive-is/src/index.test.ts
@@ -41,6 +41,23 @@ async function waitForFetchCallCount(fetchImpl: ReturnType<typeof vi.fn<typeof f
   expect(fetchImpl).toHaveBeenCalledTimes(count);
 }
 
+function buildTimeMapWithCaptures(count: number): string {
+  const entries = [
+    '<https://example.com/articles/launch>; rel="original"'
+  ];
+
+  for (let index = 1; index <= count; index += 1) {
+    const day = String(index).padStart(2, "0");
+    entries.push(`<http://archive.md/202401${day}120000/https://example.com/articles/launch>; rel="memento"; datetime="Mon, ${day} Jan 2024 12:00:00 GMT"`);
+  }
+
+  return entries.join(", ");
+}
+
+function archiveErrorBody(message: string): string {
+  return `<div id="SOLID"><div id="CONTENT"><pre>Error: ${message}</pre></div></div>`;
+}
+
 describe("archive-is sdk", () => {
   it("constructs Archive.today TimeMap URLs while preserving query and fragment boundaries", () => {
     expect(buildTimeMapUrl({
@@ -215,10 +232,10 @@ describe("archive-is sdk", () => {
       .mockResolvedValueOnce(new Response("<html><article>Archived article content</article></html>", {
         status: 200
       }))
-      .mockResolvedValueOnce(new Response("<html><pre>Error: Error -32602: Invalid InterceptionId.</pre></html>", {
+      .mockResolvedValueOnce(new Response(archiveErrorBody("Error -32602: Invalid InterceptionId."), {
         status: 200
       }))
-      .mockResolvedValueOnce(new Response("<html><pre>Error: Task timed-out after 15 seconds of inactivity</pre></html>", {
+      .mockResolvedValueOnce(new Response(archiveErrorBody("Task timed-out after 15 seconds of inactivity"), {
         status: 429
       }));
 
@@ -322,6 +339,101 @@ describe("archive-is sdk", () => {
     });
   });
 
+  it("marks archive security checks unchecked even when the provider returns HTTP 200", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(readFixture("timemap-link-format.txt"), {
+        status: 200,
+        headers: {
+          "content-type": "application/link-format"
+        }
+      }))
+      .mockResolvedValueOnce(new Response("<html><h1>One more step</h1><div>Please complete the security check to access</div><div id=\"g-recaptcha\"></div></html>", {
+        status: 200
+      }));
+
+    await expect(listSnapshots({
+      url: "https://example.com/articles/launch",
+      limit: 1
+    }, {
+      fetch: fetchImpl,
+      validateSnapshots: true
+    })).resolves.toMatchObject({
+      count: 1,
+      snapshots: [
+        {
+          archiveUrl: "http://archive.md/20240720170010/https://example.com/articles/launch",
+          validation: {
+            status: "unchecked",
+            reason: "archive_security_check",
+            statusCode: 200
+          }
+        }
+      ]
+    });
+  });
+
+  it("does not classify ordinary archived preformatted errors as archive error pages", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(readFixture("timemap-link-format.txt"), {
+        status: 200,
+        headers: {
+          "content-type": "application/link-format"
+        }
+      }))
+      .mockResolvedValueOnce(new Response("<html><article><pre>Error: this is sample output in the archived page</pre></article></html>", {
+        status: 200
+      }));
+
+    await expect(listSnapshots({
+      url: "https://example.com/articles/launch",
+      limit: 1
+    }, {
+      fetch: fetchImpl,
+      validateSnapshots: true
+    })).resolves.toMatchObject({
+      count: 1,
+      snapshots: [
+        {
+          archiveUrl: "http://archive.md/20240720170010/https://example.com/articles/launch",
+          validation: {
+            status: "usable"
+          }
+        }
+      ]
+    });
+  });
+
+  it("does not classify quoted archive error signatures in ordinary archived content as broken", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(readFixture("timemap-link-format.txt"), {
+        status: 200,
+        headers: {
+          "content-type": "application/link-format"
+        }
+      }))
+      .mockResolvedValueOnce(new Response("<html><article><p>Archive operators discussed Invalid InterceptionId and Task timed-out after 15 seconds of inactivity incidents.</p></article></html>", {
+        status: 200
+      }));
+
+    await expect(listSnapshots({
+      url: "https://example.com/articles/launch",
+      limit: 1
+    }, {
+      fetch: fetchImpl,
+      validateSnapshots: true
+    })).resolves.toMatchObject({
+      count: 1,
+      snapshots: [
+        {
+          archiveUrl: "http://archive.md/20240720170010/https://example.com/articles/launch",
+          validation: {
+            status: "usable"
+          }
+        }
+      ]
+    });
+  });
+
   it("validates snapshot pages concurrently while preserving response order", async () => {
     const validations = [
       deferred<Response>(),
@@ -354,10 +466,10 @@ describe("archive-is sdk", () => {
     });
     await waitForFetchCallCount(fetchImpl, 4);
 
-    validations[1]?.resolve(new Response("<html><pre>Error: Error -32602: Invalid InterceptionId.</pre></html>", {
+    validations[1]?.resolve(new Response(archiveErrorBody("Error -32602: Invalid InterceptionId."), {
       status: 200
     }));
-    validations[2]?.resolve(new Response("<html><pre>Error: Task timed-out after 15 seconds of inactivity</pre></html>", {
+    validations[2]?.resolve(new Response(archiveErrorBody("Task timed-out after 15 seconds of inactivity"), {
       status: 200
     }));
     validations[0]?.resolve(new Response("<html><article>Archived article content</article></html>", {
@@ -382,6 +494,116 @@ describe("archive-is sdk", () => {
           validation: {
             status: "broken",
             reason: "archive_task_timeout"
+          }
+        }
+      ]
+    });
+  });
+
+  it("limits concurrent snapshot validation requests", async () => {
+    const validations = Array.from({ length: 6 }, () => deferred<Response>());
+    const validationQueue = [...validations];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(buildTimeMapWithCaptures(6), {
+        status: 200,
+        headers: {
+          "content-type": "application/link-format"
+        }
+      }))
+      .mockImplementation(() => {
+        const validation = validationQueue.shift();
+        if (!validation) {
+          throw new Error("unexpected fetch");
+        }
+
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        return validation.promise.finally(() => {
+          inFlight -= 1;
+        });
+      });
+
+    const resultPromise = listSnapshots({
+      url: "https://example.com/articles/launch",
+      limit: 6
+    }, {
+      fetch: fetchImpl,
+      validateSnapshots: true
+    });
+    await waitForFetchCallCount(fetchImpl, 6);
+    expect(maxInFlight).toBe(5);
+
+    validations[0]?.resolve(new Response("<html><article>Archived content 1</article></html>", { status: 200 }));
+    await waitForFetchCallCount(fetchImpl, 7);
+    for (const validation of validations.slice(1)) {
+      validation.resolve(new Response("<html><article>Archived content</article></html>", { status: 200 }));
+    }
+
+    await expect(resultPromise).resolves.toMatchObject({
+      count: 6,
+      snapshots: expect.arrayContaining([
+        expect.objectContaining({
+          validation: { status: "usable" }
+        })
+      ])
+    });
+    expect(maxInFlight).toBe(5);
+  });
+
+  it("marks snapshots unchecked when validation times out", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(readFixture("timemap-link-format.txt"), {
+        status: 200,
+        headers: {
+          "content-type": "application/link-format"
+        }
+      }))
+      .mockRejectedValueOnce(new DOMException("The operation was aborted.", "AbortError"));
+
+    await expect(listSnapshots({
+      url: "https://example.com/articles/launch",
+      limit: 1
+    }, {
+      fetch: fetchImpl,
+      validateSnapshots: true
+    })).resolves.toMatchObject({
+      count: 1,
+      snapshots: [
+        {
+          validation: {
+            status: "unchecked",
+            reason: "validation_timeout"
+          }
+        }
+      ]
+    });
+  });
+
+  it("marks snapshots unchecked when validation fetches fail", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(readFixture("timemap-link-format.txt"), {
+        status: 200,
+        headers: {
+          "content-type": "application/link-format"
+        }
+      }))
+      .mockRejectedValueOnce(new Error("connection reset"));
+
+    await expect(listSnapshots({
+      url: "https://example.com/articles/launch",
+      limit: 1
+    }, {
+      fetch: fetchImpl,
+      validateSnapshots: true
+    })).resolves.toMatchObject({
+      count: 1,
+      snapshots: [
+        {
+          validation: {
+            status: "unchecked",
+            reason: "validation_fetch_failed"
           }
         }
       ]

--- a/packages/archive-is/src/index.ts
+++ b/packages/archive-is/src/index.ts
@@ -360,21 +360,21 @@ async function validateArchiveSnapshot(input: {
       userAgent: input.userAgent
     });
 
+    const blockPage = getArchiveBlockPageReason(response.body);
+    if (blockPage) {
+      return {
+        status: "unchecked",
+        reason: blockPage,
+        statusCode: response.status
+      };
+    }
+
+    const errorPage = getArchiveErrorPageReason(response.body);
     if (!response.ok) {
-      const errorPage = getArchiveErrorPageReason(response.body);
       if (errorPage) {
         return {
           status: "broken",
           reason: errorPage,
-          statusCode: response.status
-        };
-      }
-
-      const blockPage = getArchiveBlockPageReason(response.body);
-      if (blockPage) {
-        return {
-          status: "unchecked",
-          reason: blockPage,
           statusCode: response.status
         };
       }
@@ -386,7 +386,6 @@ async function validateArchiveSnapshot(input: {
       };
     }
 
-    const errorPage = getArchiveErrorPageReason(response.body);
     if (errorPage) {
       return {
         status: "broken",
@@ -494,6 +493,14 @@ async function mapWithConcurrency<T, R>(
 
 function getArchiveErrorPageReason(body: string): string | null {
   const normalized = body.toLowerCase();
+  const archiveWrapperErrorPage = normalized.includes("id=\"solid\"")
+    && normalized.includes("id=\"content\"")
+    && normalized.includes("<pre")
+    && normalized.includes("error:");
+  if (!archiveWrapperErrorPage) {
+    return null;
+  }
+
   if (normalized.includes("task timed-out after 15 seconds of inactivity")) {
     return "archive_task_timeout";
   }
@@ -502,11 +509,7 @@ function getArchiveErrorPageReason(body: string): string | null {
     return "archive_invalid_interception_id";
   }
 
-  if (normalized.includes("<pre") && normalized.includes("error:")) {
-    return "archive_error_page";
-  }
-
-  return null;
+  return "archive_error_page";
 }
 
 function getArchiveBlockPageReason(body: string): string | null {

--- a/packages/archive-is/src/index.ts
+++ b/packages/archive-is/src/index.ts
@@ -8,6 +8,15 @@ export interface ArchiveSnapshot {
   capturedAt: string;
   archiveId: string | null;
   sourceHost: string;
+  validation?: ArchiveSnapshotValidation;
+}
+
+export type ArchiveSnapshotValidationStatus = "usable" | "broken" | "unchecked";
+
+export interface ArchiveSnapshotValidation {
+  status: ArchiveSnapshotValidationStatus;
+  reason?: string;
+  statusCode?: number;
 }
 
 export interface ListSnapshotsInput {
@@ -30,6 +39,7 @@ export interface ArchiveClientOptions {
   fetch?: typeof fetch;
   timeoutMs?: number;
   userAgent?: string;
+  validateSnapshots?: boolean;
 }
 
 export type ArchiveIsErrorCode =
@@ -84,16 +94,23 @@ export async function listSnapshots(
     timeoutMs,
     userAgent: options.userAgent ?? DEFAULT_USER_AGENT
   });
-  const snapshots = applySnapshotFilters({
+  const filteredSnapshots = applySnapshotFilters({
     snapshots: parseSnapshots({
       body,
       originalUrl: normalized.originalUrl,
       sourceHost
     }),
     from: normalized.from,
-    to: normalized.to,
-    limit: normalized.limit
+    to: normalized.to
   });
+  const snapshots = options.validateSnapshots
+    ? await validateSnapshotPages({
+      fetchImpl,
+      snapshots: filteredSnapshots.slice(0, normalized.limit),
+      timeoutMs,
+      userAgent: options.userAgent ?? DEFAULT_USER_AGENT
+    })
+    : filteredSnapshots.slice(0, normalized.limit);
 
   if (snapshots.length === 0) {
     throw new ArchiveIsError("No archived captures found for the requested URL.", {
@@ -298,7 +315,6 @@ function applySnapshotFilters(input: {
   snapshots: ArchiveSnapshot[];
   from: Date | null;
   to: Date | null;
-  limit: number;
 }): ArchiveSnapshot[] {
   return input.snapshots
     .filter((snapshot) => {
@@ -306,6 +322,164 @@ function applySnapshotFilters(input: {
       return (input.from === null || capturedAt >= input.from.getTime())
         && (input.to === null || capturedAt <= input.to.getTime());
     })
-    .sort((left, right) => Date.parse(right.capturedAt) - Date.parse(left.capturedAt))
-    .slice(0, input.limit);
+    .sort((left, right) => Date.parse(right.capturedAt) - Date.parse(left.capturedAt));
+}
+
+async function validateSnapshotPages(input: {
+  fetchImpl: typeof fetch;
+  snapshots: ArchiveSnapshot[];
+  timeoutMs: number;
+  userAgent: string;
+}): Promise<ArchiveSnapshot[]> {
+  const snapshots: ArchiveSnapshot[] = [];
+  for (const snapshot of input.snapshots) {
+    snapshots.push({
+      ...snapshot,
+      validation: await validateArchiveSnapshot({
+        fetchImpl: input.fetchImpl,
+        snapshot,
+        timeoutMs: input.timeoutMs,
+        userAgent: input.userAgent
+      })
+    });
+  }
+
+  return snapshots;
+}
+
+async function validateArchiveSnapshot(input: {
+  fetchImpl: typeof fetch;
+  snapshot: ArchiveSnapshot;
+  timeoutMs: number;
+  userAgent: string;
+}): Promise<ArchiveSnapshotValidation> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), input.timeoutMs);
+
+  try {
+    const response = await fetchArchivePage({
+      fetchImpl: input.fetchImpl,
+      url: input.snapshot.archiveUrl,
+      signal: controller.signal,
+      userAgent: input.userAgent
+    });
+
+    if (!response.ok) {
+      const errorPage = getArchiveErrorPageReason(response.body);
+      if (errorPage) {
+        return {
+          status: "broken",
+          reason: errorPage,
+          statusCode: response.status
+        };
+      }
+
+      return {
+        status: "unchecked",
+        reason: "validation_http_error",
+        statusCode: response.status
+      };
+    }
+
+    const errorPage = getArchiveErrorPageReason(response.body);
+    if (errorPage) {
+      return {
+        status: "broken",
+        reason: errorPage
+      };
+    }
+
+    return { status: "usable" };
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return {
+        status: "unchecked",
+        reason: "validation_timeout"
+      };
+    }
+
+    return {
+      status: "unchecked",
+      reason: "validation_fetch_failed"
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function fetchArchivePage(input: {
+  fetchImpl: typeof fetch;
+  url: string;
+  signal: AbortSignal;
+  userAgent: string;
+}): Promise<{
+  ok: boolean;
+  status: number;
+  body: string;
+}> {
+  const response = await input.fetchImpl(input.url, {
+    method: "GET",
+    redirect: "manual",
+    headers: {
+      accept: "text/html, text/plain;q=0.9, */*;q=0.1",
+      "user-agent": input.userAgent
+    },
+    signal: input.signal
+  });
+
+  if (!isRedirectStatus(response.status)) {
+    return {
+      ok: response.ok,
+      status: response.status,
+      body: await response.text()
+    };
+  }
+
+  const location = response.headers.get("location");
+  if (!location) {
+    return {
+      ok: response.ok,
+      status: response.status,
+      body: await response.text()
+    };
+  }
+
+  const cookie = response.headers.get("set-cookie")?.split(";")[0];
+  const redirectedUrl = new URL(location, input.url).toString();
+  const redirectedResponse = await input.fetchImpl(redirectedUrl, {
+    method: "GET",
+    headers: {
+      accept: "text/html, text/plain;q=0.9, */*;q=0.1",
+      ...(cookie ? { cookie } : {}),
+      "user-agent": input.userAgent
+    },
+    signal: input.signal
+  });
+
+  return {
+    ok: redirectedResponse.ok,
+    status: redirectedResponse.status,
+    body: await redirectedResponse.text()
+  };
+}
+
+function isRedirectStatus(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+function getArchiveErrorPageReason(body: string): string | null {
+  const normalized = body.toLowerCase();
+  if (normalized.includes("task timed-out after 15 seconds of inactivity")) {
+    return "archive_task_timeout";
+  }
+
+  if (normalized.includes("invalid interceptionid")) {
+    return "archive_invalid_interception_id";
+  }
+
+  if (normalized.includes("<pre") && normalized.includes("error:")) {
+    return "archive_error_page";
+  }
+
+  return null;
 }

--- a/packages/archive-is/src/index.ts
+++ b/packages/archive-is/src/index.ts
@@ -73,6 +73,7 @@ const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_USER_AGENT = "fast-agent-marketplace-archive-is/0.1";
+const SNAPSHOT_VALIDATION_CONCURRENCY = 5;
 
 export { buildTimeMapUrl, parseLinkFormat, parseTimeMap } from "./timemap.js";
 
@@ -331,9 +332,7 @@ async function validateSnapshotPages(input: {
   timeoutMs: number;
   userAgent: string;
 }): Promise<ArchiveSnapshot[]> {
-  const snapshots: ArchiveSnapshot[] = [];
-  for (const snapshot of input.snapshots) {
-    snapshots.push({
+  return mapWithConcurrency(input.snapshots, SNAPSHOT_VALIDATION_CONCURRENCY, async (snapshot) => ({
       ...snapshot,
       validation: await validateArchiveSnapshot({
         fetchImpl: input.fetchImpl,
@@ -341,10 +340,7 @@ async function validateSnapshotPages(input: {
         timeoutMs: input.timeoutMs,
         userAgent: input.userAgent
       })
-    });
-  }
-
-  return snapshots;
+    }));
 }
 
 async function validateArchiveSnapshot(input: {
@@ -370,6 +366,15 @@ async function validateArchiveSnapshot(input: {
         return {
           status: "broken",
           reason: errorPage,
+          statusCode: response.status
+        };
+      }
+
+      const blockPage = getArchiveBlockPageReason(response.body);
+      if (blockPage) {
+        return {
+          status: "unchecked",
+          reason: blockPage,
           statusCode: response.status
         };
       }
@@ -467,6 +472,26 @@ function isRedirectStatus(status: number): boolean {
   return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
 }
 
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await mapper(items[currentIndex]);
+    }
+  }));
+
+  return results;
+}
+
 function getArchiveErrorPageReason(body: string): string | null {
   const normalized = body.toLowerCase();
   if (normalized.includes("task timed-out after 15 seconds of inactivity")) {
@@ -479,6 +504,16 @@ function getArchiveErrorPageReason(body: string): string | null {
 
   if (normalized.includes("<pre") && normalized.includes("error:")) {
     return "archive_error_page";
+  }
+
+  return null;
+}
+
+function getArchiveBlockPageReason(body: string): string | null {
+  const normalized = body.toLowerCase();
+  if (normalized.includes("g-recaptcha")
+    && normalized.includes("please complete the security check")) {
+    return "archive_security_check";
   }
 
   return null;


### PR DESCRIPTION
## Summary
- add optional SDK validation for archive snapshot pages
- enable validation in the Archive.is Railway service
- return per-capture validation metadata: usable, broken, or unchecked
- classify known archive error pages such as task timeouts and Invalid InterceptionId without relying on URL-specific date cutoffs
- harden validation with bounded concurrency, required service OpenAPI metadata, provider spec alignment, and Archive security-check classification
- tighten Archive error-page detection to avoid false positives from archived page content that quotes error strings

## Verification
- npm test -- --run packages/archive-is/src/index.test.ts apps/archive-is-service/src/app.test.ts
- npm run build
- npm test

## Live check
- deployed earlier to archive-is-mainnet on Railway as deployment 95fbcc6a-d1fc-4674-8071-bcb8928fad86
- WSJ capture validation from Railway was blocked by Archive.md with HTTP 429; this branch now classifies that provider body as unchecked/archive_security_check when returned